### PR TITLE
feat: add step routes for 2026 credits warp category

### DIFF
--- a/data/routes/cw/000.txt
+++ b/data/routes/cw/000.txt
@@ -1,0 +1,156 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	0
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	51109383
+VARS	FFFFFFFF:12 E302600:70 E305400:70 E307400:30 E307701:8 E308401:10 E308700:1 E308701:6 E308702:1 E309700:22
+
+Overworld (Kaipo)                                                             Seed:   0   Index:   0
+Overworld (Kaipo)                                                             Seed:   0   Index:   1
+  Step  36: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:   0   Index:  37
+Overworld (Kaipo)                                                             Seed:   0   Index:  37
+Watery Pass-South B1F                                                         Seed:   0   Index:  69
+  Step  18: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  28: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed:   0   Index: 101
+Watery Pass-South B1F                                                         Seed:   0   Index: 101
+  Step  19: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:   0   Index: 121
+  Step   9: 5 / Pike x3 (7.152s)
+  Step  23: 6 / CaveToad x3 (7.014s)
+  Step  59: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:   0   Index: 211
+  Extra Steps: 70
+Watery Pass-South B2F                                                         Seed:  17   Index:  29
+  Step  35: 8 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  17   Index:  68
+  Step  25: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B2F                                                         Seed:  17   Index: 102
+Watery Pass-North B1F                                                         Seed:  17   Index: 123
+  Step  35: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:  17   Index: 183
+Waterfalls B1F                                                                Seed:  17   Index: 192
+  Extra Steps: 30
+Waterfalls B2F                                                                Seed:  17   Index: 223
+  Step  40: 11 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed:  34   Index:  12
+Battle: Octomamm                                                              Seed:  34   Index:  49
+Waterfalls Lake                                                               Seed:  34   Index:  49
+Overworld (Kaipo)                                                             Seed:  34   Index:  50
+Overworld (Damcyan)                                                           Seed:  34   Index:  61
+Damcyan                                                                       Seed:  34   Index:  65
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  34   Index:  72
+Antlion B1F                                                                   Seed:  34   Index:  72
+  Step  20: 12 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  34   Index: 110
+  Antlion B2F                                                                 Seed:  34   Index: 110
+    Step  11: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  31: 14 / SandWorm x2 (6.841s)
+    Step  78: 15 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  34   Index: 190
+Battle: Antlion                                                               Seed:  34   Index: 204
+Antlion's Nest                                                                Seed:  34   Index: 204
+Antlion B2F Outward Direct                                                    Seed:  34   Index: 219
+  Antlion B2F                                                                 Seed:  34   Index: 219
+    Step   1: 16 / Basilisk x1, Turtle x1 (7.124s)
+    Step  22: 17 / Turtle x2 (7.464s)
+    Step  64: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  51   Index:  43
+  Extra Steps: 8
+  Step  11: 19 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  15: 20 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  18: 21 / Cream x4 (7.523s)
+  Step  46: 22 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  51   Index:  89
+Overworld (Kaipo)                                                             Seed:  51   Index:  89
+Kaipo Revisited                                                               Seed:  51   Index:  89
+Overworld (Kaipo)                                                             Seed:  51   Index:  89
+Overworld (Damcyan)                                                           Seed:  51   Index:  89
+Mt.Hobs-West                                                                  Seed:  51   Index:  89
+Mt.Hobs Summit                                                                Seed:  51   Index: 128
+Battle: MomBomb                                                               Seed:  51   Index: 143
+Mt.Hobs Summit                                                                Seed:  51   Index: 143
+Mt.Hobs-East                                                                  Seed:  51   Index: 149
+  Step  18: 23 / Gargoyle x2 (7.630s)
+  Step  37: 24 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed:  51   Index: 195
+  Step  41: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  51: 26 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed:  68   Index:  23
+  Optional Steps: 10
+  Extra Steps: 60
+Overworld (Fabul)                                                             Seed:  68   Index: 153
+Fabul Boat and Leviatan                                                       Seed:  68   Index: 160
+Overworld (Mysidia)                                                           Seed:  68   Index: 160
+Mysidia                                                                       Seed:  68   Index: 169
+Overworld (Mysidia)                                                           Seed:  68   Index: 169
+  Step   9: 27 / Needler x2, SwordRat x2 (8.097s)
+Overworld (Mt.Ordeals)                                                        Seed:  68   Index: 179
+  Step  71: 28 / Needler x2, SwordRat x2 (8.097s)
+  Step  85: 29 / Raven x1 (8.356s)
+  Step  87: 30 / Raven x1, Cocktric x3 (9.100s)
+Mt.Ordeals                                                                    Seed:  85   Index:  17
+Mt.Ordeals-3rd station                                                        Seed:  85   Index:  60
+  Step  16: 31 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  85   Index:  83
+Mt.Ordeals-3rd station                                                        Seed:  85   Index:  83
+  Step   2: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed:  85   Index:  88
+  Step  29: 33 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  85   Index: 130
+  Optional Steps: 1
+  Step  10: 34 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed:  85   Index: 148
+Mt.Ordeals Summit                                                             Seed:  85   Index: 148
+  Extra Steps: 6
+  Step   9: 35 / Ghoul x2, Soul x2 (8.941s)
+Paladin                                                                       Seed:  85   Index: 158
+Mt.Ordeals Summit                                                             Seed:  85   Index: 158
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  85   Index: 181
+Mt.Ordeals-3rd station                                                        Seed:  85   Index: 223
+  Step   6: 36 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals                                                                    Seed:  85   Index: 253
+  Extra Steps: 10
+  Step  42: 37 / Spirit x2, Skelton x2 (8.065s)
+  Step  54: 38 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 102   Index:  51
+Take Chocobo to Mysidia                                                       Seed: 102   Index:  64
+Overworld (Mysidia)                                                           Seed: 102   Index:  64
+Town of Baron Serpent Road                                                    Seed: 102   Index:  64
+  Extra Steps: 22
+Credit Warp Fight Search                                                      Seed: 102   Index:  90
+  Overworld (Baron)                                                           Seed: 102   Index:  90
+    Extra Steps: 12
+    Step   1: 39 / FloatEye x2 (7.230s)
+    Step  12: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  25: 41 / FloatEye x2)
+   (Step  57: 42 / FloatEye x2)
+   (Step 127: 43 / FloatEye x1, Eagle x2)
+   (Step 145: 44 / Eagle x3)
+   (Step 183: 45 / FloatEye x1, Eagle x2)
+   (Step 215: 46 / FloatEye x1, Eagle x2)
+   (Step 225: 47 / FloatEye x1, Eagle x2)
+   (Step 254: 48 / Imp x4)
+
+Encounter Time:      308.282s
+Other Time:          542.140s
+Total Time:          850.422s
+
+Base Total Time:     952.587s
+Time Saved:          102.165s
+
+Optional Steps:      12
+Extra Steps:         218
+Encounters:          40
+
+Base Encounters:     48
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/001.txt
+++ b/data/routes/cw/001.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	1
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50896370
+VARS	FFFFFFFF:40 E000202:14 E302500:59 E302600:10 E308500:6 E308501:10 E308700:1 E308702:1 E309700:38
+
+Overworld (Kaipo)                                                             Seed:   1   Index:   0
+Overworld (Kaipo)                                                             Seed:   1   Index:   1
+  Step  36: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:   1   Index:  37
+Overworld (Kaipo)                                                             Seed:   1   Index:  37
+  Step  19: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:   1   Index:  69
+  Step  18: 3 / Zombie x4 (6.967s)
+  Step  28: 4 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:   1   Index: 101
+Watery Pass-South B1F                                                         Seed:   1   Index: 101
+  Step  19: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F                                                         Seed:   1   Index: 121
+  Step   9: 6 / CaveToad x3 (7.014s)
+  Step  23: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:   1   Index: 211
+Watery Pass-South B2F                                                         Seed:   1   Index: 215
+Watery Pass-South B3F                                                         Seed:   1   Index: 254
+  Step   4: 8 / Jelly x4 (7.324s)
+  Step  31: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B2F                                                         Seed:  18   Index:  32
+Watery Pass-North B1F                                                         Seed:  18   Index:  53
+  Step  11: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  40: 11 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  18   Index: 113
+Waterfalls B1F                                                                Seed:  18   Index: 122
+Waterfalls B2F                                                                Seed:  18   Index: 123
+  Step  35: 12 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed:  18   Index: 168
+Battle: Octomamm                                                              Seed:  18   Index: 205
+Waterfalls Lake                                                               Seed:  18   Index: 205
+Overworld (Kaipo)                                                             Seed:  18   Index: 206
+  Step   6: 13 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed:  18   Index: 217
+Damcyan                                                                       Seed:  18   Index: 221
+  Optional Steps: 1
+  Extra Steps: 58
+Overworld (Damcyan)                                                           Seed:  35   Index:  31
+Antlion B1F                                                                   Seed:  35   Index:  31
+  Step  38: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Direct                                                     Seed:  35   Index:  69
+  Antlion B2F                                                                 Seed:  35   Index:  69
+    Step  52: 15 / Turtle x2 (7.487s)
+    Step  72: 16 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed:  35   Index: 149
+Battle: Antlion                                                               Seed:  35   Index: 163
+Antlion's Nest                                                                Seed:  35   Index: 163
+Antlion B2F Outward Direct                                                    Seed:  35   Index: 178
+  Antlion B2F                                                                 Seed:  35   Index: 178
+    Step  10: 17 / Turtle x2 (7.464s)
+    Step  42: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  63: 19 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  52   Index:   2
+  Step  25: 20 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  52   Index:  40
+Overworld (Kaipo)                                                             Seed:  52   Index:  40
+  Extra Steps: 14
+  Step  14: 21 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed:  52   Index:  54
+Overworld (Kaipo)                                                             Seed:  52   Index:  54
+Overworld (Damcyan)                                                           Seed:  52   Index:  54
+Mt.Hobs-West                                                                  Seed:  52   Index:  54
+  Step   7: 22 / Spirit x2 (8.028s)
+  Step  35: 23 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed:  52   Index:  93
+Battle: MomBomb                                                               Seed:  52   Index: 108
+Mt.Hobs Summit                                                                Seed:  52   Index: 108
+Mt.Hobs-East                                                                  Seed:  52   Index: 114
+  Step  29: 24 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed:  52   Index: 160
+  Step   7: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  26: 26 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed:  52   Index: 244
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  69   Index:  58
+Fabul Boat and Leviatan                                                       Seed:  69   Index:  65
+Overworld (Mysidia)                                                           Seed:  69   Index:  65
+Mysidia                                                                       Seed:  69   Index:  74
+Overworld (Mysidia)                                                           Seed:  69   Index:  74
+Overworld (Mt.Ordeals)                                                        Seed:  69   Index:  84
+  Step  35: 27 / Needler x2, SwordRat x2 (8.097s)
+  Step  69: 28 / Needler x2, SwordRat x2 (8.097s)
+  Step  94: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  69   Index: 178
+Mt.Ordeals-3rd station                                                        Seed:  69   Index: 221
+  Extra Steps: 6
+  Step  10: 30 / Lilith x1, Red Bone x2 (9.259s)
+  Step  29: 31 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  69   Index: 250
+Mt.Ordeals-3rd station                                                        Seed:  69   Index: 250
+  Extra Steps: 10
+  Step  14: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed:  86   Index:   9
+  Step  23: 33 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed:  86   Index:  51
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  86   Index:  69
+Mt.Ordeals Summit                                                             Seed:  86   Index:  69
+Paladin                                                                       Seed:  86   Index:  73
+Mt.Ordeals Summit                                                             Seed:  86   Index:  73
+  Optional Steps: 1
+  Step   3: 34 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  12: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed:  86   Index:  96
+  Step  21: 36 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-3rd station                                                        Seed:  86   Index: 138
+  Step   2: 37 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+  Step  19: 38 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed:  86   Index: 168
+Overworld (Mt.Ordeals)                                                        Seed:  86   Index: 212
+Take Chocobo to Mysidia                                                       Seed:  86   Index: 225
+Overworld (Mysidia)                                                           Seed:  86   Index: 225
+Town of Baron Serpent Road                                                    Seed:  86   Index: 225
+  Extra Steps: 38
+Credit Warp Fight Search                                                      Seed: 103   Index:  11
+  Overworld (Baron)                                                           Seed: 103   Index:  11
+    Extra Steps: 40
+    Step   1: 39 / FloatEye x2 (7.230s)
+    Step  40: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  80: 41 / FloatEye x2)
+   (Step 104: 42 / FloatEye x2)
+   (Step 136: 43 / FloatEye x1, Eagle x2)
+   (Step 206: 44 / Eagle x3)
+   (Step 224: 45 / FloatEye x1, Eagle x2)
+
+Encounter Time:      311.127s
+Other Time:          535.751s
+Total Time:          846.878s
+
+Base Total Time:     945.805s
+Time Saved:          98.927s
+
+Optional Steps:      13
+Extra Steps:         166
+Encounters:          40
+
+Base Encounters:     47
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/002.txt
+++ b/data/routes/cw/002.txt
@@ -1,0 +1,157 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	2
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50730727
+VARS	FFFFFFFF:12 C307800:1 E000200:4 E000202:4 E000500:18 E302500:23 E302600:36 E307000:32 E307B00:40 E308501:4 E308700:1 E308702:1 E309700:10
+
+Overworld (Kaipo)                                                             Seed:   2   Index:   0
+Overworld (Kaipo)                                                             Seed:   2   Index:   1
+  Step  36: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:   2   Index:  37
+Overworld (Kaipo)                                                             Seed:   2   Index:  37
+  Step  19: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:   2   Index:  69
+  Step  18: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed:   2   Index: 101
+Watery Pass-South B1F                                                         Seed:   2   Index: 101
+  Step  19: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:   2   Index: 121
+  Step   9: 5 / CaveToad x3 (7.014s)
+  Step  23: 6 / CaveToad x3 (7.014s)
+  Step  25: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:   2   Index: 211
+Watery Pass-South B2F                                                         Seed:   2   Index: 215
+  Extra Steps: 32
+  Step  43: 8 / Pike x3 (7.152s)
+  Step  70: 9 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  19   Index:  30
+Watery Pass-North B2F                                                         Seed:  19   Index:  64
+  Step   3: 10 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed:  19   Index:  85
+  Step   8: 11 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  19   Index: 145
+  Extra Steps: 4
+  Step  13: 12 / Sandpede x1, Sand Man x2 (7.188s)
+Waterfalls B1F                                                                Seed:  19   Index: 158
+Waterfalls B2F                                                                Seed:  19   Index: 159
+Waterfalls Lake                                                               Seed:  19   Index: 204
+  Step  18: 13 / Zombie x6 (7.489s)
+  Step  20: 14 / Mad Toad x4 (7.317s)
+Battle: Octomamm                                                              Seed:  19   Index: 241
+Waterfalls Lake                                                               Seed:  19   Index: 241
+Overworld (Kaipo)                                                             Seed:  19   Index: 242
+Overworld (Damcyan)                                                           Seed:  19   Index: 253
+Damcyan                                                                       Seed:  36   Index:   1
+  Optional Steps: 1
+  Extra Steps: 22
+Overworld (Damcyan)                                                           Seed:  36   Index:  31
+Antlion B1F                                                                   Seed:  36   Index:  31
+Antlion B2F Inward Charm Room Steps                                           Seed:  36   Index:  69
+  Antlion B2F                                                                 Seed:  36   Index:  69
+  Antlion B2F Treasure Room                                                   Seed:  36   Index: 102
+    Extra Steps: 40
+  Antlion B2F                                                                 Seed:  36   Index: 142
+    Step  46: 15 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  36   Index: 194
+Battle: Antlion                                                               Seed:  36   Index: 208
+Antlion's Nest                                                                Seed:  36   Index: 208
+  Step  12: 16 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed:  36   Index: 223
+  Antlion B2F                                                                 Seed:  36   Index: 223
+    Step  18: 17 / Turtle x2 (7.464s)
+    Step  48: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  60: 19 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  53   Index:  47
+  Step   7: 20 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  53   Index:  85
+Overworld (Kaipo)                                                             Seed:  53   Index:  85
+  Extra Steps: 4
+  Step   4: 21 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed:  53   Index:  89
+Overworld (Kaipo)                                                             Seed:  53   Index:  89
+Overworld (Damcyan)                                                           Seed:  53   Index:  89
+Mt.Hobs-West                                                                  Seed:  53   Index:  89
+Mt.Hobs Summit                                                                Seed:  53   Index: 128
+  Step  15: 22 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:  53   Index: 143
+Mt.Hobs Summit                                                                Seed:  53   Index: 143
+Mt.Hobs-East                                                                  Seed:  53   Index: 149
+  Step  18: 23 / Gargoyle x2 (7.630s)
+  Step  37: 24 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed:  53   Index: 195
+  Step  51: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed:  70   Index:  23
+  Optional Steps: 10
+  Extra Steps: 26
+Overworld (Fabul)                                                             Seed:  70   Index: 119
+Fabul Boat and Leviatan                                                       Seed:  70   Index: 126
+Overworld (Mysidia)                                                           Seed:  70   Index: 126
+  Extra Steps: 18
+  Step  27: 26 / Imp Cap. x3, Needler x1 (7.821s)
+Mysidia                                                                       Seed:  70   Index: 153
+Overworld (Mysidia)                                                           Seed:  70   Index: 153
+Overworld (Mt.Ordeals)                                                        Seed:  70   Index: 163
+  Step  15: 27 / Needler x2, SwordRat x2 (8.097s)
+  Step  68: 28 / Needler x2, SwordRat x2 (8.097s)
+  Step  87: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  87   Index:   1
+  Step   7: 30 / Lilith x1, Red Bone x2 (9.259s)
+  Step  31: 31 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed:  87   Index:  44
+Recruit Tellah                                                                Seed:  87   Index:  67
+Mt.Ordeals-3rd station                                                        Seed:  87   Index:  67
+  Extra Steps: 4
+  Step   9: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed:  87   Index:  76
+  Step   9: 33 / Lilith x1, Red Bone x2 (8.912s)
+  Step  41: 34 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  87   Index: 118
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  87   Index: 136
+Mt.Ordeals Summit                                                             Seed:  87   Index: 136
+  Step   4: 35 / Ghoul x2, Soul x2 (8.941s)
+Paladin                                                                       Seed:  87   Index: 140
+Mt.Ordeals Summit                                                             Seed:  87   Index: 140
+  Optional Steps: 1
+  Step  17: 36 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-7th station                                                        Seed:  87   Index: 163
+Mt.Ordeals-3rd station                                                        Seed:  87   Index: 205
+  Step   8: 37 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed:  87   Index: 235
+  Step  33: 38 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 104   Index:  23
+Take Chocobo to Mysidia                                                       Seed: 104   Index:  36
+Overworld (Mysidia)                                                           Seed: 104   Index:  36
+Town of Baron Serpent Road                                                    Seed: 104   Index:  36
+  Extra Steps: 10
+Credit Warp Fight Search                                                      Seed: 104   Index:  50
+  Overworld (Baron)                                                           Seed: 104   Index:  50
+    Extra Steps: 12
+    Step   1: 39 / FloatEye x2 (7.230s)
+    Step  12: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  65: 41 / FloatEye x2)
+   (Step  97: 42 / FloatEye x2)
+   (Step 167: 43 / FloatEye x1, Eagle x2)
+   (Step 185: 44 / Eagle x3)
+   (Step 229: 45 / FloatEye x1, Eagle x2)
+
+Encounter Time:      309.636s
+Other Time:          534.486s
+Total Time:          844.122s
+
+Base Total Time:     946.036s
+Time Saved:          101.914s
+
+Optional Steps:      13
+Extra Steps:         172
+Encounters:          40
+
+Base Encounters:     47
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/003.txt
+++ b/data/routes/cw/003.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	3
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50094605
+VARS	FFFFFFFF:24 C307800:1 E302500:59 E302600:10 E307B00:40 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:   3   Index:   0
+Overworld (Kaipo)                                                             Seed:   3   Index:   1
+  Step  36: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:   3   Index:  37
+Overworld (Kaipo)                                                             Seed:   3   Index:  37
+  Step  19: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:   3   Index:  69
+  Step  18: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed:   3   Index: 101
+Watery Pass-South B1F                                                         Seed:   3   Index: 101
+  Step  19: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:   3   Index: 121
+  Step   9: 5 / CaveToad x3 (7.014s)
+  Step  23: 6 / CaveToad x3 (7.014s)
+  Step  25: 7 / Pike x3 (7.152s)
+  Step  61: 8 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:   3   Index: 211
+Watery Pass-South B2F                                                         Seed:   3   Index: 215
+Watery Pass-South B3F                                                         Seed:   3   Index: 254
+  Step   4: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  31: 10 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  20   Index:  32
+Watery Pass-North B1F                                                         Seed:  20   Index:  53
+  Step  14: 11 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  40: 12 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed:  20   Index: 113
+Waterfalls B1F                                                                Seed:  20   Index: 122
+Waterfalls B2F                                                                Seed:  20   Index: 123
+  Step  35: 13 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed:  20   Index: 168
+Battle: Octomamm                                                              Seed:  20   Index: 205
+Waterfalls Lake                                                               Seed:  20   Index: 205
+Overworld (Kaipo)                                                             Seed:  20   Index: 206
+Overworld (Damcyan)                                                           Seed:  20   Index: 217
+Damcyan                                                                       Seed:  20   Index: 221
+  Optional Steps: 1
+  Extra Steps: 58
+Overworld (Damcyan)                                                           Seed:  37   Index:  31
+Antlion B1F                                                                   Seed:  37   Index:  31
+Antlion B2F Inward Charm Room Steps                                           Seed:  37   Index:  69
+  Antlion B2F                                                                 Seed:  37   Index:  69
+    Step  25: 14 / SandWorm x1, Sandpede x1 (6.829s)
+  Antlion B2F Treasure Room                                                   Seed:  37   Index: 102
+    Extra Steps: 40
+  Antlion B2F                                                                 Seed:  37   Index: 142
+    Step  46: 15 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  37   Index: 194
+Battle: Antlion                                                               Seed:  37   Index: 208
+Antlion's Nest                                                                Seed:  37   Index: 208
+  Step  12: 16 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed:  37   Index: 223
+  Antlion B2F                                                                 Seed:  37   Index: 223
+    Step  18: 17 / Turtle x2 (7.464s)
+    Step  48: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  60: 19 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  54   Index:  47
+  Step   6: 20 / Imp x3, Imp Cap. x1 (6.753s)
+  Step   7: 21 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed:  54   Index:  85
+Overworld (Kaipo)                                                             Seed:  54   Index:  85
+Kaipo Revisited                                                               Seed:  54   Index:  85
+Overworld (Kaipo)                                                             Seed:  54   Index:  85
+Overworld (Damcyan)                                                           Seed:  54   Index:  85
+Mt.Hobs-West                                                                  Seed:  54   Index:  85
+  Step   4: 22 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed:  54   Index: 124
+Battle: MomBomb                                                               Seed:  54   Index: 139
+Mt.Hobs Summit                                                                Seed:  54   Index: 139
+  Step   4: 23 / Spirit x2 (7.652s)
+Mt.Hobs-East                                                                  Seed:  54   Index: 145
+  Step  22: 24 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed:  54   Index: 191
+  Step  55: 25 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed:  71   Index:  19
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  71   Index:  89
+Fabul Boat and Leviatan                                                       Seed:  71   Index:  96
+Overworld (Mysidia)                                                           Seed:  71   Index:  96
+Mysidia                                                                       Seed:  71   Index: 105
+Overworld (Mysidia)                                                           Seed:  71   Index: 105
+Overworld (Mt.Ordeals)                                                        Seed:  71   Index: 115
+  Step   4: 26 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  38: 27 / Needler x2, SwordRat x2 (8.097s)
+  Step  63: 28 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed:  71   Index: 209
+  Step  22: 29 / Soul x2, Red Bone x2 (9.583s)
+  Step  41: 30 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed:  71   Index: 252
+  Step  12: 31 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  88   Index:  19
+Mt.Ordeals-3rd station                                                        Seed:  88   Index:  19
+Mt.Ordeals-7th station                                                        Seed:  88   Index:  24
+  Step   8: 32 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed:  88   Index:  66
+  Optional Steps: 1
+  Step  10: 33 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed:  88   Index:  84
+Mt.Ordeals Summit                                                             Seed:  88   Index:  84
+  Step   1: 34 / Soul x2, Ghoul x2, Revenant x2 (10.046s)
+Paladin                                                                       Seed:  88   Index:  88
+Mt.Ordeals Summit                                                             Seed:  88   Index:  88
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  88   Index: 111
+  Step   6: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed:  88   Index: 153
+  Step   4: 36 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals                                                                    Seed:  88   Index: 183
+  Step  30: 37 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed:  88   Index: 227
+  Step   2: 38 / Raven x1 (8.065s)
+Take Chocobo to Mysidia                                                       Seed:  88   Index: 240
+Overworld (Mysidia)                                                           Seed:  88   Index: 240
+Town of Baron Serpent Road                                                    Seed:  88   Index: 240
+Credit Warp Fight Search                                                      Seed:  88   Index: 244
+  Overworld (Baron)                                                           Seed:  88   Index: 244
+    Extra Steps: 24
+    Step   1: 39 / FloatEye x2 (7.230s)
+    Step  24: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  74: 41 / FloatEye x2)
+   (Step 127: 42 / FloatEye x2)
+   (Step 148: 43 / FloatEye x1, Eagle x2)
+   (Step 159: 44 / Eagle x3)
+   (Step 229: 45 / FloatEye x1, Eagle x2)
+   (Step 247: 46 / FloatEye x1, Eagle x2)
+
+Encounter Time:      309.168s
+Other Time:          524.370s
+Total Time:          833.537s
+
+Base Total Time:     914.876s
+Time Saved:          81.338s
+
+Optional Steps:      13
+Extra Steps:         122
+Encounters:          40
+
+Base Encounters:     47
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/004.txt
+++ b/data/routes/cw/004.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	4
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48261531
+VARS	FFFFFFFF:24 C307800:1 E000202:4 E302500:23 E302600:7 E307B00:76 E308702:1
+
+Overworld (Kaipo)                                                             Seed:   4   Index:   0
+Overworld (Kaipo)                                                             Seed:   4   Index:   1
+Kaipo                                                                         Seed:   4   Index:  37
+Overworld (Kaipo)                                                             Seed:   4   Index:  37
+  Step  19: 1 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:   4   Index:  69
+  Step  12: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  18: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed:   4   Index: 101
+Watery Pass-South B1F                                                         Seed:   4   Index: 101
+Watery Pass-South B2F                                                         Seed:   4   Index: 121
+  Step   9: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  23: 5 / CaveToad x3 (7.014s)
+  Step  25: 6 / CaveToad x3 (7.014s)
+  Step  61: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:   4   Index: 211
+Watery Pass-South B2F                                                         Seed:   4   Index: 215
+Watery Pass-South B3F                                                         Seed:   4   Index: 254
+  Step   4: 8 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed:  21   Index:  32
+Watery Pass-North B1F                                                         Seed:  21   Index:  53
+  Step  14: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  40: 10 / Jelly x4 (7.324s)
+  Step  43: 11 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  21   Index: 113
+Waterfalls B1F                                                                Seed:  21   Index: 122
+Waterfalls B2F                                                                Seed:  21   Index: 123
+Waterfalls Lake                                                               Seed:  21   Index: 168
+Battle: Octomamm                                                              Seed:  21   Index: 205
+Waterfalls Lake                                                               Seed:  21   Index: 205
+Overworld (Kaipo)                                                             Seed:  21   Index: 206
+Overworld (Damcyan)                                                           Seed:  21   Index: 217
+Damcyan                                                                       Seed:  21   Index: 221
+  Optional Steps: 1
+  Extra Steps: 22
+Overworld (Damcyan)                                                           Seed:  21   Index: 251
+Antlion B1F                                                                   Seed:  21   Index: 251
+  Step  36: 12 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Charm Room Steps                                           Seed:  38   Index:  33
+  Antlion B2F                                                                 Seed:  38   Index:  33
+  Antlion B2F Treasure Room                                                   Seed:  38   Index:  66
+    Extra Steps: 76
+  Antlion B2F                                                                 Seed:  38   Index: 142
+Antlion's Nest                                                                Seed:  38   Index: 194
+Battle: Antlion                                                               Seed:  38   Index: 208
+Antlion's Nest                                                                Seed:  38   Index: 208
+  Step  12: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed:  38   Index: 223
+  Antlion B2F                                                                 Seed:  38   Index: 223
+    Step  18: 14 / SandWorm x1, Sandpede x1 (6.848s)
+    Step  48: 15 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  55   Index:  47
+  Step   6: 16 / Turtle x2 (7.464s)
+  Step   7: 17 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  55   Index:  85
+Overworld (Kaipo)                                                             Seed:  55   Index:  85
+  Extra Steps: 4
+  Step   4: 18 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed:  55   Index:  89
+Overworld (Kaipo)                                                             Seed:  55   Index:  89
+Overworld (Damcyan)                                                           Seed:  55   Index:  89
+Mt.Hobs-West                                                                  Seed:  55   Index:  89
+  Step  10: 19 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed:  55   Index: 128
+  Step  15: 20 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:  55   Index: 143
+Mt.Hobs Summit                                                                Seed:  55   Index: 143
+Mt.Hobs-East                                                                  Seed:  55   Index: 149
+  Step  18: 21 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed:  55   Index: 195
+  Step  51: 22 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed:  72   Index:  23
+  Optional Steps: 7
+Overworld (Fabul)                                                             Seed:  72   Index:  90
+Fabul Boat and Leviatan                                                       Seed:  72   Index:  97
+Overworld (Mysidia)                                                           Seed:  72   Index:  97
+Mysidia                                                                       Seed:  72   Index: 106
+Overworld (Mysidia)                                                           Seed:  72   Index: 106
+Overworld (Mt.Ordeals)                                                        Seed:  72   Index: 116
+  Step   3: 23 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  37: 24 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  62: 25 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed:  72   Index: 210
+  Step  21: 26 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  37: 27 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed:  72   Index: 253
+  Step  11: 28 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+  Step  23: 29 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  89   Index:  20
+Mt.Ordeals-3rd station                                                        Seed:  89   Index:  20
+Mt.Ordeals-7th station                                                        Seed:  89   Index:  25
+  Step   7: 30 / Soul x3, Ghoul x1, Revenant x1 (9.933s)
+Mt.Ordeals Summit                                                             Seed:  89   Index:  67
+  Optional Steps: 0
+  Step   9: 31 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed:  89   Index:  84
+Mt.Ordeals Summit                                                             Seed:  89   Index:  84
+  Step   1: 32 / Lilith x1 (8.568s)
+Paladin                                                                       Seed:  89   Index:  88
+Mt.Ordeals Summit                                                             Seed:  89   Index:  88
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  89   Index: 111
+  Step   6: 33 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  89   Index: 153
+Mt.Ordeals                                                                    Seed:  89   Index: 183
+  Step  30: 34 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  89   Index: 227
+Take Chocobo to Mysidia                                                       Seed:  89   Index: 240
+Overworld (Mysidia)                                                           Seed:  89   Index: 240
+Town of Baron Serpent Road                                                    Seed:  89   Index: 240
+Credit Warp Fight Search                                                      Seed:  89   Index: 244
+  Overworld (Baron)                                                           Seed:  89   Index: 244
+    Extra Steps: 24
+    Step   1: 35 / Imp x3 (7.174s)
+    Step  24: 36 / Imp x6 (7.090s)
+   (Step  74: 37 / FloatEye x2)
+   (Step 127: 38 / Imp x3)
+   (Step 128: 39 / FloatEye x2)
+   (Step 148: 40 / Imp x3, SwordRat x1)
+   (Step 159: 41 / FloatEye x2)
+   (Step 247: 42 / FloatEye x1, Eagle x2)
+
+Encounter Time:      277.602s
+Other Time:          525.435s
+Total Time:          803.036s
+
+Base Total Time:     953.328s
+Time Saved:          150.292s
+
+Optional Steps:      9
+Extra Steps:         126
+Encounters:          36
+
+Base Encounters:     47
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/005.txt
+++ b/data/routes/cw/005.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	5
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49004476
+VARS	FFFFFFFF:10 E302500:59 E307701:14 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:   5   Index:   0
+Overworld (Kaipo)                                                             Seed:   5   Index:   1
+Kaipo                                                                         Seed:   5   Index:  37
+Overworld (Kaipo)                                                             Seed:   5   Index:  37
+  Step  19: 1 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:   5   Index:  69
+  Step  12: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  18: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed:   5   Index: 101
+Watery Pass-South B1F                                                         Seed:   5   Index: 101
+Watery Pass-South B2F                                                         Seed:   5   Index: 121
+  Step   9: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  25: 5 / CaveToad x3 (7.014s)
+  Step  38: 6 / CaveToad x3 (7.014s)
+  Step  61: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:   5   Index: 211
+Watery Pass-South B2F                                                         Seed:   5   Index: 215
+Watery Pass-South B3F                                                         Seed:   5   Index: 254
+  Step   4: 8 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed:  22   Index:  32
+Watery Pass-North B1F                                                         Seed:  22   Index:  53
+  Step  14: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  40: 10 / Jelly x4 (7.324s)
+  Step  43: 11 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  22   Index: 113
+Waterfalls B1F                                                                Seed:  22   Index: 122
+Waterfalls B2F                                                                Seed:  22   Index: 123
+Waterfalls Lake                                                               Seed:  22   Index: 168
+Battle: Octomamm                                                              Seed:  22   Index: 205
+Waterfalls Lake                                                               Seed:  22   Index: 205
+  Step   1: 12 / TinyMage x2, WaterHag x4 (8.190s)
+Overworld (Kaipo)                                                             Seed:  22   Index: 206
+Overworld (Damcyan)                                                           Seed:  22   Index: 217
+Damcyan                                                                       Seed:  22   Index: 221
+  Optional Steps: 1
+  Extra Steps: 58
+Overworld (Damcyan)                                                           Seed:  39   Index:  31
+Antlion B1F                                                                   Seed:  39   Index:  31
+Antlion B2F Inward Direct                                                     Seed:  39   Index:  69
+  Antlion B2F                                                                 Seed:  39   Index:  69
+    Step   4: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  25: 14 / Cream x4 (7.552s)
+    Step  52: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  54: 16 / Weeper x2 (7.114s)
+    Step  72: 17 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  39   Index: 149
+Battle: Antlion                                                               Seed:  39   Index: 163
+Antlion's Nest                                                                Seed:  39   Index: 163
+Antlion B2F Outward Direct                                                    Seed:  39   Index: 178
+  Antlion B2F                                                                 Seed:  39   Index: 178
+    Step  25: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  63: 19 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  56   Index:   2
+  Extra Steps: 14
+  Step  13: 20 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  51: 21 / Basilisk x1, Imp x3 (6.783s)
+  Step  52: 22 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  56   Index:  54
+Overworld (Kaipo)                                                             Seed:  56   Index:  54
+Kaipo Revisited                                                               Seed:  56   Index:  54
+Overworld (Kaipo)                                                             Seed:  56   Index:  54
+Overworld (Damcyan)                                                           Seed:  56   Index:  54
+Mt.Hobs-West                                                                  Seed:  56   Index:  54
+  Step  35: 23 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed:  56   Index:  93
+  Step   6: 24 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed:  56   Index: 108
+Mt.Hobs Summit                                                                Seed:  56   Index: 108
+Mt.Hobs-East                                                                  Seed:  56   Index: 114
+  Step  29: 25 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  56   Index: 160
+  Step   7: 26 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed:  56   Index: 244
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed:  73   Index:  48
+Fabul Boat and Leviatan                                                       Seed:  73   Index:  55
+Overworld (Mysidia)                                                           Seed:  73   Index:  55
+Mysidia                                                                       Seed:  73   Index:  64
+Overworld (Mysidia)                                                           Seed:  73   Index:  64
+  Step   8: 27 / Needler x2, SwordRat x2 (8.097s)
+Overworld (Mt.Ordeals)                                                        Seed:  73   Index:  74
+  Step   3: 28 / Needler x2, SwordRat x2 (8.097s)
+  Step  45: 29 / Needler x2, SwordRat x2 (8.097s)
+  Step  53: 30 / Raven x1, Cocktric x3 (9.100s)
+  Step  79: 31 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  73   Index: 168
+Mt.Ordeals-3rd station                                                        Seed:  73   Index: 211
+  Step  20: 32 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed:  73   Index: 234
+Mt.Ordeals-3rd station                                                        Seed:  73   Index: 234
+Mt.Ordeals-7th station                                                        Seed:  73   Index: 239
+  Step   8: 33 / Lilith x1, Red Bone x2 (8.912s)
+  Step  37: 34 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  90   Index:  25
+  Optional Steps: 1
+  Step   7: 35 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed:  90   Index:  43
+Mt.Ordeals Summit                                                             Seed:  90   Index:  43
+Paladin                                                                       Seed:  90   Index:  47
+Mt.Ordeals Summit                                                             Seed:  90   Index:  47
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  90   Index:  70
+  Step   6: 36 / Ghoul x2, Soul x2 (8.971s)
+  Step  15: 37 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed:  90   Index: 112
+  Step   5: 38 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed:  90   Index: 142
+Overworld (Mt.Ordeals)                                                        Seed:  90   Index: 186
+Take Chocobo to Mysidia                                                       Seed:  90   Index: 199
+Overworld (Mysidia)                                                           Seed:  90   Index: 199
+Town of Baron Serpent Road                                                    Seed:  90   Index: 199
+Credit Warp Fight Search                                                      Seed:  90   Index: 203
+  Overworld (Baron)                                                           Seed:  90   Index: 203
+    Extra Steps: 10
+    Step   2: 39 / FloatEye x2 (7.230s)
+    Step  10: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  42: 41 / FloatEye x2)
+   (Step  65: 42 / FloatEye x1, Eagle x2)
+   (Step 115: 43 / FloatEye x1, Eagle x2)
+   (Step 135: 44 / Eagle x3)
+   (Step 169: 45 / FloatEye x1, Eagle x2)
+   (Step 189: 46 / FloatEye x1, Eagle x2)
+   (Step 200: 47 / Imp x3, SwordRat x1)
+
+Encounter Time:      309.997s
+Other Time:          505.401s
+Total Time:          815.398s
+
+Base Total Time:     952.784s
+Time Saved:          137.386s
+
+Optional Steps:      3
+Extra Steps:         82
+Encounters:          40
+
+Base Encounters:     47
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/006.txt
+++ b/data/routes/cw/006.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	6
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49025154
+VARS	FFFFFFFF:4 C307800:1 C307801:1 E302500:21 E307600:2 E307B00:60 E307B01:98 E308702:1 E309700:48
+
+Overworld (Kaipo)                                                             Seed:   6   Index:   0
+Overworld (Kaipo)                                                             Seed:   6   Index:   1
+Kaipo                                                                         Seed:   6   Index:  37
+Overworld (Kaipo)                                                             Seed:   6   Index:  37
+  Step  19: 1 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:   6   Index:  69
+  Step  12: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  18: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed:   6   Index: 101
+Watery Pass-South B1F                                                         Seed:   6   Index: 101
+Watery Pass-South B2F                                                         Seed:   6   Index: 121
+  Step  25: 4 / Pike x3 (7.152s)
+  Step  38: 5 / CaveToad x3 (7.014s)
+  Step  61: 6 / CaveToad x3 (7.014s)
+  Step  62: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:   6   Index: 211
+Watery Pass-South B2F                                                         Seed:   6   Index: 215
+Watery Pass-South B3F                                                         Seed:   6   Index: 254
+Watery Pass-North B2F                                                         Seed:  23   Index:  32
+Watery Pass-North B1F                                                         Seed:  23   Index:  53
+  Step  14: 8 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  40: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  43: 10 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed:  23   Index: 113
+Waterfalls B1F                                                                Seed:  23   Index: 122
+Waterfalls B2F                                                                Seed:  23   Index: 123
+Waterfalls Lake                                                               Seed:  23   Index: 168
+  Extra Steps: 2
+  Step  38: 11 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed:  23   Index: 207
+Waterfalls Lake                                                               Seed:  23   Index: 207
+Overworld (Kaipo)                                                             Seed:  23   Index: 208
+Overworld (Damcyan)                                                           Seed:  23   Index: 219
+Damcyan                                                                       Seed:  23   Index: 223
+  Optional Steps: 1
+  Extra Steps: 20
+Overworld (Damcyan)                                                           Seed:  23   Index: 251
+Antlion B1F                                                                   Seed:  23   Index: 251
+  Step  36: 12 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Charm Room Steps                                           Seed:  40   Index:  33
+  Antlion B2F                                                                 Seed:  40   Index:  33
+  Antlion B2F Treasure Room                                                   Seed:  40   Index:  66
+    Extra Steps: 60
+  Antlion B2F                                                                 Seed:  40   Index: 126
+Antlion's Nest                                                                Seed:  40   Index: 178
+Battle: Antlion                                                               Seed:  40   Index: 192
+Antlion's Nest                                                                Seed:  40   Index: 192
+  Step  11: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Charm Room Steps                                          Seed:  40   Index: 207
+  Antlion B2F                                                                 Seed:  40   Index: 207
+    Step  34: 14 / Cream x4 (7.523s)
+  Antlion B2F Treasure Room                                                   Seed:  57   Index:   2
+    Extra Steps: 98
+  Antlion B2F                                                                 Seed:  57   Index: 100
+Antlion B1F                                                                   Seed:  57   Index: 134
+  Step   9: 15 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed:  57   Index: 172
+Overworld (Kaipo)                                                             Seed:  57   Index: 172
+Kaipo Revisited                                                               Seed:  57   Index: 172
+Overworld (Kaipo)                                                             Seed:  57   Index: 172
+Overworld (Damcyan)                                                           Seed:  57   Index: 172
+Mt.Hobs-West                                                                  Seed:  57   Index: 172
+Mt.Hobs Summit                                                                Seed:  57   Index: 211
+Battle: MomBomb                                                               Seed:  57   Index: 226
+Mt.Hobs Summit                                                                Seed:  57   Index: 226
+Mt.Hobs-East                                                                  Seed:  57   Index: 232
+  Step  17: 16 / Turtle x2 (7.432s)
+  Step  25: 17 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed:  74   Index:  22
+  Step  21: 18 / Cocktric x3 (8.241s)
+  Step  50: 19 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  55: 20 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed:  74   Index: 106
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed:  74   Index: 166
+Fabul Boat and Leviatan                                                       Seed:  74   Index: 173
+Overworld (Mysidia)                                                           Seed:  74   Index: 173
+Mysidia                                                                       Seed:  74   Index: 182
+Overworld (Mysidia)                                                           Seed:  74   Index: 182
+Overworld (Mt.Ordeals)                                                        Seed:  74   Index: 192
+  Step  39: 21 / Raven x1 (8.356s)
+  Step  55: 22 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  72: 23 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  84: 24 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  91   Index:  30
+  Step   2: 25 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed:  91   Index:  73
+  Step   3: 26 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  91   Index:  96
+Mt.Ordeals-3rd station                                                        Seed:  91   Index:  96
+Mt.Ordeals-7th station                                                        Seed:  91   Index: 101
+  Step  16: 27 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed:  91   Index: 143
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed:  91   Index: 160
+Mt.Ordeals Summit                                                             Seed:  91   Index: 160
+Paladin                                                                       Seed:  91   Index: 164
+Mt.Ordeals Summit                                                             Seed:  91   Index: 164
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  91   Index: 187
+  Step  18: 28 / Lilith x1 (8.563s)
+  Step  26: 29 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed:  91   Index: 229
+  Step   1: 30 / Lilith x1, Red Bone x2 (8.437s)
+  Step  16: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 108   Index:   3
+  Step   9: 32 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 108   Index:  47
+Take Chocobo to Mysidia                                                       Seed: 108   Index:  60
+Overworld (Mysidia)                                                           Seed: 108   Index:  60
+Town of Baron Serpent Road                                                    Seed: 108   Index:  60
+  Extra Steps: 48
+Credit Warp Fight Search                                                      Seed: 108   Index: 112
+  Overworld (Baron)                                                           Seed: 108   Index: 112
+    Extra Steps: 4
+    Step   2: 33 / Eagle x3 (7.417s)
+    Step   4: 34 / Imp x3, SwordRat x1 (7.227s)
+   (Step  24: 35 / Imp x3)
+   (Step 123: 36 / Imp x3)
+   (Step 167: 37 / FloatEye x2)
+   (Step 224: 38 / Imp x3)
+   (Step 230: 39 / FloatEye x2)
+   (Step 256: 40 / Eagle x3)
+
+Encounter Time:      262.820s
+Other Time:          552.923s
+Total Time:          815.742s
+
+Base Total Time:     913.728s
+Time Saved:          97.985s
+
+Optional Steps:      2
+Extra Steps:         232
+Encounters:          34
+
+Base Encounters:     47
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/007.txt
+++ b/data/routes/cw/007.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	7
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48282441
+VARS	FFFFFFFF:30 C307800:1 C307801:1 E302500:57 E302600:33 E307600:2 E307700:4 E307701:4 E307B00:20 E307B01:22 E308401:4 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed:   7   Index:   0
+Overworld (Kaipo)                                                             Seed:   7   Index:   1
+Kaipo                                                                         Seed:   7   Index:  37
+Overworld (Kaipo)                                                             Seed:   7   Index:  37
+  Step  19: 1 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:   7   Index:  69
+  Step  12: 2 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:   7   Index: 101
+Watery Pass-South B1F                                                         Seed:   7   Index: 101
+Watery Pass-South B2F                                                         Seed:   7   Index: 121
+  Step  25: 3 / Zombie x4 (7.148s)
+  Step  38: 4 / Pike x3 (7.152s)
+  Step  61: 5 / CaveToad x3 (7.014s)
+  Step  62: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed:   7   Index: 211
+Watery Pass-South B2F                                                         Seed:   7   Index: 215
+  Step   8: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:   7   Index: 254
+Watery Pass-North B2F                                                         Seed:  24   Index:  32
+Watery Pass-North B1F                                                         Seed:  24   Index:  53
+  Step  14: 8 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  40: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  43: 10 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed:  24   Index: 113
+Waterfalls B1F                                                                Seed:  24   Index: 122
+Waterfalls B2F                                                                Seed:  24   Index: 123
+Waterfalls Lake                                                               Seed:  24   Index: 168
+  Extra Steps: 2
+  Step  38: 11 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed:  24   Index: 207
+Waterfalls Lake                                                               Seed:  24   Index: 207
+Overworld (Kaipo)                                                             Seed:  24   Index: 208
+Overworld (Damcyan)                                                           Seed:  24   Index: 219
+Damcyan                                                                       Seed:  24   Index: 223
+  Optional Steps: 1
+  Extra Steps: 56
+Overworld (Damcyan)                                                           Seed:  41   Index:  31
+Antlion B1F                                                                   Seed:  41   Index:  31
+  Extra Steps: 4
+  Step  42: 12 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Charm Room Steps                                           Seed:  41   Index:  73
+  Antlion B2F                                                                 Seed:  41   Index:  73
+    Step  21: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+  Antlion B2F Treasure Room                                                   Seed:  41   Index: 106
+    Extra Steps: 20
+  Antlion B2F                                                                 Seed:  41   Index: 126
+Antlion's Nest                                                                Seed:  41   Index: 178
+Battle: Antlion                                                               Seed:  41   Index: 192
+Antlion's Nest                                                                Seed:  41   Index: 192
+  Step  11: 14 / Cream x4 (7.523s)
+Antlion B2F Outward Charm Room Steps                                          Seed:  41   Index: 207
+  Antlion B2F                                                                 Seed:  41   Index: 207
+  Antlion B2F Treasure Room                                                   Seed:  58   Index:   2
+    Extra Steps: 22
+  Antlion B2F                                                                 Seed:  58   Index:  24
+    Step  29: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  58   Index:  58
+  Extra Steps: 4
+  Step  31: 16 / Turtle x2 (7.464s)
+  Step  41: 17 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  58   Index: 100
+Overworld (Kaipo)                                                             Seed:  58   Index: 100
+Kaipo Revisited                                                               Seed:  58   Index: 100
+Overworld (Kaipo)                                                             Seed:  58   Index: 100
+Overworld (Damcyan)                                                           Seed:  58   Index: 100
+Mt.Hobs-West                                                                  Seed:  58   Index: 100
+Mt.Hobs Summit                                                                Seed:  58   Index: 139
+  Step   4: 18 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed:  58   Index: 154
+Mt.Hobs Summit                                                                Seed:  58   Index: 154
+Mt.Hobs-East                                                                  Seed:  58   Index: 160
+Overworld (Fabul)                                                             Seed:  58   Index: 206
+  Step  26: 19 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  43: 20 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  51: 21 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed:  75   Index:  34
+  Optional Steps: 9
+  Extra Steps: 24
+Overworld (Fabul)                                                             Seed:  75   Index: 127
+Fabul Boat and Leviatan                                                       Seed:  75   Index: 134
+Overworld (Mysidia)                                                           Seed:  75   Index: 134
+Mysidia                                                                       Seed:  75   Index: 143
+Overworld (Mysidia)                                                           Seed:  75   Index: 143
+Overworld (Mt.Ordeals)                                                        Seed:  75   Index: 153
+  Step  78: 22 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  94: 23 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  75   Index: 247
+  Step  29: 24 / Spirit x3, Soul x1 (8.687s)
+  Step  41: 25 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed:  92   Index:  34
+  Step  16: 26 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  92   Index:  57
+Mt.Ordeals-3rd station                                                        Seed:  92   Index:  57
+Mt.Ordeals-7th station                                                        Seed:  92   Index:  62
+  Step  14: 27 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed:  92   Index: 104
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  92   Index: 122
+Mt.Ordeals Summit                                                             Seed:  92   Index: 122
+Paladin                                                                       Seed:  92   Index: 126
+Mt.Ordeals Summit                                                             Seed:  92   Index: 126
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  92   Index: 149
+Mt.Ordeals-3rd station                                                        Seed:  92   Index: 191
+  Step  14: 28 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  22: 29 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed:  92   Index: 221
+  Extra Steps: 4
+  Step   9: 30 / Spirit x2, Skelton x2 (8.065s)
+  Step  24: 31 / Skelton x3, Red Bone x2 (7.997s)
+  Step  47: 32 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 109   Index:  13
+Take Chocobo to Mysidia                                                       Seed: 109   Index:  26
+Overworld (Mysidia)                                                           Seed: 109   Index:  26
+Town of Baron Serpent Road                                                    Seed: 109   Index:  26
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 109   Index:  32
+  Overworld (Baron)                                                           Seed: 109   Index:  32
+    Extra Steps: 30
+    Step   1: 33 / Eagle x3 (7.417s)
+    Step  30: 34 / Imp x3, SwordRat x1 (7.227s)
+   (Step  50: 35 / Imp x3)
+   (Step  82: 36 / Imp x3)
+   (Step  84: 37 / FloatEye x2)
+   (Step 104: 38 / Imp x3)
+   (Step 247: 39 / FloatEye x2)
+
+Encounter Time:      260.578s
+Other Time:          542.806s
+Total Time:          803.384s
+
+Base Total Time:     888.934s
+Time Saved:          85.550s
+
+Optional Steps:      12
+Extra Steps:         168
+Encounters:          34
+
+Base Encounters:     47
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/008.txt
+++ b/data/routes/cw/008.txt
@@ -1,0 +1,159 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	8
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50347428
+VARS	FFFFFFFF:10 E000201:22 E000500:4 E302500:1 E302600:10 E307000:2 E307200:12 E307701:6 E308700:1 E308702:1 E309700:16
+
+Overworld (Kaipo)                                                             Seed:   8   Index:   0
+Overworld (Kaipo)                                                             Seed:   8   Index:   1
+Kaipo                                                                         Seed:   8   Index:  37
+Overworld (Kaipo)                                                             Seed:   8   Index:  37
+  Step  19: 1 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:   8   Index:  69
+  Step  12: 2 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:   8   Index: 101
+Watery Pass-South B1F                                                         Seed:   8   Index: 101
+Watery Pass-South B2F                                                         Seed:   8   Index: 121
+  Step  25: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  38: 4 / Pike x3 (7.152s)
+  Step  61: 5 / CaveToad x3 (7.014s)
+  Step  62: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed:   8   Index: 211
+Watery Pass-South B2F                                                         Seed:   8   Index: 215
+  Extra Steps: 2
+  Step   8: 7 / Pike x3 (7.152s)
+  Step  40: 8 / Zombie x4 (7.148s)
+Watery Pass-South B3F                                                         Seed:  25   Index:   0
+Watery Pass-North B2F                                                         Seed:  25   Index:  34
+  Extra Steps: 12
+  Step  18: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  33: 10 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed:  25   Index:  67
+  Step  29: 11 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  25   Index: 127
+Waterfalls B1F                                                                Seed:  25   Index: 136
+Waterfalls B2F                                                                Seed:  25   Index: 137
+Waterfalls Lake                                                               Seed:  25   Index: 182
+  Step  24: 12 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed:  25   Index: 219
+Waterfalls Lake                                                               Seed:  25   Index: 219
+Overworld (Kaipo)                                                             Seed:  25   Index: 220
+  Extra Steps: 22
+  Step   4: 13 / Imp x4 (7.092s)
+  Step  19: 14 / SandMoth x2, Larva x2 (7.188s)
+  Step  31: 15 / Imp x4 (7.092s)
+  Step  33: 16 / SandMoth x2, Larva x2 (7.188s)
+Overworld (Damcyan)                                                           Seed:  25   Index: 253
+Damcyan                                                                       Seed:  42   Index:   1
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  42   Index:   9
+Antlion B1F                                                                   Seed:  42   Index:   9
+  Step  17: 17 / Turtle x1, Imp x2 (7.044s)
+  Step  22: 18 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed:  42   Index:  47
+  Antlion B2F                                                                 Seed:  42   Index:  47
+    Step  26: 19 / Basilisk x1, Imp x3 (6.775s)
+    Step  47: 20 / Basilisk x1, Imp x3 (6.775s)
+    Step  76: 21 / Basilisk x1, Turtle x1 (7.110s)
+    Step  78: 22 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  42   Index: 127
+Battle: Antlion                                                               Seed:  42   Index: 141
+Antlion's Nest                                                                Seed:  42   Index: 141
+Antlion B2F Outward Direct                                                    Seed:  42   Index: 156
+  Antlion B2F                                                                 Seed:  42   Index: 156
+    Step  47: 23 / Basilisk x1, Imp x3 (6.783s)
+    Step  80: 24 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  42   Index: 236
+  Extra Steps: 6
+  Step  35: 25 / Turtle x2 (7.464s)
+  Step  44: 26 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  59   Index:  24
+Overworld (Kaipo)                                                             Seed:  59   Index:  24
+Kaipo Revisited                                                               Seed:  59   Index:  24
+Overworld (Kaipo)                                                             Seed:  59   Index:  24
+Overworld (Damcyan)                                                           Seed:  59   Index:  24
+Mt.Hobs-West                                                                  Seed:  59   Index:  24
+  Step  29: 27 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed:  59   Index:  63
+Battle: MomBomb                                                               Seed:  59   Index:  78
+Mt.Hobs Summit                                                                Seed:  59   Index:  78
+Mt.Hobs-East                                                                  Seed:  59   Index:  84
+  Step  15: 28 / Turtle x2 (7.432s)
+  Step  40: 29 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  59   Index: 130
+  Step  13: 30 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  59   Index: 214
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  76   Index:  28
+Fabul Boat and Leviatan                                                       Seed:  76   Index:  35
+Overworld (Mysidia)                                                           Seed:  76   Index:  35
+  Extra Steps: 4
+  Step  13: 31 / Needler x2, SwordRat x2 (8.011s)
+Mysidia                                                                       Seed:  76   Index:  48
+Overworld (Mysidia)                                                           Seed:  76   Index:  48
+Overworld (Mt.Ordeals)                                                        Seed:  76   Index:  58
+  Step  14: 32 / Raven x1, Cocktric x3 (9.100s)
+  Step  19: 33 / Raven x1 (8.356s)
+  Step  60: 34 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  61: 35 / Raven x1 (8.356s)
+  Step  69: 36 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  76   Index: 152
+Mt.Ordeals-3rd station                                                        Seed:  76   Index: 195
+Recruit Tellah                                                                Seed:  76   Index: 218
+Mt.Ordeals-3rd station                                                        Seed:  76   Index: 218
+Mt.Ordeals-7th station                                                        Seed:  76   Index: 223
+  Step   8: 37 / Revenant x1, Ghoul x3 (8.914s)
+  Step  24: 38 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed:  93   Index:   9
+  Optional Steps: 1
+  Step  11: 39 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:  93   Index:  27
+Mt.Ordeals Summit                                                             Seed:  93   Index:  27
+Paladin                                                                       Seed:  93   Index:  31
+Mt.Ordeals Summit                                                             Seed:  93   Index:  31
+  Optional Steps: 1
+  Step   1: 40 / Lilith x1, Red Bone x2 (8.437s)
+  Step  19: 41 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed:  93   Index:  54
+Mt.Ordeals-3rd station                                                        Seed:  93   Index:  96
+Mt.Ordeals                                                                    Seed:  93   Index: 126
+  Step  22: 42 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed:  93   Index: 170
+Take Chocobo to Mysidia                                                       Seed:  93   Index: 183
+Overworld (Mysidia)                                                           Seed:  93   Index: 183
+Town of Baron Serpent Road                                                    Seed:  93   Index: 183
+  Extra Steps: 16
+Credit Warp Fight Search                                                      Seed:  93   Index: 203
+  Overworld (Baron)                                                           Seed:  93   Index: 203
+    Extra Steps: 10
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  10: 44 / Imp x4 (7.223s)
+   (Step  27: 45 / FloatEye x1, Eagle x2)
+   (Step  42: 46 / FloatEye x1, Eagle x2)
+   (Step  86: 47 / Imp x3, SwordRat x1)
+   (Step 115: 48 / Imp x4)
+   (Step 135: 49 / Eagle x3)
+   (Step 167: 50 / Imp x3, SwordRat x1)
+   (Step 169: 51 / Eagle x3)
+   (Step 189: 52 / Eagle x3)
+
+Encounter Time:      335.005s
+Other Time:          502.739s
+Total Time:          837.744s
+
+Base Total Time:     891.067s
+Time Saved:          53.323s
+
+Optional Steps:      13
+Extra Steps:         72
+Encounters:          44
+
+Base Encounters:     47
+Encounters Saved:    3
+
+Number of Variables: 54

--- a/data/routes/cw/009.txt
+++ b/data/routes/cw/009.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	9
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50431466
+VARS	FFFFFFFF:34 E302500:1 E302600:10 E308700:1 E308702:1 E309700:6
+
+Overworld (Kaipo)                                                             Seed:   9   Index:   0
+Overworld (Kaipo)                                                             Seed:   9   Index:   1
+  Step  34: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:   9   Index:  37
+Overworld (Kaipo)                                                             Seed:   9   Index:  37
+Watery Pass-South B1F                                                         Seed:   9   Index:  69
+  Step  12: 2 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:   9   Index: 101
+Watery Pass-South B1F                                                         Seed:   9   Index: 101
+Watery Pass-South B2F                                                         Seed:   9   Index: 121
+  Step  38: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  61: 4 / Pike x3 (7.152s)
+  Step  62: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed:   9   Index: 211
+Watery Pass-South B2F                                                         Seed:   9   Index: 215
+  Step   8: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:   9   Index: 254
+  Step   1: 7 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  26   Index:  32
+  Step  20: 8 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B1F                                                         Seed:  26   Index:  53
+  Step   7: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  14: 10 / Jelly x4 (7.324s)
+  Step  43: 11 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  26   Index: 113
+Waterfalls B1F                                                                Seed:  26   Index: 122
+Waterfalls B2F                                                                Seed:  26   Index: 123
+Waterfalls Lake                                                               Seed:  26   Index: 168
+Battle: Octomamm                                                              Seed:  26   Index: 205
+Waterfalls Lake                                                               Seed:  26   Index: 205
+  Step   1: 12 / TinyMage x2, WaterHag x4 (8.190s)
+Overworld (Kaipo)                                                             Seed:  26   Index: 206
+Overworld (Damcyan)                                                           Seed:  26   Index: 217
+Damcyan                                                                       Seed:  26   Index: 221
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  26   Index: 229
+Antlion B1F                                                                   Seed:  26   Index: 229
+  Step  10: 13 / Cream x4 (7.552s)
+  Step  22: 14 / Imp x3 (6.649s)
+  Step  24: 15 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed:  43   Index:  11
+  Antlion B2F                                                                 Seed:  43   Index:  11
+    Step  15: 16 / Weeper x2 (7.114s)
+    Step  36: 17 / Turtle x2 (7.487s)
+    Step  62: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed:  43   Index:  91
+  Step   3: 19 / Basilisk x1, Imp x3 (6.775s)
+Battle: Antlion                                                               Seed:  43   Index: 105
+Antlion's Nest                                                                Seed:  43   Index: 105
+Antlion B2F Outward Direct                                                    Seed:  43   Index: 120
+  Antlion B2F                                                                 Seed:  43   Index: 120
+    Step   3: 20 / Basilisk x1, Imp x3 (6.783s)
+    Step   5: 21 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed:  43   Index: 200
+  Step   3: 22 / Turtle x1, Imp x2 (7.009s)
+  Step  36: 23 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  43   Index: 238
+Overworld (Kaipo)                                                             Seed:  43   Index: 238
+Kaipo Revisited                                                               Seed:  43   Index: 238
+Overworld (Kaipo)                                                             Seed:  43   Index: 238
+Overworld (Damcyan)                                                           Seed:  43   Index: 238
+Mt.Hobs-West                                                                  Seed:  43   Index: 238
+  Step  33: 24 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed:  60   Index:  21
+  Step   3: 25 / Spirit x2, Skelton x2 (9.087s)
+Battle: MomBomb                                                               Seed:  60   Index:  36
+Mt.Hobs Summit                                                                Seed:  60   Index:  36
+Mt.Hobs-East                                                                  Seed:  60   Index:  42
+  Step  11: 26 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  26: 27 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  60   Index:  88
+  Step   1: 28 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  11: 29 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  36: 30 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  55: 31 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed:  60   Index: 172
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  60   Index: 242
+  Step   7: 32 / SwordRat x3, Needler x3 (7.573s)
+Fabul Boat and Leviatan                                                       Seed:  60   Index: 249
+Overworld (Mysidia)                                                           Seed:  60   Index: 249
+  Step   8: 33 / Raven x1 (8.246s)
+Mysidia                                                                       Seed:  77   Index:   2
+Overworld (Mysidia)                                                           Seed:  77   Index:   2
+Overworld (Mt.Ordeals)                                                        Seed:  77   Index:  12
+  Step  36: 34 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  60: 35 / Raven x1 (8.356s)
+  Step  65: 36 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  77   Index: 106
+  Step  12: 37 / Red Bone x1, Skelton x3 (8.067s)
+  Step  21: 38 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed:  77   Index: 149
+Recruit Tellah                                                                Seed:  77   Index: 172
+Mt.Ordeals-3rd station                                                        Seed:  77   Index: 172
+Mt.Ordeals-7th station                                                        Seed:  77   Index: 177
+  Step  18: 39 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed:  77   Index: 219
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  77   Index: 237
+Mt.Ordeals Summit                                                             Seed:  77   Index: 237
+Paladin                                                                       Seed:  77   Index: 241
+Mt.Ordeals Summit                                                             Seed:  77   Index: 241
+  Optional Steps: 1
+  Step   6: 40 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed:  94   Index:   8
+  Step  12: 41 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  42: 42 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  94   Index:  50
+Mt.Ordeals                                                                    Seed:  94   Index:  80
+Overworld (Mt.Ordeals)                                                        Seed:  94   Index: 124
+Take Chocobo to Mysidia                                                       Seed:  94   Index: 137
+Overworld (Mysidia)                                                           Seed:  94   Index: 137
+Town of Baron Serpent Road                                                    Seed:  94   Index: 137
+  Extra Steps: 6
+Credit Warp Fight Search                                                      Seed:  94   Index: 147
+  Overworld (Baron)                                                           Seed:  94   Index: 147
+    Extra Steps: 34
+    Step   1: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  34: 44 / Imp x4 (7.223s)
+   (Step  58: 45 / FloatEye x1, Eagle x2)
+   (Step  83: 46 / FloatEye x1, Eagle x2)
+   (Step  98: 47 / Imp x3, SwordRat x1)
+   (Step 142: 48 / Imp x4)
+   (Step 191: 49 / Eagle x3)
+   (Step 223: 50 / Imp x3, SwordRat x1)
+   (Step 225: 51 / Eagle x3)
+   (Step 245: 52 / Eagle x3)
+
+Encounter Time:      338.534s
+Other Time:          500.609s
+Total Time:          839.142s
+
+Base Total Time:     894.966s
+Time Saved:          55.824s
+
+Optional Steps:      13
+Extra Steps:         40
+Encounters:          44
+
+Base Encounters:     47
+Encounters Saved:    3
+
+Number of Variables: 54

--- a/data/routes/cw/010.txt
+++ b/data/routes/cw/010.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	10
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50416078
+VARS	FFFFFFFF:34 E302600:6 E307600:2 E308000:10 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  10   Index:   0
+Overworld (Kaipo)                                                             Seed:  10   Index:   1
+  Step  12: 1 / SandMoth x2, Larva x2 (7.009s)
+  Step  34: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  10   Index:  37
+Overworld (Kaipo)                                                             Seed:  10   Index:  37
+Watery Pass-South B1F                                                         Seed:  10   Index:  69
+  Step  12: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:  10   Index: 101
+Watery Pass-South B1F                                                         Seed:  10   Index: 101
+Watery Pass-South B2F                                                         Seed:  10   Index: 121
+  Step  38: 4 / Pike x3 (7.152s)
+  Step  62: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed:  10   Index: 211
+Watery Pass-South B2F                                                         Seed:  10   Index: 215
+  Step   8: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  10   Index: 254
+  Step   1: 7 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  27   Index:  32
+  Step  20: 8 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B1F                                                         Seed:  27   Index:  53
+  Step   7: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  39: 10 / Jelly x4 (7.324s)
+  Step  43: 11 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  27   Index: 113
+Waterfalls B1F                                                                Seed:  27   Index: 122
+Waterfalls B2F                                                                Seed:  27   Index: 123
+Waterfalls Lake                                                               Seed:  27   Index: 168
+  Extra Steps: 2
+  Step  38: 12 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed:  27   Index: 207
+Waterfalls Lake                                                               Seed:  27   Index: 207
+Overworld (Kaipo)                                                             Seed:  27   Index: 208
+Overworld (Damcyan)                                                           Seed:  27   Index: 219
+Damcyan                                                                       Seed:  27   Index: 223
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  27   Index: 230
+Antlion B1F                                                                   Seed:  27   Index: 230
+  Step   9: 13 / Basilisk x1, Imp x3 (6.775s)
+  Step  21: 14 / Imp x3 (6.649s)
+  Step  23: 15 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed:  44   Index:  12
+  Antlion B2F                                                                 Seed:  44   Index:  12
+    Step  14: 16 / Weeper x2 (7.114s)
+    Step  35: 17 / Turtle x2 (7.487s)
+    Step  46: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  61: 19 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  44   Index:  92
+  Step   2: 20 / Basilisk x1, Imp x3 (6.775s)
+Battle: Antlion                                                               Seed:  44   Index: 106
+Antlion's Nest                                                                Seed:  44   Index: 106
+Antlion B2F Outward Direct                                                    Seed:  44   Index: 121
+  Antlion B2F                                                                 Seed:  44   Index: 121
+    Step   4: 21 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed:  44   Index: 201
+  Step   2: 22 / Turtle x1, Imp x2 (7.009s)
+  Step  35: 23 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  44   Index: 239
+Overworld (Kaipo)                                                             Seed:  44   Index: 239
+Kaipo Revisited                                                               Seed:  44   Index: 239
+Overworld (Kaipo)                                                             Seed:  44   Index: 239
+Overworld (Damcyan)                                                           Seed:  44   Index: 239
+Mt.Hobs-West                                                                  Seed:  44   Index: 239
+Mt.Hobs Summit                                                                Seed:  61   Index:  22
+  Step   2: 24 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed:  61   Index:  37
+Mt.Hobs Summit                                                                Seed:  61   Index:  37
+Mt.Hobs-East                                                                  Seed:  61   Index:  43
+  Extra Steps: 10
+  Step  10: 25 / Turtle x2 (7.432s)
+  Step  25: 26 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  35: 27 / Turtle x2 (7.432s)
+  Step  56: 28 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  61   Index:  99
+  Step  25: 29 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  44: 30 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  61   Index: 183
+  Optional Steps: 6
+Overworld (Fabul)                                                             Seed:  61   Index: 249
+Fabul Boat and Leviatan                                                       Seed:  78   Index:   0
+Overworld (Mysidia)                                                           Seed:  78   Index:   0
+  Step   1: 31 / Needler x2, SwordRat x2 (8.011s)
+Mysidia                                                                       Seed:  78   Index:   9
+Overworld (Mysidia)                                                           Seed:  78   Index:   9
+  Step   1: 32 / Raven x1, Cocktric x3 (9.100s)
+Overworld (Mt.Ordeals)                                                        Seed:  78   Index:  19
+  Step  29: 33 / Raven x1 (8.356s)
+  Step  53: 34 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  58: 35 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  78   Index: 113
+  Step   5: 36 / Spirit x2, Skelton x2 (8.285s)
+  Step  14: 37 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  78   Index: 156
+Recruit Tellah                                                                Seed:  78   Index: 179
+Mt.Ordeals-3rd station                                                        Seed:  78   Index: 179
+Mt.Ordeals-7th station                                                        Seed:  78   Index: 184
+  Step  11: 38 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed:  78   Index: 226
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed:  78   Index: 243
+Mt.Ordeals Summit                                                             Seed:  78   Index: 243
+  Step   4: 39 / Revenant x1, Ghoul x3 (8.611s)
+Paladin                                                                       Seed:  78   Index: 247
+Mt.Ordeals Summit                                                             Seed:  78   Index: 247
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  95   Index:  14
+  Step   6: 40 / Lilith x1, Red Bone x2 (8.437s)
+  Step  25: 41 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  36: 42 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  95   Index:  56
+Mt.Ordeals                                                                    Seed:  95   Index:  86
+Overworld (Mt.Ordeals)                                                        Seed:  95   Index: 130
+Take Chocobo to Mysidia                                                       Seed:  95   Index: 143
+Overworld (Mysidia)                                                           Seed:  95   Index: 143
+Town of Baron Serpent Road                                                    Seed:  95   Index: 143
+Credit Warp Fight Search                                                      Seed:  95   Index: 147
+  Overworld (Baron)                                                           Seed:  95   Index: 147
+    Extra Steps: 34
+    Step   1: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  34: 44 / Imp x4 (7.223s)
+   (Step  58: 45 / FloatEye x1, Eagle x2)
+   (Step  83: 46 / Imp x3, SwordRat x1)
+   (Step 142: 47 / Imp x3, SwordRat x1)
+   (Step 191: 48 / Imp x4)
+   (Step 223: 49 / Eagle x3)
+   (Step 225: 50 / Imp x3, SwordRat x1)
+
+Encounter Time:      336.680s
+Other Time:          502.206s
+Total Time:          838.886s
+
+Base Total Time:     862.437s
+Time Saved:          23.551s
+
+Optional Steps:      7
+Extra Steps:         46
+Encounters:          44
+
+Base Encounters:     46
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/011.txt
+++ b/data/routes/cw/011.txt
@@ -1,0 +1,146 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	11
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49276822
+VARS	FFFFFFFF:10 C307800:1 E000600:8 E302500:25 E302600:10 E305400:110 E307400:96 E307701:6 E307B00:82 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  11   Index:   0
+Overworld (Kaipo)                                                             Seed:  11   Index:   1
+  Step  12: 1 / SandMoth x2, Larva x2 (7.009s)
+  Step  34: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  11   Index:  37
+Overworld (Kaipo)                                                             Seed:  11   Index:  37
+Watery Pass-South B1F                                                         Seed:  11   Index:  69
+Recruit Tellah                                                                Seed:  11   Index: 101
+Watery Pass-South B1F                                                         Seed:  11   Index: 101
+Watery Pass-South B2F                                                         Seed:  11   Index: 121
+  Step  38: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  62: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  11   Index: 211
+  Extra Steps: 110
+Watery Pass-South B2F                                                         Seed:  28   Index:  69
+  Step  23: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  28   Index: 108
+Watery Pass-North B2F                                                         Seed:  28   Index: 142
+Watery Pass-North B1F                                                         Seed:  28   Index: 163
+  Step  43: 6 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed:  28   Index: 223
+Waterfalls B1F                                                                Seed:  28   Index: 232
+  Extra Steps: 96
+Waterfalls B2F                                                                Seed:  45   Index:  73
+Waterfalls Lake                                                               Seed:  45   Index: 118
+  Step   7: 7 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed:  45   Index: 155
+Waterfalls Lake                                                               Seed:  45   Index: 155
+Overworld (Kaipo)                                                             Seed:  45   Index: 156
+Overworld (Damcyan)                                                           Seed:  45   Index: 167
+Damcyan                                                                       Seed:  45   Index: 171
+  Optional Steps: 1
+  Extra Steps: 24
+Overworld (Damcyan)                                                           Seed:  45   Index: 203
+Antlion B1F                                                                   Seed:  45   Index: 203
+  Step  33: 8 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Charm Room Steps                                           Seed:  45   Index: 241
+  Antlion B2F                                                                 Seed:  45   Index: 241
+  Antlion B2F Treasure Room                                                   Seed:  62   Index:  18
+    Extra Steps: 82
+  Antlion B2F                                                                 Seed:  62   Index: 100
+    Step  24: 9 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:  62   Index: 152
+Battle: Antlion                                                               Seed:  62   Index: 166
+Antlion's Nest                                                                Seed:  62   Index: 166
+Antlion B2F Outward Direct                                                    Seed:  62   Index: 181
+  Antlion B2F                                                                 Seed:  62   Index: 181
+    Step  51: 10 / Turtle x2 (7.464s)
+    Step  68: 11 / Basilisk x1, Turtle x1 (7.124s)
+    Step  76: 12 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  79   Index:   5
+  Extra Steps: 6
+  Step   5: 13 / Basilisk x1, Imp x3 (6.783s)
+  Step  43: 14 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  79   Index:  49
+Overworld (Kaipo)                                                             Seed:  79   Index:  49
+Kaipo Revisited                                                               Seed:  79   Index:  49
+Overworld (Kaipo)                                                             Seed:  79   Index:  49
+Overworld (Damcyan)                                                           Seed:  79   Index:  49
+Mt.Hobs-West                                                                  Seed:  79   Index:  49
+Mt.Hobs Summit                                                                Seed:  79   Index:  88
+Battle: MomBomb                                                               Seed:  79   Index: 103
+Mt.Hobs Summit                                                                Seed:  79   Index: 103
+Mt.Hobs-East                                                                  Seed:  79   Index: 109
+  Step   9: 15 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  18: 16 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  79   Index: 155
+  Step  40: 17 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  74: 18 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  79   Index: 239
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  96   Index:  53
+Fabul Boat and Leviatan                                                       Seed:  96   Index:  60
+Overworld (Mysidia)                                                           Seed:  96   Index:  60
+Mysidia                                                                       Seed:  96   Index:  69
+Overworld (Mysidia)                                                           Seed:  96   Index:  69
+Overworld (Mt.Ordeals)                                                        Seed:  96   Index:  79
+  Extra Steps: 8
+  Step  23: 19 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  69: 20 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step 102: 21 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  96   Index: 181
+  Step  24: 22 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:  96   Index: 224
+  Step   6: 23 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed:  96   Index: 247
+Mt.Ordeals-3rd station                                                        Seed:  96   Index: 247
+Mt.Ordeals-7th station                                                        Seed:  96   Index: 252
+  Step  21: 24 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  37: 25 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 113   Index:  38
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 113   Index:  56
+Mt.Ordeals Summit                                                             Seed: 113   Index:  56
+Paladin                                                                       Seed: 113   Index:  60
+Mt.Ordeals Summit                                                             Seed: 113   Index:  60
+  Optional Steps: 1
+  Step  22: 26 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 113   Index:  83
+  Step  31: 27 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+  Step  33: 28 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed: 113   Index: 125
+Mt.Ordeals                                                                    Seed: 113   Index: 155
+  Step  11: 29 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 113   Index: 199
+Take Chocobo to Mysidia                                                       Seed: 113   Index: 212
+Overworld (Mysidia)                                                           Seed: 113   Index: 212
+Town of Baron Serpent Road                                                    Seed: 113   Index: 212
+Credit Warp Fight Search                                                      Seed: 113   Index: 216
+  Overworld (Baron)                                                           Seed: 113   Index: 216
+    Extra Steps: 10
+    Step   2: 30 / Imp x3 (7.174s)
+    Step  10: 31 / Imp x4 (7.223s)
+   (Step  86: 32 / Imp x3, SwordRat x1)
+   (Step 130: 33 / Eagle x3)
+   (Step 152: 34 / Imp x3, SwordRat x1)
+   (Step 200: 35 / FloatEye x2)
+   (Step 248: 36 / Imp x3)
+   (Step 255: 37 / FloatEye x2)
+
+Encounter Time:      242.315s
+Other Time:          577.615s
+Total Time:          819.930s
+
+Base Total Time:     863.435s
+Time Saved:          43.505s
+
+Optional Steps:      13
+Extra Steps:         336
+Encounters:          31
+
+Base Encounters:     46
+Encounters Saved:    15
+
+Number of Variables: 54

--- a/data/routes/cw/012.txt
+++ b/data/routes/cw/012.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	12
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49671225
+VARS	FFFFFFFF:10 C307800:1 E000600:10 E302500:37 E302600:22 E305400:110 E307400:84 E307B00:60 E308000:14 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  12   Index:   0
+Overworld (Kaipo)                                                             Seed:  12   Index:   1
+  Step  12: 1 / SandMoth x2, Larva x2 (7.009s)
+  Step  34: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  12   Index:  37
+Overworld (Kaipo)                                                             Seed:  12   Index:  37
+  Step  27: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:  12   Index:  69
+Recruit Tellah                                                                Seed:  12   Index: 101
+Watery Pass-South B1F                                                         Seed:  12   Index: 101
+Watery Pass-South B2F                                                         Seed:  12   Index: 121
+  Step  62: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  12   Index: 211
+  Extra Steps: 110
+Watery Pass-South B2F                                                         Seed:  29   Index:  69
+  Step  23: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  29   Index: 108
+Watery Pass-North B2F                                                         Seed:  29   Index: 142
+Watery Pass-North B1F                                                         Seed:  29   Index: 163
+  Step  43: 6 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed:  29   Index: 223
+Waterfalls B1F                                                                Seed:  29   Index: 232
+  Extra Steps: 84
+Waterfalls B2F                                                                Seed:  46   Index:  61
+Waterfalls Lake                                                               Seed:  46   Index: 106
+  Step  19: 7 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed:  46   Index: 143
+Waterfalls Lake                                                               Seed:  46   Index: 143
+Overworld (Kaipo)                                                             Seed:  46   Index: 144
+Overworld (Damcyan)                                                           Seed:  46   Index: 155
+Damcyan                                                                       Seed:  46   Index: 159
+  Optional Steps: 1
+  Extra Steps: 36
+Overworld (Damcyan)                                                           Seed:  46   Index: 203
+Antlion B1F                                                                   Seed:  46   Index: 203
+  Step  33: 8 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Charm Room Steps                                           Seed:  46   Index: 241
+  Antlion B2F                                                                 Seed:  46   Index: 241
+  Antlion B2F Treasure Room                                                   Seed:  63   Index:  18
+    Extra Steps: 60
+  Antlion B2F                                                                 Seed:  63   Index:  78
+    Step  46: 9 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:  63   Index: 130
+Battle: Antlion                                                               Seed:  63   Index: 144
+Antlion's Nest                                                                Seed:  63   Index: 144
+Antlion B2F Outward Direct                                                    Seed:  63   Index: 159
+  Antlion B2F                                                                 Seed:  63   Index: 159
+    Step  73: 10 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  63   Index: 239
+  Step  10: 11 / Basilisk x1, Imp x3 (6.783s)
+  Step  18: 12 / Turtle x1, Imp x2 (7.009s)
+  Step  27: 13 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed:  80   Index:  21
+Overworld (Kaipo)                                                             Seed:  80   Index:  21
+Kaipo Revisited                                                               Seed:  80   Index:  21
+Overworld (Kaipo)                                                             Seed:  80   Index:  21
+Overworld (Damcyan)                                                           Seed:  80   Index:  21
+Mt.Hobs-West                                                                  Seed:  80   Index:  21
+  Step  27: 14 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  80   Index:  60
+Battle: MomBomb                                                               Seed:  80   Index:  75
+Mt.Hobs Summit                                                                Seed:  80   Index:  75
+Mt.Hobs-East                                                                  Seed:  80   Index:  81
+  Extra Steps: 14
+  Step  37: 15 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  46: 16 / Turtle x2 (7.432s)
+  Step  59: 17 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed:  80   Index: 141
+  Step  54: 18 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  80   Index: 225
+  Optional Steps: 10
+  Extra Steps: 12
+Overworld (Fabul)                                                             Seed:  97   Index:  51
+Fabul Boat and Leviatan                                                       Seed:  97   Index:  58
+Overworld (Mysidia)                                                           Seed:  97   Index:  58
+Mysidia                                                                       Seed:  97   Index:  67
+Overworld (Mysidia)                                                           Seed:  97   Index:  67
+Overworld (Mt.Ordeals)                                                        Seed:  97   Index:  77
+  Extra Steps: 10
+  Step  14: 19 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  25: 20 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  71: 21 / Raven x1 (8.356s)
+  Step 104: 22 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  97   Index: 181
+  Step  24: 23 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  97   Index: 224
+  Step   6: 24 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed:  97   Index: 247
+Mt.Ordeals-3rd station                                                        Seed:  97   Index: 247
+Mt.Ordeals-7th station                                                        Seed:  97   Index: 252
+  Step  21: 25 / Lilith x1 (8.745s)
+  Step  37: 26 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 114   Index:  38
+  Optional Steps: 1
+  Step  11: 27 / Soul x3, Ghoul x1, Revenant x1 (9.933s)
+Battle: Milon and Milon Z                                                     Seed: 114   Index:  56
+Mt.Ordeals Summit                                                             Seed: 114   Index:  56
+Paladin                                                                       Seed: 114   Index:  60
+Mt.Ordeals Summit                                                             Seed: 114   Index:  60
+  Optional Steps: 1
+  Step  22: 28 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed: 114   Index:  83
+  Step  31: 29 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed: 114   Index: 125
+Mt.Ordeals                                                                    Seed: 114   Index: 155
+  Step  11: 30 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 114   Index: 199
+Take Chocobo to Mysidia                                                       Seed: 114   Index: 212
+Overworld (Mysidia)                                                           Seed: 114   Index: 212
+Town of Baron Serpent Road                                                    Seed: 114   Index: 212
+Credit Warp Fight Search                                                      Seed: 114   Index: 216
+  Overworld (Baron)                                                           Seed: 114   Index: 216
+    Extra Steps: 10
+    Step   2: 31 / Imp x4 (7.223s)
+    Step  10: 32 / Imp x3, SwordRat x1 (7.227s)
+   (Step  86: 33 / Eagle x3)
+   (Step 119: 34 / Imp x3, SwordRat x1)
+   (Step 130: 35 / FloatEye x2)
+   (Step 200: 36 / Imp x3)
+   (Step 248: 37 / FloatEye x2)
+   (Step 255: 38 / Imp x3)
+
+Encounter Time:      248.877s
+Other Time:          577.615s
+Total Time:          826.493s
+
+Base Total Time:     866.651s
+Time Saved:          40.158s
+
+Optional Steps:      13
+Extra Steps:         336
+Encounters:          32
+
+Base Encounters:     46
+Encounters Saved:    14
+
+Number of Variables: 54

--- a/data/routes/cw/013.txt
+++ b/data/routes/cw/013.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	13
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49443655
+VARS	FFFFFFFF:10 C307800:1 E000600:10 E302500:21 E302600:22 E305400:110 E307400:84 E307802:12 E307B00:76 E308000:2 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  13   Index:   0
+Overworld (Kaipo)                                                             Seed:  13   Index:   1
+  Step  12: 1 / SandMoth x2, Larva x2 (7.009s)
+  Step  34: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  13   Index:  37
+Overworld (Kaipo)                                                             Seed:  13   Index:  37
+  Step  27: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:  13   Index:  69
+Recruit Tellah                                                                Seed:  13   Index: 101
+Watery Pass-South B1F                                                         Seed:  13   Index: 101
+Watery Pass-South B2F                                                         Seed:  13   Index: 121
+  Step  37: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  13   Index: 211
+  Extra Steps: 110
+Watery Pass-South B2F                                                         Seed:  30   Index:  69
+  Step  23: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  30   Index: 108
+Watery Pass-North B2F                                                         Seed:  30   Index: 142
+Watery Pass-North B1F                                                         Seed:  30   Index: 163
+  Step  25: 6 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed:  30   Index: 223
+Waterfalls B1F                                                                Seed:  30   Index: 232
+  Extra Steps: 84
+Waterfalls B2F                                                                Seed:  47   Index:  61
+Waterfalls Lake                                                               Seed:  47   Index: 106
+  Step  19: 7 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed:  47   Index: 143
+Waterfalls Lake                                                               Seed:  47   Index: 143
+Overworld (Kaipo)                                                             Seed:  47   Index: 144
+Overworld (Damcyan)                                                           Seed:  47   Index: 155
+Damcyan                                                                       Seed:  47   Index: 159
+  Optional Steps: 1
+  Extra Steps: 20
+Overworld (Damcyan)                                                           Seed:  47   Index: 187
+Antlion B1F                                                                   Seed:  47   Index: 187
+Antlion B2F Inward Charm Room Steps                                           Seed:  47   Index: 225
+  Antlion B2F                                                                 Seed:  47   Index: 225
+    Step  11: 8 / SandWorm x1, Sandpede x1 (6.829s)
+  Antlion B2F Treasure Room                                                   Seed:  64   Index:   2
+    Extra Steps: 76
+  Antlion B2F                                                                 Seed:  64   Index:  78
+    Step  46: 9 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:  64   Index: 130
+Battle: Antlion                                                               Seed:  64   Index: 144
+Antlion's Nest                                                                Seed:  64   Index: 144
+Antlion B2F Outward Direct                                                    Seed:  64   Index: 159
+  Antlion B2F                                                                 Seed:  64   Index: 159
+    Extra Steps: 12
+    Step  73: 10 / Turtle x2 (7.464s)
+    Step  91: 11 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed:  64   Index: 251
+  Step   6: 12 / Turtle x1, Imp x2 (7.009s)
+  Step  15: 13 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed:  81   Index:  33
+Overworld (Kaipo)                                                             Seed:  81   Index:  33
+Kaipo Revisited                                                               Seed:  81   Index:  33
+Overworld (Kaipo)                                                             Seed:  81   Index:  33
+Overworld (Damcyan)                                                           Seed:  81   Index:  33
+Mt.Hobs-West                                                                  Seed:  81   Index:  33
+  Step  15: 14 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  81   Index:  72
+Battle: MomBomb                                                               Seed:  81   Index:  87
+Mt.Hobs Summit                                                                Seed:  81   Index:  87
+Mt.Hobs-East                                                                  Seed:  81   Index:  93
+  Extra Steps: 2
+  Step  25: 15 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  47: 16 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  81   Index: 141
+  Step  16: 17 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  54: 18 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  81   Index: 225
+  Optional Steps: 10
+  Extra Steps: 12
+Overworld (Fabul)                                                             Seed:  98   Index:  51
+Fabul Boat and Leviatan                                                       Seed:  98   Index:  58
+Overworld (Mysidia)                                                           Seed:  98   Index:  58
+Mysidia                                                                       Seed:  98   Index:  67
+Overworld (Mysidia)                                                           Seed:  98   Index:  67
+Overworld (Mt.Ordeals)                                                        Seed:  98   Index:  77
+  Extra Steps: 10
+  Step  14: 19 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  25: 20 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  71: 21 / Raven x1 (8.356s)
+  Step 104: 22 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  98   Index: 181
+Mt.Ordeals-3rd station                                                        Seed:  98   Index: 224
+  Step   6: 23 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed:  98   Index: 247
+Mt.Ordeals-3rd station                                                        Seed:  98   Index: 247
+Mt.Ordeals-7th station                                                        Seed:  98   Index: 252
+  Step  21: 24 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  37: 25 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 115   Index:  38
+  Optional Steps: 1
+  Step  11: 26 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 115   Index:  56
+Mt.Ordeals Summit                                                             Seed: 115   Index:  56
+Paladin                                                                       Seed: 115   Index:  60
+Mt.Ordeals Summit                                                             Seed: 115   Index:  60
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 115   Index:  83
+  Step   5: 27 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+  Step  31: 28 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed: 115   Index: 125
+Mt.Ordeals                                                                    Seed: 115   Index: 155
+  Step  11: 29 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 115   Index: 199
+Take Chocobo to Mysidia                                                       Seed: 115   Index: 212
+Overworld (Mysidia)                                                           Seed: 115   Index: 212
+Town of Baron Serpent Road                                                    Seed: 115   Index: 212
+Credit Warp Fight Search                                                      Seed: 115   Index: 216
+  Overworld (Baron)                                                           Seed: 115   Index: 216
+    Extra Steps: 10
+    Step   2: 30 / Imp x3 (7.174s)
+    Step  10: 31 / Imp x4 (7.223s)
+   (Step  86: 32 / Imp x3, SwordRat x1)
+   (Step 119: 33 / Eagle x3)
+   (Step 130: 34 / Eagle x3)
+   (Step 151: 35 / FloatEye x2)
+   (Step 248: 36 / Imp x3)
+   (Step 255: 37 / FloatEye x2)
+
+Encounter Time:      245.091s
+Other Time:          577.615s
+Total Time:          822.706s
+
+Base Total Time:     869.492s
+Time Saved:          46.786s
+
+Optional Steps:      13
+Extra Steps:         336
+Encounters:          31
+
+Base Encounters:     46
+Encounters Saved:    15
+
+Number of Variables: 54

--- a/data/routes/cw/014.txt
+++ b/data/routes/cw/014.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	14
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50805783
+VARS	FFFFFFFF:34 E302500:1 E302600:10 E307000:2 E307701:6
+
+Overworld (Kaipo)                                                             Seed:  14   Index:   0
+Overworld (Kaipo)                                                             Seed:  14   Index:   1
+  Step  12: 1 / SandMoth x2, Larva x2 (7.009s)
+  Step  28: 2 / SandMoth x2, Larva x2 (7.009s)
+  Step  34: 3 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  14   Index:  37
+Overworld (Kaipo)                                                             Seed:  14   Index:  37
+  Step  27: 4 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  14   Index:  69
+Recruit Tellah                                                                Seed:  14   Index: 101
+Watery Pass-South B1F                                                         Seed:  14   Index: 101
+Watery Pass-South B2F                                                         Seed:  14   Index: 121
+  Step  37: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed:  14   Index: 211
+Watery Pass-South B2F                                                         Seed:  14   Index: 215
+  Extra Steps: 2
+  Step  40: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  31   Index:   0
+  Step   7: 7 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  31   Index:  34
+  Step  18: 8 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B1F                                                         Seed:  31   Index:  55
+  Step   5: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  14: 10 / Jelly x4 (7.324s)
+  Step  37: 11 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  31   Index: 115
+Waterfalls B1F                                                                Seed:  31   Index: 124
+Waterfalls B2F                                                                Seed:  31   Index: 125
+Waterfalls Lake                                                               Seed:  31   Index: 170
+  Step  18: 12 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed:  31   Index: 207
+Waterfalls Lake                                                               Seed:  31   Index: 207
+Overworld (Kaipo)                                                             Seed:  31   Index: 208
+Overworld (Damcyan)                                                           Seed:  31   Index: 219
+  Step   1: 13 / SandWorm x1 (7.264s)
+Damcyan                                                                       Seed:  31   Index: 223
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  31   Index: 231
+Antlion B1F                                                                   Seed:  31   Index: 231
+  Step  22: 14 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed:  48   Index:  13
+  Antlion B2F                                                                 Seed:  48   Index:  13
+    Step  13: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  14: 16 / Weeper x2 (7.114s)
+    Step  34: 17 / Turtle x2 (7.487s)
+    Step  45: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  48: 19 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  48   Index:  93
+Battle: Antlion                                                               Seed:  48   Index: 107
+Antlion's Nest                                                                Seed:  48   Index: 107
+Antlion B2F Outward Direct                                                    Seed:  48   Index: 122
+  Antlion B2F                                                                 Seed:  48   Index: 122
+    Step  64: 20 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  48   Index: 202
+  Extra Steps: 6
+  Step  34: 21 / Basilisk x1, Imp x3 (6.783s)
+  Step  44: 22 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  48   Index: 246
+Overworld (Kaipo)                                                             Seed:  48   Index: 246
+Kaipo Revisited                                                               Seed:  48   Index: 246
+Overworld (Kaipo)                                                             Seed:  48   Index: 246
+Overworld (Damcyan)                                                           Seed:  48   Index: 246
+Mt.Hobs-West                                                                  Seed:  48   Index: 246
+  Step  38: 23 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed:  65   Index:  29
+  Step   1: 24 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed:  65   Index:  44
+Mt.Hobs Summit                                                                Seed:  65   Index:  44
+Mt.Hobs-East                                                                  Seed:  65   Index:  50
+  Step  18: 25 / Turtle x2 (7.432s)
+  Step  28: 26 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed:  65   Index:  96
+  Step  28: 27 / SwordRat x3, Needler x3 (7.663s)
+  Step  82: 28 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed:  65   Index: 180
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  65   Index: 250
+  Step   7: 29 / GrayBomb x2, Bomb x2 (8.759s)
+Fabul Boat and Leviatan                                                       Seed:  82   Index:   1
+Overworld (Mysidia)                                                           Seed:  82   Index:   1
+  Step   7: 30 / Raven x1 (8.246s)
+  Step   9: 31 / Needler x2, SwordRat x2 (8.011s)
+Mysidia                                                                       Seed:  82   Index:  10
+Overworld (Mysidia)                                                           Seed:  82   Index:  10
+Overworld (Mt.Ordeals)                                                        Seed:  82   Index:  20
+  Step  28: 32 / Raven x1, Cocktric x3 (9.100s)
+Mt.Ordeals                                                                    Seed:  82   Index: 114
+  Step   4: 33 / Soul x2, Red Bone x2 (9.583s)
+  Step  26: 34 / Soul x2, Red Bone x2 (9.583s)
+  Step  43: 35 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  82   Index: 157
+Recruit Tellah                                                                Seed:  82   Index: 180
+Mt.Ordeals-3rd station                                                        Seed:  82   Index: 180
+Mt.Ordeals-7th station                                                        Seed:  82   Index: 185
+  Step  10: 36 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed:  82   Index: 227
+  Optional Steps: 0
+  Step   2: 37 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:  82   Index: 244
+Mt.Ordeals Summit                                                             Seed:  82   Index: 244
+Paladin                                                                       Seed:  82   Index: 248
+Mt.Ordeals Summit                                                             Seed:  82   Index: 248
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed:  99   Index:  14
+  Step  25: 38 / Ghoul x2, Soul x2 (8.971s)
+  Step  36: 39 / Revenant x1, Ghoul x3 (8.489s)
+  Step  37: 40 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  99   Index:  56
+Mt.Ordeals                                                                    Seed:  99   Index:  86
+  Step   5: 41 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+  Step  16: 42 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed:  99   Index: 130
+Take Chocobo to Mysidia                                                       Seed:  99   Index: 143
+Overworld (Mysidia)                                                           Seed:  99   Index: 143
+Town of Baron Serpent Road                                                    Seed:  99   Index: 143
+Credit Warp Fight Search                                                      Seed:  99   Index: 147
+  Overworld (Baron)                                                           Seed:  99   Index: 147
+    Extra Steps: 34
+    Step   1: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  34: 44 / Imp x4 (7.223s)
+   (Step  70: 45 / Imp x3, SwordRat x1)
+   (Step 126: 46 / Imp x3, SwordRat x1)
+   (Step 158: 47 / Imp x3, SwordRat x1)
+   (Step 168: 48 / Imp x3, SwordRat x1)
+   (Step 197: 49 / Imp x4)
+
+Encounter Time:      344.229s
+Other Time:          501.141s
+Total Time:          845.371s
+
+Base Total Time:     857.368s
+Time Saved:          11.997s
+
+Optional Steps:      11
+Extra Steps:         42
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/015.txt
+++ b/data/routes/cw/015.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	15
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	51261541
+VARS	FFFFFFFF:12 C307801:1 E302500:133 E302600:66 E305400:134 E307000:10 E307400:50 E307701:2 E307B01:26 E308000:4 E308700:1 E308702:1 E309700:30
+
+Overworld (Kaipo)                                                             Seed:  15   Index:   0
+Overworld (Kaipo)                                                             Seed:  15   Index:   1
+  Step  12: 1 / SandMoth x2, Larva x2 (7.009s)
+  Step  28: 2 / SandMoth x2, Larva x2 (7.009s)
+  Step  34: 3 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  15   Index:  37
+Overworld (Kaipo)                                                             Seed:  15   Index:  37
+  Step  27: 4 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  15   Index:  69
+Recruit Tellah                                                                Seed:  15   Index: 101
+Watery Pass-South B1F                                                         Seed:  15   Index: 101
+Watery Pass-South B2F                                                         Seed:  15   Index: 121
+  Step  37: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed:  15   Index: 211
+  Extra Steps: 134
+Watery Pass-South B2F                                                         Seed:  32   Index:  93
+  Extra Steps: 10
+  Step  48: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  32   Index: 142
+Watery Pass-North B2F                                                         Seed:  32   Index: 176
+  Step  12: 7 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed:  32   Index: 197
+  Step  23: 8 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed:  49   Index:   1
+Waterfalls B1F                                                                Seed:  49   Index:  10
+  Extra Steps: 50
+Waterfalls B2F                                                                Seed:  49   Index:  61
+Waterfalls Lake                                                               Seed:  49   Index: 106
+Battle: Octomamm                                                              Seed:  49   Index: 143
+Waterfalls Lake                                                               Seed:  49   Index: 143
+Overworld (Kaipo)                                                             Seed:  49   Index: 144
+Overworld (Damcyan)                                                           Seed:  49   Index: 155
+Damcyan                                                                       Seed:  49   Index: 159
+  Optional Steps: 1
+  Extra Steps: 132
+Overworld (Damcyan)                                                           Seed:  66   Index:  43
+Antlion B1F                                                                   Seed:  66   Index:  43
+  Step  25: 9 / Turtle x2 (7.487s)
+  Step  35: 10 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  66   Index:  81
+  Antlion B2F                                                                 Seed:  66   Index:  81
+    Step  43: 11 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed:  66   Index: 161
+Battle: Antlion                                                               Seed:  66   Index: 175
+Antlion's Nest                                                                Seed:  66   Index: 175
+  Step   3: 12 / Turtle x2 (7.464s)
+Antlion B2F Outward Charm Room Steps                                          Seed:  66   Index: 190
+  Antlion B2F                                                                 Seed:  66   Index: 190
+  Antlion B2F Treasure Room                                                   Seed:  66   Index: 241
+    Extra Steps: 26
+  Antlion B2F                                                                 Seed:  83   Index:  11
+Antlion B1F                                                                   Seed:  83   Index:  45
+  Extra Steps: 2
+  Step  40: 13 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed:  83   Index:  85
+Overworld (Kaipo)                                                             Seed:  83   Index:  85
+Kaipo Revisited                                                               Seed:  83   Index:  85
+Overworld (Kaipo)                                                             Seed:  83   Index:  85
+Overworld (Damcyan)                                                           Seed:  83   Index:  85
+Mt.Hobs-West                                                                  Seed:  83   Index:  85
+  Step  33: 14 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  83   Index: 124
+Battle: MomBomb                                                               Seed:  83   Index: 139
+Mt.Hobs Summit                                                                Seed:  83   Index: 139
+  Step   1: 15 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed:  83   Index: 145
+  Extra Steps: 4
+  Step  12: 16 / Turtle x2 (7.432s)
+  Step  50: 17 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed:  83   Index: 195
+  Step  34: 18 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 100   Index:  23
+  Optional Steps: 10
+  Extra Steps: 56
+Overworld (Fabul)                                                             Seed: 100   Index: 149
+Fabul Boat and Leviatan                                                       Seed: 100   Index: 156
+Overworld (Mysidia)                                                           Seed: 100   Index: 156
+Mysidia                                                                       Seed: 100   Index: 165
+Overworld (Mysidia)                                                           Seed: 100   Index: 165
+Overworld (Mt.Ordeals)                                                        Seed: 100   Index: 175
+  Step   6: 19 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  42: 20 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  55: 21 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 117   Index:  13
+  Step   4: 22 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  36: 23 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 117   Index:  56
+  Step   3: 24 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 117   Index:  79
+Mt.Ordeals-3rd station                                                        Seed: 117   Index:  79
+Mt.Ordeals-7th station                                                        Seed: 117   Index:  84
+  Step   4: 25 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 117   Index: 126
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 117   Index: 144
+Mt.Ordeals Summit                                                             Seed: 117   Index: 144
+Paladin                                                                       Seed: 117   Index: 148
+Mt.Ordeals Summit                                                             Seed: 117   Index: 148
+  Optional Steps: 1
+  Step  18: 26 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  21: 27 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-7th station                                                        Seed: 117   Index: 171
+Mt.Ordeals-3rd station                                                        Seed: 117   Index: 213
+  Step   5: 28 / Lilith x1, Red Bone x2 (8.437s)
+  Step  13: 29 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 117   Index: 243
+Overworld (Mt.Ordeals)                                                        Seed: 134   Index:  31
+Take Chocobo to Mysidia                                                       Seed: 134   Index:  44
+Overworld (Mysidia)                                                           Seed: 134   Index:  44
+Town of Baron Serpent Road                                                    Seed: 134   Index:  44
+  Extra Steps: 30
+Credit Warp Fight Search                                                      Seed: 134   Index:  78
+  Overworld (Baron)                                                           Seed: 134   Index:  78
+    Extra Steps: 12
+    Step   1: 30 / Imp x3 (7.174s)
+    Step  12: 31 / Imp x4 (7.223s)
+   (Step  33: 32 / Imp x3, SwordRat x1)
+   (Step  90: 33 / Eagle x3)
+   (Step 159: 34 / Eagle x3)
+   (Step 160: 35 / FloatEye x2)
+   (Step 222: 36 / Imp x3)
+   (Step 223: 37 / FloatEye x2)
+
+Encounter Time:      242.859s
+Other Time:          610.095s
+Total Time:          852.954s
+
+Base Total Time:     889.802s
+Time Saved:          36.847s
+
+Optional Steps:      13
+Extra Steps:         456
+Encounters:          31
+
+Base Encounters:     46
+Encounters Saved:    15
+
+Number of Variables: 54

--- a/data/routes/cw/016.txt
+++ b/data/routes/cw/016.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	16
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	51382241
+VARS	FFFFFFFF:12 C307801:1 E302500:133 E302600:66 E305400:48 E307400:146 E307701:2 E307900:4 E307B01:22 E308000:4 E308700:1 E308702:1 E309700:30
+
+Overworld (Kaipo)                                                             Seed:  16   Index:   0
+Overworld (Kaipo)                                                             Seed:  16   Index:   1
+  Step   1: 1 / SandMoth x2, Larva x2 (7.009s)
+  Step  12: 2 / SandMoth x2, Larva x2 (7.009s)
+  Step  28: 3 / SandMoth x2, Larva x2 (7.009s)
+  Step  34: 4 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  16   Index:  37
+Overworld (Kaipo)                                                             Seed:  16   Index:  37
+  Step  27: 5 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  16   Index:  69
+Recruit Tellah                                                                Seed:  16   Index: 101
+Watery Pass-South B1F                                                         Seed:  16   Index: 101
+Watery Pass-South B2F                                                         Seed:  16   Index: 121
+  Step  37: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed:  16   Index: 211
+  Extra Steps: 48
+Watery Pass-South B2F                                                         Seed:  33   Index:   7
+Watery Pass-South B3F                                                         Seed:  33   Index:  46
+  Step  23: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed:  33   Index:  80
+  Step  12: 8 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed:  33   Index: 101
+  Step  40: 9 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  33   Index: 161
+Waterfalls B1F                                                                Seed:  33   Index: 170
+  Extra Steps: 146
+Waterfalls B2F                                                                Seed:  50   Index:  61
+Waterfalls Lake                                                               Seed:  50   Index: 106
+Battle: Octomamm                                                              Seed:  50   Index: 143
+Waterfalls Lake                                                               Seed:  50   Index: 143
+Overworld (Kaipo)                                                             Seed:  50   Index: 144
+Overworld (Damcyan)                                                           Seed:  50   Index: 155
+Damcyan                                                                       Seed:  50   Index: 159
+  Optional Steps: 1
+  Extra Steps: 132
+Overworld (Damcyan)                                                           Seed:  67   Index:  43
+Antlion B1F                                                                   Seed:  67   Index:  43
+  Step  25: 10 / Turtle x1, Imp x2 (7.044s)
+  Step  35: 11 / Turtle x2 (7.487s)
+Antlion B2F Inward Direct                                                     Seed:  67   Index:  81
+  Antlion B2F                                                                 Seed:  67   Index:  81
+    Step  72: 12 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  67   Index: 161
+  Extra Steps: 4
+  Step  17: 13 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed:  67   Index: 179
+Antlion's Nest                                                                Seed:  67   Index: 179
+Antlion B2F Outward Charm Room Steps                                          Seed:  67   Index: 194
+  Antlion B2F                                                                 Seed:  67   Index: 194
+  Antlion B2F Treasure Room                                                   Seed:  67   Index: 245
+    Extra Steps: 22
+  Antlion B2F                                                                 Seed:  84   Index:  11
+Antlion B1F                                                                   Seed:  84   Index:  45
+  Extra Steps: 2
+  Step  40: 14 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  84   Index:  85
+Overworld (Kaipo)                                                             Seed:  84   Index:  85
+Kaipo Revisited                                                               Seed:  84   Index:  85
+Overworld (Kaipo)                                                             Seed:  84   Index:  85
+Overworld (Damcyan)                                                           Seed:  84   Index:  85
+Mt.Hobs-West                                                                  Seed:  84   Index:  85
+  Step  32: 15 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed:  84   Index: 124
+Battle: MomBomb                                                               Seed:  84   Index: 139
+Mt.Hobs Summit                                                                Seed:  84   Index: 139
+  Step   1: 16 / Spirit x2, Skelton x2 (8.237s)
+Mt.Hobs-East                                                                  Seed:  84   Index: 145
+  Extra Steps: 4
+  Step  12: 17 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  50: 18 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed:  84   Index: 195
+  Step  34: 19 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 101   Index:  23
+  Optional Steps: 10
+  Extra Steps: 56
+Overworld (Fabul)                                                             Seed: 101   Index: 149
+Fabul Boat and Leviatan                                                       Seed: 101   Index: 156
+Overworld (Mysidia)                                                           Seed: 101   Index: 156
+Mysidia                                                                       Seed: 101   Index: 165
+Overworld (Mysidia)                                                           Seed: 101   Index: 165
+Overworld (Mt.Ordeals)                                                        Seed: 101   Index: 175
+  Step   6: 20 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  42: 21 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 118   Index:  13
+  Step   4: 22 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  36: 23 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 118   Index:  56
+  Step   3: 24 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 118   Index:  79
+Mt.Ordeals-3rd station                                                        Seed: 118   Index:  79
+Mt.Ordeals-7th station                                                        Seed: 118   Index:  84
+  Step   4: 25 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 118   Index: 126
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 118   Index: 144
+Mt.Ordeals Summit                                                             Seed: 118   Index: 144
+Paladin                                                                       Seed: 118   Index: 148
+Mt.Ordeals Summit                                                             Seed: 118   Index: 148
+  Optional Steps: 1
+  Step  18: 26 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  21: 27 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-7th station                                                        Seed: 118   Index: 171
+  Step   6: 28 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-3rd station                                                        Seed: 118   Index: 213
+  Step  13: 29 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 118   Index: 243
+Overworld (Mt.Ordeals)                                                        Seed: 135   Index:  31
+Take Chocobo to Mysidia                                                       Seed: 135   Index:  44
+Overworld (Mysidia)                                                           Seed: 135   Index:  44
+Town of Baron Serpent Road                                                    Seed: 135   Index:  44
+  Extra Steps: 30
+Credit Warp Fight Search                                                      Seed: 135   Index:  78
+  Overworld (Baron)                                                           Seed: 135   Index:  78
+    Extra Steps: 12
+    Step   1: 30 / Imp x3 (7.174s)
+    Step  12: 31 / Imp x4 (7.223s)
+   (Step  33: 32 / Imp x6)
+   (Step  90: 33 / Eagle x3)
+   (Step 120: 34 / Eagle x3)
+   (Step 159: 35 / FloatEye x2)
+   (Step 160: 36 / Imp x3)
+   (Step 203: 37 / FloatEye x2)
+   (Step 222: 38 / Imp x3)
+   (Step 223: 39 / FloatEye x1, Eagle x2)
+
+Encounter Time:      244.867s
+Other Time:          610.095s
+Total Time:          854.963s
+
+Base Total Time:     901.104s
+Time Saved:          46.141s
+
+Optional Steps:      13
+Extra Steps:         456
+Encounters:          31
+
+Base Encounters:     48
+Encounters Saved:    17
+
+Number of Variables: 54

--- a/data/routes/cw/017.txt
+++ b/data/routes/cw/017.txt
@@ -1,0 +1,158 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	17
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50825069
+VARS	FFFFFFFF:20 E000202:16 E302500:1 E302600:10 E305400:8 E307000:2 E307701:36 E308502:6 E308700:1 E308702:1 E309700:6
+
+Overworld (Kaipo)                                                             Seed:  17   Index:   0
+Overworld (Kaipo)                                                             Seed:  17   Index:   1
+  Step   1: 1 / SandMoth x2, Larva x2 (7.009s)
+  Step  12: 2 / SandMoth x2, Larva x2 (7.009s)
+  Step  28: 3 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  17   Index:  37
+Overworld (Kaipo)                                                             Seed:  17   Index:  37
+  Step  27: 4 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  17   Index:  69
+  Step  24: 5 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed:  17   Index: 101
+Watery Pass-South B1F                                                         Seed:  17   Index: 101
+Watery Pass-South B2F                                                         Seed:  17   Index: 121
+  Step  37: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed:  17   Index: 211
+  Extra Steps: 8
+Watery Pass-South B2F                                                         Seed:  17   Index: 223
+  Extra Steps: 2
+  Step  40: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  34   Index:   8
+Watery Pass-North B2F                                                         Seed:  34   Index:  42
+Watery Pass-North B1F                                                         Seed:  34   Index:  63
+  Step   6: 8 / Zombie x4 (7.148s)
+  Step  29: 9 / Aligator x1, Pike x2 (7.368s)
+  Step  58: 10 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed:  34   Index: 123
+Waterfalls B1F                                                                Seed:  34   Index: 132
+Waterfalls B2F                                                                Seed:  34   Index: 133
+  Step   8: 11 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed:  34   Index: 178
+  Step  10: 12 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed:  34   Index: 215
+Waterfalls Lake                                                               Seed:  34   Index: 215
+Overworld (Kaipo)                                                             Seed:  34   Index: 216
+  Step   4: 13 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed:  34   Index: 227
+Damcyan                                                                       Seed:  34   Index: 231
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  34   Index: 239
+Antlion B1F                                                                   Seed:  34   Index: 239
+  Step   2: 14 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed:  51   Index:  21
+  Antlion B2F                                                                 Seed:  51   Index:  21
+    Step   6: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  33: 16 / SandWorm x2 (6.841s)
+    Step  37: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  40: 18 / Basilisk x1, Turtle x1 (7.110s)
+    Step  68: 19 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  51   Index: 101
+Battle: Antlion                                                               Seed:  51   Index: 115
+Antlion's Nest                                                                Seed:  51   Index: 115
+Antlion B2F Outward Direct                                                    Seed:  51   Index: 130
+  Antlion B2F                                                                 Seed:  51   Index: 130
+    Step  37: 20 / Turtle x2 (7.464s)
+    Step  56: 21 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed:  51   Index: 210
+  Extra Steps: 36
+  Step  36: 22 / Turtle x1, Imp x2 (7.009s)
+  Step  74: 23 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  68   Index:  28
+Overworld (Kaipo)                                                             Seed:  68   Index:  28
+  Extra Steps: 16
+  Step   2: 24 / Imp x4 (7.024s)
+  Step  15: 25 / SandMoth x2, Larva x2 (7.135s)
+Kaipo Revisited                                                               Seed:  68   Index:  44
+Overworld (Kaipo)                                                             Seed:  68   Index:  44
+Overworld (Damcyan)                                                           Seed:  68   Index:  44
+Mt.Hobs-West                                                                  Seed:  68   Index:  44
+  Step  34: 26 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed:  68   Index:  83
+Battle: MomBomb                                                               Seed:  68   Index:  98
+Mt.Hobs Summit                                                                Seed:  68   Index:  98
+Mt.Hobs-East                                                                  Seed:  68   Index: 104
+  Step  15: 27 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  68   Index: 150
+  Step   3: 28 / SwordRat x3, Needler x3 (7.663s)
+  Step  28: 29 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed:  68   Index: 234
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  85   Index:  48
+Fabul Boat and Leviatan                                                       Seed:  85   Index:  55
+Overworld (Mysidia)                                                           Seed:  85   Index:  55
+Mysidia                                                                       Seed:  85   Index:  64
+Overworld (Mysidia)                                                           Seed:  85   Index:  64
+Overworld (Mt.Ordeals)                                                        Seed:  85   Index:  74
+  Step   2: 30 / Raven x1 (8.356s)
+  Step  11: 31 / Needler x2, SwordRat x2 (8.097s)
+  Step  43: 32 / Raven x1, Cocktric x3 (9.100s)
+  Step  44: 33 / Needler x2, SwordRat x2 (8.097s)
+  Step  66: 34 / Raven x1 (8.356s)
+  Step  83: 35 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  85   Index: 168
+Mt.Ordeals-3rd station                                                        Seed:  85   Index: 211
+  Step  18: 36 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed:  85   Index: 234
+Mt.Ordeals-3rd station                                                        Seed:  85   Index: 234
+Mt.Ordeals-7th station                                                        Seed:  85   Index: 239
+Mt.Ordeals Summit                                                             Seed: 102   Index:  25
+  Optional Steps: 1
+  Step  14: 37 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed: 102   Index:  43
+Mt.Ordeals Summit                                                             Seed: 102   Index:  43
+Paladin                                                                       Seed: 102   Index:  47
+Mt.Ordeals Summit                                                             Seed: 102   Index:  47
+  Optional Steps: 1
+  Step   4: 38 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed: 102   Index:  70
+  Step  21: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  32: 40 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 102   Index: 112
+  Extra Steps: 6
+  Step   3: 41 / Zombie x2, Ghoul x2 (7.552s)
+  Step  35: 42 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 102   Index: 148
+Overworld (Mt.Ordeals)                                                        Seed: 102   Index: 192
+Take Chocobo to Mysidia                                                       Seed: 102   Index: 205
+Overworld (Mysidia)                                                           Seed: 102   Index: 205
+Town of Baron Serpent Road                                                    Seed: 102   Index: 205
+  Extra Steps: 6
+Credit Warp Fight Search                                                      Seed: 102   Index: 215
+  Overworld (Baron)                                                           Seed: 102   Index: 215
+    Extra Steps: 20
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  20: 44 / Imp x4 (7.223s)
+   (Step  58: 45 / Imp x3, SwordRat x1)
+   (Step  90: 46 / Imp x3, SwordRat x1)
+   (Step 100: 47 / Imp x3, SwordRat x1)
+   (Step 129: 48 / Imp x3, SwordRat x1)
+   (Step 210: 49 / Imp x4)
+   (Step 218: 50 / Eagle x3)
+   (Step 250: 51 / Eagle x3)
+
+Encounter Time:      334.434s
+Other Time:          511.258s
+Total Time:          845.692s
+
+Base Total Time:     886.381s
+Time Saved:          40.690s
+
+Optional Steps:      13
+Extra Steps:         94
+Encounters:          44
+
+Base Encounters:     46
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/018.txt
+++ b/data/routes/cw/018.txt
@@ -1,0 +1,158 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	18
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50652397
+VARS	FFFFFFFF:20 E000201:4 E000202:16 E000301:8 E302500:1 E302600:10 E307701:34 E308502:6 E308700:1 E308702:1 E309700:6
+
+Overworld (Kaipo)                                                             Seed:  18   Index:   0
+Overworld (Kaipo)                                                             Seed:  18   Index:   1
+  Step   1: 1 / Sand Man x4 (7.172s)
+  Step  28: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  18   Index:  37
+Overworld (Kaipo)                                                             Seed:  18   Index:  37
+  Step  27: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:  18   Index:  69
+  Step  24: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  18   Index: 101
+Watery Pass-South B1F                                                         Seed:  18   Index: 101
+Watery Pass-South B2F                                                         Seed:  18   Index: 121
+  Step  37: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed:  18   Index: 211
+Watery Pass-South B2F                                                         Seed:  18   Index: 215
+  Step   7: 6 / CaveToad x3 (7.014s)
+  Step   9: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  18   Index: 254
+  Step   9: 8 / Pike x3 (7.152s)
+  Step  33: 9 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed:  35   Index:  32
+Watery Pass-North B1F                                                         Seed:  35   Index:  53
+  Step  16: 10 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed:  35   Index: 113
+  Step   8: 11 / SandMoth x2, Larva x2 (7.163s)
+Waterfalls B1F                                                                Seed:  35   Index: 122
+Waterfalls B2F                                                                Seed:  35   Index: 123
+  Step  18: 12 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed:  35   Index: 168
+  Step  20: 13 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed:  35   Index: 205
+Waterfalls Lake                                                               Seed:  35   Index: 205
+Overworld (Kaipo)                                                             Seed:  35   Index: 206
+  Extra Steps: 4
+  Step  14: 14 / SandMoth x2, Larva x2 (7.188s)
+Overworld (Damcyan)                                                           Seed:  35   Index: 221
+Damcyan                                                                       Seed:  35   Index: 225
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  35   Index: 233
+  Extra Steps: 8
+  Step   8: 15 / SandWorm x1, Sandpede x1 (7.162s)
+Antlion B1F                                                                   Seed:  35   Index: 241
+Antlion B2F Inward Direct                                                     Seed:  52   Index:  23
+  Antlion B2F                                                                 Seed:  52   Index:  23
+    Step   4: 16 / SandWorm x2 (6.841s)
+    Step  31: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  38: 18 / Basilisk x1, Turtle x1 (7.110s)
+    Step  66: 19 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  52   Index: 103
+Battle: Antlion                                                               Seed:  52   Index: 117
+Antlion's Nest                                                                Seed:  52   Index: 117
+Antlion B2F Outward Direct                                                    Seed:  52   Index: 132
+  Antlion B2F                                                                 Seed:  52   Index: 132
+    Step  11: 20 / Turtle x2 (7.464s)
+    Step  35: 21 / Basilisk x1, Turtle x1 (7.124s)
+    Step  54: 22 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  52   Index: 212
+  Extra Steps: 34
+  Step  34: 23 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  72: 24 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed:  69   Index:  28
+Overworld (Kaipo)                                                             Seed:  69   Index:  28
+  Extra Steps: 16
+  Step   2: 25 / SandMoth x2, Larva x2 (7.135s)
+  Step  15: 26 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed:  69   Index:  44
+Overworld (Kaipo)                                                             Seed:  69   Index:  44
+Overworld (Damcyan)                                                           Seed:  69   Index:  44
+Mt.Hobs-West                                                                  Seed:  69   Index:  44
+Mt.Hobs Summit                                                                Seed:  69   Index:  83
+Battle: MomBomb                                                               Seed:  69   Index:  98
+Mt.Hobs Summit                                                                Seed:  69   Index:  98
+Mt.Hobs-East                                                                  Seed:  69   Index: 104
+  Step  15: 27 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  69   Index: 150
+  Step   3: 28 / SwordRat x3, Needler x3 (7.663s)
+  Step  28: 29 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  81: 30 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  69   Index: 234
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  86   Index:  48
+Fabul Boat and Leviatan                                                       Seed:  86   Index:  55
+Overworld (Mysidia)                                                           Seed:  86   Index:  55
+Mysidia                                                                       Seed:  86   Index:  64
+Overworld (Mysidia)                                                           Seed:  86   Index:  64
+Overworld (Mt.Ordeals)                                                        Seed:  86   Index:  74
+  Step   2: 31 / Needler x2, SwordRat x2 (8.097s)
+  Step  11: 32 / Raven x1 (8.356s)
+  Step  43: 33 / Needler x2, SwordRat x2 (8.097s)
+  Step  66: 34 / Raven x1 (8.356s)
+  Step  83: 35 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  86   Index: 168
+Mt.Ordeals-3rd station                                                        Seed:  86   Index: 211
+  Step  18: 36 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed:  86   Index: 234
+Mt.Ordeals-3rd station                                                        Seed:  86   Index: 234
+Mt.Ordeals-7th station                                                        Seed:  86   Index: 239
+  Step  29: 37 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 103   Index:  25
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 103   Index:  43
+Mt.Ordeals Summit                                                             Seed: 103   Index:  43
+Paladin                                                                       Seed: 103   Index:  47
+Mt.Ordeals Summit                                                             Seed: 103   Index:  47
+  Optional Steps: 1
+  Step   4: 38 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed: 103   Index:  70
+  Step  21: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  32: 40 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 103   Index: 112
+  Extra Steps: 6
+  Step   3: 41 / Zombie x2, Ghoul x2 (7.552s)
+  Step  35: 42 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 103   Index: 148
+Overworld (Mt.Ordeals)                                                        Seed: 103   Index: 192
+Take Chocobo to Mysidia                                                       Seed: 103   Index: 205
+Overworld (Mysidia)                                                           Seed: 103   Index: 205
+Town of Baron Serpent Road                                                    Seed: 103   Index: 205
+  Extra Steps: 6
+Credit Warp Fight Search                                                      Seed: 103   Index: 215
+  Overworld (Baron)                                                           Seed: 103   Index: 215
+    Extra Steps: 20
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  20: 44 / Imp x4 (7.223s)
+   (Step  64: 45 / Imp x3, SwordRat x1)
+   (Step  90: 46 / Imp x3, SwordRat x1)
+   (Step 100: 47 / Imp x3, SwordRat x1)
+   (Step 129: 48 / Imp x3, SwordRat x1)
+   (Step 210: 49 / Imp x4)
+   (Step 218: 50 / Eagle x3)
+   (Step 250: 51 / Eagle x3)
+
+Encounter Time:      331.561s
+Other Time:          511.258s
+Total Time:          842.819s
+
+Base Total Time:     878.737s
+Time Saved:          35.918s
+
+Optional Steps:      13
+Extra Steps:         94
+Encounters:          44
+
+Base Encounters:     45
+Encounters Saved:    1
+
+Number of Variables: 54

--- a/data/routes/cw/019.txt
+++ b/data/routes/cw/019.txt
@@ -1,0 +1,159 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	19
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50804745
+VARS	FFFFFFFF:20 E000200:20 E000201:4 E000202:8 E000301:30 E302500:1 E302600:10 E308400:2 E308502:4 E308700:1 E308702:1 E309700:6
+
+Overworld (Kaipo)                                                             Seed:  19   Index:   0
+Overworld (Kaipo)                                                             Seed:  19   Index:   1
+  Step   1: 1 / Sand Man x4 (7.172s)
+  Step  28: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  19   Index:  37
+Overworld (Kaipo)                                                             Seed:  19   Index:  37
+  Step  27: 3 / SandMoth x2, Larva x2 (7.049s)
+  Step  30: 4 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  19   Index:  69
+  Step  24: 5 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed:  19   Index: 101
+Watery Pass-South B1F                                                         Seed:  19   Index: 101
+Watery Pass-South B2F                                                         Seed:  19   Index: 121
+  Step  37: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  19   Index: 211
+Watery Pass-South B2F                                                         Seed:  19   Index: 215
+  Step   7: 7 / CaveToad x3 (7.014s)
+  Step   9: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  19   Index: 254
+  Step  33: 9 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed:  36   Index:  32
+Watery Pass-North B1F                                                         Seed:  36   Index:  53
+Overworld (Kaipo)                                                             Seed:  36   Index: 113
+  Extra Steps: 20
+  Step   8: 10 / Sandpede x1, Sand Man x2 (7.188s)
+  Step  10: 11 / SandMoth x2, Larva x2 (7.163s)
+  Step  28: 12 / Imp x4 (7.049s)
+Waterfalls B1F                                                                Seed:  36   Index: 142
+Waterfalls B2F                                                                Seed:  36   Index: 143
+  Step  45: 13 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed:  36   Index: 188
+  Step  32: 14 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed:  36   Index: 225
+Waterfalls Lake                                                               Seed:  36   Index: 225
+Overworld (Kaipo)                                                             Seed:  36   Index: 226
+  Extra Steps: 4
+  Step  15: 15 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed:  36   Index: 241
+Damcyan                                                                       Seed:  36   Index: 245
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  36   Index: 253
+  Extra Steps: 30
+  Step  18: 16 / Imp x8 (7.394s)
+  Step  30: 17 / SandWorm x1, Sandpede x1 (7.162s)
+Antlion B1F                                                                   Seed:  53   Index:  27
+  Step  27: 18 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed:  53   Index:  65
+  Antlion B2F                                                                 Seed:  53   Index:  65
+    Step  24: 19 / Turtle x2 (7.487s)
+    Step  78: 20 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  53   Index: 145
+Battle: Antlion                                                               Seed:  53   Index: 159
+Antlion's Nest                                                                Seed:  53   Index: 159
+  Step   8: 21 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed:  53   Index: 174
+  Antlion B2F                                                                 Seed:  53   Index: 174
+    Step  12: 22 / Turtle x2 (7.464s)
+    Step  72: 23 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  53   Index: 254
+  Step  32: 24 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed:  70   Index:  36
+Overworld (Kaipo)                                                             Seed:  70   Index:  36
+  Extra Steps: 8
+  Step   7: 25 / SandWorm x1 (7.203s)
+Kaipo Revisited                                                               Seed:  70   Index:  44
+Overworld (Kaipo)                                                             Seed:  70   Index:  44
+Overworld (Damcyan)                                                           Seed:  70   Index:  44
+Mt.Hobs-West                                                                  Seed:  70   Index:  44
+  Step  28: 26 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed:  70   Index:  83
+Battle: MomBomb                                                               Seed:  70   Index:  98
+Mt.Hobs Summit                                                                Seed:  70   Index:  98
+Mt.Hobs-East                                                                  Seed:  70   Index: 104
+  Step  15: 27 / GrayBomb x2, Bomb x4 (9.348s)
+Overworld (Fabul)                                                             Seed:  70   Index: 150
+  Step   3: 28 / SwordRat x3, Needler x3 (7.663s)
+  Step  28: 29 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  81: 30 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  70   Index: 234
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  87   Index:  48
+Fabul Boat and Leviatan                                                       Seed:  87   Index:  55
+Overworld (Mysidia)                                                           Seed:  87   Index:  55
+Mysidia                                                                       Seed:  87   Index:  64
+Overworld (Mysidia)                                                           Seed:  87   Index:  64
+Overworld (Mt.Ordeals)                                                        Seed:  87   Index:  74
+  Step   2: 31 / Needler x2, SwordRat x2 (8.097s)
+  Step  11: 32 / Raven x1 (8.356s)
+  Step  43: 33 / Needler x2, SwordRat x2 (8.097s)
+  Step  66: 34 / Raven x1 (8.356s)
+  Step  83: 35 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  87   Index: 168
+  Extra Steps: 2
+  Step  45: 36 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed:  87   Index: 213
+Recruit Tellah                                                                Seed:  87   Index: 236
+Mt.Ordeals-3rd station                                                        Seed:  87   Index: 236
+Mt.Ordeals-7th station                                                        Seed:  87   Index: 241
+  Step  27: 37 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 104   Index:  27
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 104   Index:  45
+Mt.Ordeals Summit                                                             Seed: 104   Index:  45
+Paladin                                                                       Seed: 104   Index:  49
+Mt.Ordeals Summit                                                             Seed: 104   Index:  49
+  Optional Steps: 1
+  Step   2: 38 / Ghoul x2, Soul x2 (8.971s)
+  Step  13: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 104   Index:  72
+  Step  19: 40 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 104   Index: 114
+  Extra Steps: 4
+  Step   1: 41 / Zombie x2, Ghoul x2 (7.552s)
+  Step  33: 42 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 104   Index: 148
+Overworld (Mt.Ordeals)                                                        Seed: 104   Index: 192
+Take Chocobo to Mysidia                                                       Seed: 104   Index: 205
+Overworld (Mysidia)                                                           Seed: 104   Index: 205
+Town of Baron Serpent Road                                                    Seed: 104   Index: 205
+  Extra Steps: 6
+Credit Warp Fight Search                                                      Seed: 104   Index: 215
+  Overworld (Baron)                                                           Seed: 104   Index: 215
+    Extra Steps: 20
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  20: 44 / Imp x4 (7.223s)
+   (Step  64: 45 / Imp x3, SwordRat x1)
+   (Step 100: 46 / Imp x3, SwordRat x1)
+   (Step 129: 47 / Imp x3, SwordRat x1)
+   (Step 196: 48 / Imp x3, SwordRat x1)
+   (Step 210: 49 / Imp x4)
+   (Step 218: 50 / Eagle x3)
+   (Step 250: 51 / Eagle x3)
+
+Encounter Time:      334.096s
+Other Time:          511.258s
+Total Time:          845.354s
+
+Base Total Time:     872.188s
+Time Saved:          26.835s
+
+Optional Steps:      13
+Extra Steps:         94
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/020.txt
+++ b/data/routes/cw/020.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	20
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49664280
+VARS	FFFFFFFF:12 E000200:2 E000400:4 E302500:1
+
+Overworld (Kaipo)                                                             Seed:  20   Index:   0
+Overworld (Kaipo)                                                             Seed:  20   Index:   1
+  Step   1: 1 / Sand Man x4 (7.172s)
+  Step  28: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  20   Index:  37
+Overworld (Kaipo)                                                             Seed:  20   Index:  37
+  Step  30: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:  20   Index:  69
+  Step  24: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  20   Index: 101
+Watery Pass-South B1F                                                         Seed:  20   Index: 101
+Watery Pass-South B2F                                                         Seed:  20   Index: 121
+Watery Pass-South B2F Save Room                                               Seed:  20   Index: 211
+Watery Pass-South B2F                                                         Seed:  20   Index: 215
+  Step   7: 5 / CaveToad x3 (7.014s)
+  Step   9: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  36: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  20   Index: 254
+  Step  33: 8 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed:  37   Index:  32
+Watery Pass-North B1F                                                         Seed:  37   Index:  53
+  Step  41: 9 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  37   Index: 113
+  Extra Steps: 2
+  Step   8: 10 / Sandpede x1, Sand Man x2 (7.188s)
+  Step  10: 11 / SandMoth x2, Larva x2 (7.163s)
+Waterfalls B1F                                                                Seed:  37   Index: 124
+Waterfalls B2F                                                                Seed:  37   Index: 125
+  Step  16: 12 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed:  37   Index: 170
+  Step  18: 13 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed:  37   Index: 207
+Waterfalls Lake                                                               Seed:  37   Index: 207
+Overworld (Kaipo)                                                             Seed:  37   Index: 208
+Overworld (Damcyan)                                                           Seed:  37   Index: 219
+  Step   1: 14 / SandWorm x1 (7.264s)
+Damcyan                                                                       Seed:  37   Index: 223
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  37   Index: 231
+Antlion B1F                                                                   Seed:  37   Index: 231
+  Step  10: 15 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed:  54   Index:  13
+  Antlion B2F                                                                 Seed:  54   Index:  13
+    Step   2: 16 / SandWorm x2 (6.841s)
+    Step  14: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  40: 18 / Basilisk x1, Turtle x1 (7.110s)
+    Step  41: 19 / Turtle x2 (7.487s)
+    Step  76: 20 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  54   Index:  93
+Battle: Antlion                                                               Seed:  54   Index: 107
+Antlion's Nest                                                                Seed:  54   Index: 107
+Antlion B2F Outward Direct                                                    Seed:  54   Index: 122
+  Antlion B2F                                                                 Seed:  54   Index: 122
+    Step  21: 21 / Weeper x2 (7.132s)
+    Step  45: 22 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  54   Index: 202
+Overworld (Damcyan)                                                           Seed:  54   Index: 240
+Overworld (Kaipo)                                                             Seed:  54   Index: 240
+Kaipo Revisited                                                               Seed:  54   Index: 240
+Overworld (Kaipo)                                                             Seed:  54   Index: 240
+Overworld (Damcyan)                                                           Seed:  54   Index: 240
+Mt.Hobs-West                                                                  Seed:  54   Index: 240
+  Step   6: 23 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed:  71   Index:  23
+Battle: MomBomb                                                               Seed:  71   Index:  38
+Mt.Hobs Summit                                                                Seed:  71   Index:  38
+  Step   5: 24 / Cocktric x3 (7.853s)
+Mt.Hobs-East                                                                  Seed:  71   Index:  44
+  Step  28: 25 / Gargoyle x2 (7.630s)
+  Step  33: 26 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed:  71   Index:  90
+  Extra Steps: 4
+  Step  29: 27 / SwordRat x3, Needler x3 (7.663s)
+  Step  63: 28 / SwordRat x3, Needler x3 (7.663s)
+  Step  88: 29 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed:  71   Index: 178
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed:  71   Index: 238
+Fabul Boat and Leviatan                                                       Seed:  71   Index: 245
+Overworld (Mysidia)                                                           Seed:  71   Index: 245
+  Step   5: 30 / Raven x1 (8.246s)
+Mysidia                                                                       Seed:  71   Index: 254
+Overworld (Mysidia)                                                           Seed:  71   Index: 254
+  Step  10: 31 / Needler x2, SwordRat x2 (8.097s)
+Overworld (Mt.Ordeals)                                                        Seed:  88   Index:   8
+  Step  24: 32 / Raven x1 (8.356s)
+  Step  68: 33 / Needler x2, SwordRat x2 (8.097s)
+  Step  77: 34 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  88   Index: 102
+  Step  15: 35 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  88   Index: 145
+  Step  12: 36 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed:  88   Index: 168
+Mt.Ordeals-3rd station                                                        Seed:  88   Index: 168
+Mt.Ordeals-7th station                                                        Seed:  88   Index: 173
+  Step  40: 37 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed:  88   Index: 215
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed:  88   Index: 232
+Mt.Ordeals Summit                                                             Seed:  88   Index: 232
+Paladin                                                                       Seed:  88   Index: 236
+Mt.Ordeals Summit                                                             Seed:  88   Index: 236
+  Optional Steps: 0
+  Step   9: 38 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed: 105   Index:   2
+  Step  10: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 105   Index:  44
+  Step   7: 40 / Revenant x1, Ghoul x3 (8.489s)
+  Step  18: 41 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 105   Index:  74
+  Step  41: 42 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 105   Index: 118
+Take Chocobo to Mysidia                                                       Seed: 105   Index: 131
+Overworld (Mysidia)                                                           Seed: 105   Index: 131
+Town of Baron Serpent Road                                                    Seed: 105   Index: 131
+Credit Warp Fight Search                                                      Seed: 105   Index: 135
+  Overworld (Baron)                                                           Seed: 105   Index: 135
+    Extra Steps: 12
+    Step   1: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  12: 44 / Imp x4 (7.223s)
+   (Step  82: 45 / Imp x3, SwordRat x1)
+   (Step 100: 46 / Imp x3, SwordRat x1)
+   (Step 144: 47 / Imp x3, SwordRat x1)
+   (Step 180: 48 / Imp x6)
+   (Step 207: 49 / Imp x4)
+
+Encounter Time:      337.482s
+Other Time:          488.895s
+Total Time:          826.377s
+
+Base Total Time:     877.472s
+Time Saved:          51.095s
+
+Optional Steps:      1
+Extra Steps:         18
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/021.txt
+++ b/data/routes/cw/021.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	21
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49526271
+VARS	FFFFFFFF:12 E000200:2 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed:  21   Index:   0
+Overworld (Kaipo)                                                             Seed:  21   Index:   1
+  Step   1: 1 / Sand Man x4 (7.172s)
+  Step  28: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  21   Index:  37
+Overworld (Kaipo)                                                             Seed:  21   Index:  37
+  Step  30: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:  21   Index:  69
+  Step  24: 4 / Pike x3 (6.935s)
+  Step  27: 5 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed:  21   Index: 101
+Watery Pass-South B1F                                                         Seed:  21   Index: 101
+Watery Pass-South B2F                                                         Seed:  21   Index: 121
+Watery Pass-South B2F Save Room                                               Seed:  21   Index: 211
+Watery Pass-South B2F                                                         Seed:  21   Index: 215
+  Step   7: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step   9: 7 / CaveToad x3 (7.014s)
+  Step  36: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  21   Index: 254
+  Step  33: 9 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed:  38   Index:  32
+Watery Pass-North B1F                                                         Seed:  38   Index:  53
+  Step  20: 10 / Jelly x4 (7.324s)
+  Step  41: 11 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  38   Index: 113
+  Extra Steps: 2
+  Step   8: 12 / Imp x4 (7.049s)
+  Step  10: 13 / Sand Man x4 (7.310s)
+Waterfalls B1F                                                                Seed:  38   Index: 124
+Waterfalls B2F                                                                Seed:  38   Index: 125
+  Step  16: 14 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed:  38   Index: 170
+Battle: Octomamm                                                              Seed:  38   Index: 207
+Waterfalls Lake                                                               Seed:  38   Index: 207
+Overworld (Kaipo)                                                             Seed:  38   Index: 208
+Overworld (Damcyan)                                                           Seed:  38   Index: 219
+  Step   1: 15 / SandWorm x1, Sandpede x1 (7.206s)
+Damcyan                                                                       Seed:  38   Index: 223
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  38   Index: 230
+Antlion B1F                                                                   Seed:  38   Index: 230
+  Step  11: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Direct                                                     Seed:  55   Index:  12
+  Antlion B2F                                                                 Seed:  55   Index:  12
+    Step   3: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  41: 18 / Basilisk x1, Turtle x1 (7.110s)
+    Step  42: 19 / Turtle x2 (7.487s)
+    Step  77: 20 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  55   Index:  92
+  Step   7: 21 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed:  55   Index: 106
+Antlion's Nest                                                                Seed:  55   Index: 106
+Antlion B2F Outward Direct                                                    Seed:  55   Index: 121
+  Antlion B2F                                                                 Seed:  55   Index: 121
+    Step  22: 22 / Turtle x2 (7.464s)
+    Step  46: 23 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  55   Index: 201
+Overworld (Damcyan)                                                           Seed:  55   Index: 239
+Overworld (Kaipo)                                                             Seed:  55   Index: 239
+Kaipo Revisited                                                               Seed:  55   Index: 239
+Overworld (Kaipo)                                                             Seed:  55   Index: 239
+Overworld (Damcyan)                                                           Seed:  55   Index: 239
+Mt.Hobs-West                                                                  Seed:  55   Index: 239
+  Step   7: 24 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed:  72   Index:  22
+Battle: MomBomb                                                               Seed:  72   Index:  37
+Mt.Hobs Summit                                                                Seed:  72   Index:  37
+  Step   6: 25 / Gargoyle x2 (7.630s)
+Mt.Hobs-East                                                                  Seed:  72   Index:  43
+  Step  29: 26 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  34: 27 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:  72   Index:  89
+  Step  30: 28 / SwordRat x3, Needler x3 (7.663s)
+  Step  64: 29 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed:  72   Index: 173
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed:  72   Index: 233
+Fabul Boat and Leviatan                                                       Seed:  72   Index: 240
+Overworld (Mysidia)                                                           Seed:  72   Index: 240
+  Step   7: 30 / Raven x1 (8.246s)
+Mysidia                                                                       Seed:  72   Index: 249
+Overworld (Mysidia)                                                           Seed:  72   Index: 249
+Overworld (Mt.Ordeals)                                                        Seed:  89   Index:   3
+  Step   5: 31 / Needler x2, SwordRat x2 (8.097s)
+  Step  17: 32 / Raven x1 (8.356s)
+  Step  29: 33 / Needler x2, SwordRat x2 (8.097s)
+  Step  73: 34 / Raven x1 (8.356s)
+  Step  82: 35 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  89   Index:  97
+  Step  20: 36 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed:  89   Index: 140
+Recruit Tellah                                                                Seed:  89   Index: 163
+Mt.Ordeals-3rd station                                                        Seed:  89   Index: 163
+Mt.Ordeals-7th station                                                        Seed:  89   Index: 168
+Mt.Ordeals Summit                                                             Seed:  89   Index: 210
+  Optional Steps: 0
+  Step   3: 37 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:  89   Index: 227
+Mt.Ordeals Summit                                                             Seed:  89   Index: 227
+Paladin                                                                       Seed:  89   Index: 231
+Mt.Ordeals Summit                                                             Seed:  89   Index: 231
+  Optional Steps: 1
+  Step  14: 38 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed:  89   Index: 254
+  Step  14: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 106   Index:  40
+  Step  22: 40 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed: 106   Index:  70
+Overworld (Mt.Ordeals)                                                        Seed: 106   Index: 114
+  Step   1: 41 / Imp Cap. x3, Needler x1 (7.897s)
+  Step   2: 42 / Imp Cap. x3, Needler x1 (7.897s)
+Take Chocobo to Mysidia                                                       Seed: 106   Index: 127
+Overworld (Mysidia)                                                           Seed: 106   Index: 127
+Town of Baron Serpent Road                                                    Seed: 106   Index: 127
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed: 106   Index: 135
+  Overworld (Baron)                                                           Seed: 106   Index: 135
+    Extra Steps: 12
+    Step   1: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  12: 44 / Imp x4 (7.223s)
+   (Step 100: 45 / Imp x3, SwordRat x1)
+   (Step 144: 46 / Imp x3, SwordRat x1)
+   (Step 201: 47 / Imp x3, SwordRat x1)
+   (Step 207: 48 / Imp x6)
+
+Encounter Time:      335.186s
+Other Time:          488.895s
+Total Time:          824.081s
+
+Base Total Time:     875.693s
+Time Saved:          51.612s
+
+Optional Steps:      1
+Extra Steps:         18
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/022.txt
+++ b/data/routes/cw/022.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	22
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49928072
+VARS	FFFFFFFF:12 E302600:7
+
+Overworld (Kaipo)                                                             Seed:  22   Index:   0
+Overworld (Kaipo)                                                             Seed:  22   Index:   1
+  Step   1: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  22   Index:  37
+Overworld (Kaipo)                                                             Seed:  22   Index:  37
+  Step  30: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:  22   Index:  69
+  Step  24: 3 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  27: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  22   Index: 101
+Watery Pass-South B1F                                                         Seed:  22   Index: 101
+Watery Pass-South B2F                                                         Seed:  22   Index: 121
+  Step  85: 5 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  22   Index: 211
+Watery Pass-South B2F                                                         Seed:  22   Index: 215
+  Step   9: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  36: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  22   Index: 254
+  Step  33: 8 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed:  39   Index:  32
+Watery Pass-North B1F                                                         Seed:  39   Index:  53
+  Step  20: 9 / Aligator x1, Pike x2 (7.368s)
+  Step  41: 10 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed:  39   Index: 113
+  Step   8: 11 / SandMoth x2, Larva x2 (7.163s)
+Waterfalls B1F                                                                Seed:  39   Index: 122
+Waterfalls B2F                                                                Seed:  39   Index: 123
+  Step  18: 12 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed:  39   Index: 168
+  Step  35: 13 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed:  39   Index: 205
+Waterfalls Lake                                                               Seed:  39   Index: 205
+Overworld (Kaipo)                                                             Seed:  39   Index: 206
+Overworld (Damcyan)                                                           Seed:  39   Index: 217
+Damcyan                                                                       Seed:  39   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  39   Index: 228
+Antlion B1F                                                                   Seed:  39   Index: 228
+  Step  13: 14 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed:  56   Index:  10
+  Antlion B2F                                                                 Seed:  56   Index:  10
+    Step   5: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  43: 16 / SandWorm x2 (6.841s)
+    Step  44: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  79: 18 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:  56   Index:  90
+  Step   9: 19 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed:  56   Index: 104
+Antlion's Nest                                                                Seed:  56   Index: 104
+Antlion B2F Outward Direct                                                    Seed:  56   Index: 119
+  Antlion B2F                                                                 Seed:  56   Index: 119
+    Step  24: 20 / Turtle x2 (7.464s)
+    Step  48: 21 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed:  56   Index: 199
+Overworld (Damcyan)                                                           Seed:  56   Index: 237
+Overworld (Kaipo)                                                             Seed:  56   Index: 237
+Kaipo Revisited                                                               Seed:  56   Index: 237
+Overworld (Kaipo)                                                             Seed:  56   Index: 237
+Overworld (Damcyan)                                                           Seed:  56   Index: 237
+Mt.Hobs-West                                                                  Seed:  56   Index: 237
+  Step  12: 22 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed:  73   Index:  20
+Battle: MomBomb                                                               Seed:  73   Index:  35
+Mt.Hobs Summit                                                                Seed:  73   Index:  35
+Mt.Hobs-East                                                                  Seed:  73   Index:  41
+  Step   2: 23 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  31: 24 / Red Bone x1, Skelton x3 (8.007s)
+  Step  36: 25 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  73   Index:  87
+  Step  32: 26 / Cocktric x3 (8.241s)
+  Step  40: 27 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  66: 28 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed:  73   Index: 171
+  Optional Steps: 7
+Overworld (Fabul)                                                             Seed:  73   Index: 238
+Fabul Boat and Leviatan                                                       Seed:  73   Index: 245
+Overworld (Mysidia)                                                           Seed:  73   Index: 245
+  Step   2: 29 / Raven x1, Cocktric x3 (9.153s)
+Mysidia                                                                       Seed:  73   Index: 254
+Overworld (Mysidia)                                                           Seed:  73   Index: 254
+Overworld (Mt.Ordeals)                                                        Seed:  90   Index:   8
+  Step  12: 30 / Raven x1 (8.356s)
+  Step  24: 31 / Raven x1, Cocktric x3 (9.100s)
+  Step  68: 32 / Raven x1 (8.356s)
+  Step  77: 33 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed:  90   Index: 102
+  Step  15: 34 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed:  90   Index: 145
+Recruit Tellah                                                                Seed:  90   Index: 168
+Mt.Ordeals-3rd station                                                        Seed:  90   Index: 168
+Mt.Ordeals-7th station                                                        Seed:  90   Index: 173
+  Step  32: 35 / Revenant x1, Ghoul x3 (8.914s)
+  Step  40: 36 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed:  90   Index: 215
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed:  90   Index: 232
+Mt.Ordeals Summit                                                             Seed:  90   Index: 232
+Paladin                                                                       Seed:  90   Index: 236
+Mt.Ordeals Summit                                                             Seed:  90   Index: 236
+  Optional Steps: 0
+  Step   9: 37 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed: 107   Index:   2
+  Step  10: 38 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 107   Index:  44
+  Step  18: 39 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 107   Index:  74
+  Step   8: 40 / Skelton x3, Red Bone x2 (7.997s)
+  Step  41: 41 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+  Step  42: 42 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 107   Index: 118
+Take Chocobo to Mysidia                                                       Seed: 107   Index: 131
+Overworld (Mysidia)                                                           Seed: 107   Index: 131
+Town of Baron Serpent Road                                                    Seed: 107   Index: 131
+Credit Warp Fight Search                                                      Seed: 107   Index: 135
+  Overworld (Baron)                                                           Seed: 107   Index: 135
+    Extra Steps: 12
+    Step   1: 43 / Imp x3, SwordRat x1 (7.227s)
+    Step  12: 44 / Imp x4 (7.223s)
+   (Step 100: 45 / Imp x3, SwordRat x1)
+   (Step 144: 46 / Imp x3, SwordRat x1)
+   (Step 201: 47 / Eagle x3)
+   (Step 207: 48 / Imp x3)
+   (Step 233: 49 / Imp x4)
+
+Encounter Time:      343.469s
+Other Time:          487.297s
+Total Time:          830.766s
+
+Base Total Time:     841.214s
+Time Saved:          10.447s
+
+Optional Steps:      7
+Extra Steps:         12
+Encounters:          44
+
+Base Encounters:     45
+Encounters Saved:    1
+
+Number of Variables: 54

--- a/data/routes/cw/023.txt
+++ b/data/routes/cw/023.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	23
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50749290
+VARS	FFFFFFFF:46 E302500:50 E302600:44 E307400:2 E307E00:6 E308401:2 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  23   Index:   0
+Overworld (Kaipo)                                                             Seed:  23   Index:   1
+  Step   1: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  23   Index:  37
+Overworld (Kaipo)                                                             Seed:  23   Index:  37
+  Step  30: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:  23   Index:  69
+  Step  24: 3 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  27: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  23   Index: 101
+Watery Pass-South B1F                                                         Seed:  23   Index: 101
+Watery Pass-South B2F                                                         Seed:  23   Index: 121
+  Step  85: 5 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  23   Index: 211
+Watery Pass-South B2F                                                         Seed:  23   Index: 215
+  Step   9: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  24: 7 / CaveToad x3 (7.014s)
+  Step  36: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  23   Index: 254
+  Step  33: 9 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed:  40   Index:  32
+Watery Pass-North B1F                                                         Seed:  40   Index:  53
+  Step  20: 10 / Jelly x4 (7.324s)
+  Step  41: 11 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  40   Index: 113
+  Step   8: 12 / Imp x4 (7.049s)
+Waterfalls B1F                                                                Seed:  40   Index: 122
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed:  40   Index: 125
+Waterfalls Lake                                                               Seed:  40   Index: 170
+  Step  33: 13 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed:  40   Index: 207
+Waterfalls Lake                                                               Seed:  40   Index: 207
+Overworld (Kaipo)                                                             Seed:  40   Index: 208
+Overworld (Damcyan)                                                           Seed:  40   Index: 219
+Damcyan                                                                       Seed:  40   Index: 223
+  Optional Steps: 0
+  Extra Steps: 50
+Overworld (Damcyan)                                                           Seed:  57   Index:  24
+Antlion B1F                                                                   Seed:  57   Index:  24
+  Step  29: 14 / Imp x3 (6.649s)
+  Step  30: 15 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed:  57   Index:  62
+  Antlion B2F                                                                 Seed:  57   Index:  62
+    Step  27: 16 / SandWorm x2 (6.841s)
+    Step  37: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed:  57   Index: 142
+  Step   1: 18 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed:  57   Index: 156
+Antlion's Nest                                                                Seed:  57   Index: 156
+Antlion B2F Outward Direct                                                    Seed:  57   Index: 171
+  Antlion B2F                                                                 Seed:  57   Index: 171
+    Step  78: 19 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  57   Index: 251
+  Step   6: 20 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  74   Index:  33
+Overworld (Kaipo)                                                             Seed:  74   Index:  33
+Kaipo Revisited                                                               Seed:  74   Index:  33
+Overworld (Kaipo)                                                             Seed:  74   Index:  33
+Overworld (Damcyan)                                                           Seed:  74   Index:  33
+Mt.Hobs-West                                                                  Seed:  74   Index:  33
+  Extra Steps: 6
+  Step  39: 21 / Gargoyle x2 (8.791s)
+  Step  44: 22 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed:  74   Index:  78
+Battle: MomBomb                                                               Seed:  74   Index:  93
+Mt.Hobs Summit                                                                Seed:  74   Index:  93
+Mt.Hobs-East                                                                  Seed:  74   Index:  99
+  Step  20: 23 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  28: 24 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed:  74   Index: 145
+  Step   8: 25 / SwordRat x3, Needler x3 (7.663s)
+  Step  33: 26 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  74   Index: 229
+  Optional Steps: 10
+  Extra Steps: 34
+Overworld (Fabul)                                                             Seed:  91   Index:  77
+Fabul Boat and Leviatan                                                       Seed:  91   Index:  84
+Overworld (Mysidia)                                                           Seed:  91   Index:  84
+Mysidia                                                                       Seed:  91   Index:  93
+Overworld (Mysidia)                                                           Seed:  91   Index:  93
+Overworld (Mt.Ordeals)                                                        Seed:  91   Index: 103
+  Step  14: 27 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  91   Index: 197
+  Step   8: 28 / Lilith x1, Red Bone x2 (9.259s)
+  Step  16: 29 / Lilith x1, Red Bone x2 (9.259s)
+  Step  33: 30 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed:  91   Index: 240
+  Step   5: 31 / Lilith x1, Red Bone x2 (9.259s)
+Recruit Tellah                                                                Seed: 108   Index:   7
+Mt.Ordeals-3rd station                                                        Seed: 108   Index:   7
+  Step   5: 32 / Ghoul x1, Red Bone x2, Skelton x2 (8.832s)
+Mt.Ordeals-7th station                                                        Seed: 108   Index:  12
+Mt.Ordeals Summit                                                             Seed: 108   Index:  54
+  Optional Steps: 1
+  Step   8: 33 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed: 108   Index:  72
+Mt.Ordeals Summit                                                             Seed: 108   Index:  72
+Paladin                                                                       Seed: 108   Index:  76
+Mt.Ordeals Summit                                                             Seed: 108   Index:  76
+  Optional Steps: 1
+  Step   6: 34 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed: 108   Index:  99
+  Step  15: 35 / Revenant x1, Ghoul x3 (8.489s)
+  Step  17: 36 / Ghoul x2, Soul x2 (8.971s)
+  Step  37: 37 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 108   Index: 141
+  Step   6: 38 / Spirit x2, Soul x2, Red Bone x2 (9.471s)
+Mt.Ordeals                                                                    Seed: 108   Index: 171
+  Extra Steps: 2
+Overworld (Mt.Ordeals)                                                        Seed: 108   Index: 217
+Take Chocobo to Mysidia                                                       Seed: 108   Index: 230
+Overworld (Mysidia)                                                           Seed: 108   Index: 230
+Town of Baron Serpent Road                                                    Seed: 108   Index: 230
+Credit Warp Fight Search                                                      Seed: 108   Index: 234
+  Overworld (Baron)                                                           Seed: 108   Index: 234
+    Extra Steps: 46
+    Step   1: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  45: 40 / Imp x4 (7.223s)
+   (Step 102: 41 / FloatEye x1, Eagle x2)
+   (Step 108: 42 / FloatEye x1, Eagle x2)
+   (Step 134: 43 / Imp x3, SwordRat x1)
+   (Step 177: 44 / Imp x3, SwordRat x1)
+   (Step 182: 45 / Imp x3, SwordRat x1)
+   (Step 231: 46 / Imp x3, SwordRat x1)
+
+Encounter Time:      314.004s
+Other Time:          530.426s
+Total Time:          844.431s
+
+Base Total Time:     941.392s
+Time Saved:          96.961s
+
+Optional Steps:      12
+Extra Steps:         140
+Encounters:          40
+
+Base Encounters:     49
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/024.txt
+++ b/data/routes/cw/024.txt
@@ -1,0 +1,156 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	24
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50783310
+VARS	FFFFFFFF:8 E000201:12 E000202:16 E000501:6 E000600:20 E302600:10 E305400:38 E307200:4 E307700:26 E307E00:4 E308400:16 E308700:1 E308702:1 E309700:52
+
+Overworld (Kaipo)                                                             Seed:  24   Index:   0
+Overworld (Kaipo)                                                             Seed:  24   Index:   1
+Kaipo                                                                         Seed:  24   Index:  37
+Overworld (Kaipo)                                                             Seed:  24   Index:  37
+  Step  30: 1 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  24   Index:  69
+  Step  27: 2 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  24   Index: 101
+Watery Pass-South B1F                                                         Seed:  24   Index: 101
+Watery Pass-South B2F                                                         Seed:  24   Index: 121
+  Step  85: 3 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  24   Index: 211
+  Extra Steps: 38
+Watery Pass-South B2F                                                         Seed:  24   Index: 253
+  Step  29: 4 / Pike x3 (7.152s)
+  Step  34: 5 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed:  41   Index:  36
+Watery Pass-North B2F                                                         Seed:  41   Index:  70
+  Extra Steps: 4
+  Step   3: 6 / Zombie x4 (7.148s)
+  Step  24: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed:  41   Index:  95
+  Step  26: 8 / Zombie x4 (7.148s)
+  Step  28: 9 / Aligator x1, Pike x2 (7.368s)
+  Step  30: 10 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed:  41   Index: 155
+Waterfalls B1F                                                                Seed:  41   Index: 164
+Waterfalls B2F                                                                Seed:  41   Index: 165
+  Step  38: 11 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed:  41   Index: 210
+Battle: Octomamm                                                              Seed:  41   Index: 247
+Waterfalls Lake                                                               Seed:  41   Index: 247
+Overworld (Kaipo)                                                             Seed:  41   Index: 248
+  Extra Steps: 12
+  Step  23: 12 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed:  58   Index:  15
+Damcyan                                                                       Seed:  58   Index:  19
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  58   Index:  26
+Antlion B1F                                                                   Seed:  58   Index:  26
+  Extra Steps: 26
+  Step  27: 13 / Basilisk x1, Imp x3 (6.775s)
+  Step  63: 14 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed:  58   Index:  90
+  Antlion B2F                                                                 Seed:  58   Index:  90
+    Step   9: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  53: 16 / SandWorm x2 (6.841s)
+Antlion's Nest                                                                Seed:  58   Index: 170
+Battle: Antlion                                                               Seed:  58   Index: 184
+Antlion's Nest                                                                Seed:  58   Index: 184
+Antlion B2F Outward Direct                                                    Seed:  58   Index: 199
+  Antlion B2F                                                                 Seed:  58   Index: 199
+    Step  33: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  50: 18 / Basilisk x1, Turtle x1 (7.124s)
+    Step  58: 19 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  75   Index:  23
+  Step  25: 20 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  75   Index:  61
+Overworld (Kaipo)                                                             Seed:  75   Index:  61
+  Extra Steps: 16
+  Step  11: 21 / SandMoth x2, Larva x2 (7.135s)
+  Step  16: 22 / Sandpede x1, Sand Man x2 (7.135s)
+Kaipo Revisited                                                               Seed:  75   Index:  77
+Overworld (Kaipo)                                                             Seed:  75   Index:  77
+Overworld (Damcyan)                                                           Seed:  75   Index:  77
+Mt.Hobs-West                                                                  Seed:  75   Index:  77
+  Extra Steps: 4
+  Step  42: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed:  75   Index: 120
+  Step   7: 24 / Cocktric x3 (9.055s)
+Battle: MomBomb                                                               Seed:  75   Index: 135
+Mt.Hobs Summit                                                                Seed:  75   Index: 135
+Mt.Hobs-East                                                                  Seed:  75   Index: 141
+Overworld (Fabul)                                                             Seed:  75   Index: 187
+  Step  44: 25 / SwordRat x3, Needler x3 (7.663s)
+  Step  60: 26 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  92   Index:  15
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  92   Index:  85
+Fabul Boat and Leviatan                                                       Seed:  92   Index:  92
+Overworld (Mysidia)                                                           Seed:  92   Index:  92
+Mysidia                                                                       Seed:  92   Index: 101
+Overworld (Mysidia)                                                           Seed:  92   Index: 101
+  Extra Steps: 6
+Overworld (Mt.Ordeals)                                                        Seed:  92   Index: 117
+  Extra Steps: 20
+  Step  88: 27 / Raven x1 (8.356s)
+  Step  96: 28 / Raven x1 (8.356s)
+  Step 113: 29 / Raven x1, Cocktric x3 (9.100s)
+Mt.Ordeals                                                                    Seed:  92   Index: 231
+  Extra Steps: 16
+  Step  14: 30 / Spirit x2, Skelton x2 (8.285s)
+  Step  37: 31 / Lilith x1, Red Bone x2 (9.259s)
+  Step  58: 32 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 109   Index:  34
+Recruit Tellah                                                                Seed: 109   Index:  57
+Mt.Ordeals-3rd station                                                        Seed: 109   Index:  57
+  Step   5: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed: 109   Index:  62
+  Step  20: 34 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 109   Index: 104
+  Optional Steps: 1
+  Step  10: 35 / Revenant x1, Ghoul x3 (8.914s)
+  Step  12: 36 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed: 109   Index: 122
+Mt.Ordeals Summit                                                             Seed: 109   Index: 122
+Paladin                                                                       Seed: 109   Index: 126
+Mt.Ordeals Summit                                                             Seed: 109   Index: 126
+  Optional Steps: 1
+  Step  10: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 109   Index: 149
+Mt.Ordeals-3rd station                                                        Seed: 109   Index: 191
+Mt.Ordeals                                                                    Seed: 109   Index: 221
+  Step  14: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 126   Index:   9
+Take Chocobo to Mysidia                                                       Seed: 126   Index:  22
+Overworld (Mysidia)                                                           Seed: 126   Index:  22
+Town of Baron Serpent Road                                                    Seed: 126   Index:  22
+  Extra Steps: 52
+Credit Warp Fight Search                                                      Seed: 126   Index:  78
+  Overworld (Baron)                                                           Seed: 126   Index:  78
+    Extra Steps: 8
+    Step   2: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step   8: 40 / Imp x4 (7.223s)
+   (Step  34: 41 / FloatEye x1, Eagle x2)
+   (Step  77: 42 / FloatEye x1, Eagle x2)
+   (Step  82: 43 / Imp x3, SwordRat x1)
+   (Step 137: 44 / Imp x3, SwordRat x1)
+   (Step 192: 45 / Imp x3, SwordRat x1)
+
+Encounter Time:      308.181s
+Other Time:          536.816s
+Total Time:          844.997s
+
+Base Total Time:     972.518s
+Time Saved:          127.521s
+
+Optional Steps:      12
+Extra Steps:         202
+Encounters:          40
+
+Base Encounters:     49
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/025.txt
+++ b/data/routes/cw/025.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	25
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50832719
+VARS	FFFFFFFF:8 E000600:20 E302500:150 E302600:14 E307400:2 E308000:8 E308700:1 E308702:1 E309700:10
+
+Overworld (Kaipo)                                                             Seed:  25   Index:   0
+Overworld (Kaipo)                                                             Seed:  25   Index:   1
+Kaipo                                                                         Seed:  25   Index:  37
+Overworld (Kaipo)                                                             Seed:  25   Index:  37
+  Step  15: 1 / Sand Man x4 (7.242s)
+  Step  30: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:  25   Index:  69
+  Step  27: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:  25   Index: 101
+Watery Pass-South B1F                                                         Seed:  25   Index: 101
+Watery Pass-South B2F                                                         Seed:  25   Index: 121
+  Step  85: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  25   Index: 211
+Watery Pass-South B2F                                                         Seed:  25   Index: 215
+  Step  24: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  36: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  38: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  25   Index: 254
+  Step  28: 8 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed:  42   Index:  32
+Watery Pass-North B1F                                                         Seed:  42   Index:  53
+  Step  20: 9 / Aligator x1, Pike x2 (7.368s)
+  Step  41: 10 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed:  42   Index: 113
+Waterfalls B1F                                                                Seed:  42   Index: 122
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed:  42   Index: 125
+Waterfalls Lake                                                               Seed:  42   Index: 170
+  Step  33: 11 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed:  42   Index: 207
+Waterfalls Lake                                                               Seed:  42   Index: 207
+Overworld (Kaipo)                                                             Seed:  42   Index: 208
+Overworld (Damcyan)                                                           Seed:  42   Index: 219
+Damcyan                                                                       Seed:  42   Index: 223
+  Optional Steps: 0
+  Extra Steps: 150
+Overworld (Damcyan)                                                           Seed:  59   Index: 124
+Antlion B1F                                                                   Seed:  59   Index: 124
+  Step  19: 12 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed:  59   Index: 162
+  Antlion B2F                                                                 Seed:  59   Index: 162
+    Step  70: 13 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:  59   Index: 242
+  Step   7: 14 / Cream x4 (7.552s)
+Battle: Antlion                                                               Seed:  76   Index:   0
+Antlion's Nest                                                                Seed:  76   Index:   0
+  Step   1: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed:  76   Index:  15
+  Antlion B2F                                                                 Seed:  76   Index:  15
+    Step  33: 16 / SandWorm x1, Sandpede x1 (6.848s)
+    Step  57: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  62: 18 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed:  76   Index:  95
+  Step  23: 19 / Turtle x1, Imp x2 (7.009s)
+  Step  32: 20 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  76   Index: 133
+Overworld (Kaipo)                                                             Seed:  76   Index: 133
+Kaipo Revisited                                                               Seed:  76   Index: 133
+Overworld (Kaipo)                                                             Seed:  76   Index: 133
+Overworld (Damcyan)                                                           Seed:  76   Index: 133
+Mt.Hobs-West                                                                  Seed:  76   Index: 133
+Mt.Hobs Summit                                                                Seed:  76   Index: 172
+Battle: MomBomb                                                               Seed:  76   Index: 187
+Mt.Hobs Summit                                                                Seed:  76   Index: 187
+Mt.Hobs-East                                                                  Seed:  76   Index: 193
+  Extra Steps: 8
+  Step  38: 21 / Turtle x2 (7.432s)
+  Step  54: 22 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed:  76   Index: 247
+  Step  29: 23 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  41: 24 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  59: 25 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed:  93   Index:  75
+  Optional Steps: 10
+  Extra Steps: 4
+Overworld (Fabul)                                                             Seed:  93   Index: 149
+Fabul Boat and Leviatan                                                       Seed:  93   Index: 156
+Overworld (Mysidia)                                                           Seed:  93   Index: 156
+Mysidia                                                                       Seed:  93   Index: 165
+Overworld (Mysidia)                                                           Seed:  93   Index: 165
+Overworld (Mt.Ordeals)                                                        Seed:  93   Index: 175
+  Extra Steps: 20
+  Step  30: 26 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  38: 27 / Raven x1 (8.356s)
+  Step  55: 28 / Raven x1 (8.356s)
+  Step  70: 29 / Raven x1, Cocktric x3 (9.100s)
+  Step  93: 30 / Raven x1 (8.356s)
+  Step 114: 31 / Raven x1, Cocktric x3 (9.100s)
+Mt.Ordeals                                                                    Seed: 110   Index:  33
+  Step  29: 32 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 110   Index:  76
+  Step   6: 33 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed: 110   Index:  99
+Mt.Ordeals-3rd station                                                        Seed: 110   Index:  99
+Mt.Ordeals-7th station                                                        Seed: 110   Index: 104
+  Step  10: 34 / Lilith x1, Red Bone x2 (8.912s)
+  Step  12: 35 / Revenant x1, Ghoul x3 (8.914s)
+  Step  32: 36 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 110   Index: 146
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 110   Index: 164
+Mt.Ordeals Summit                                                             Seed: 110   Index: 164
+Paladin                                                                       Seed: 110   Index: 168
+Mt.Ordeals Summit                                                             Seed: 110   Index: 168
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 110   Index: 191
+  Step  27: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 110   Index: 233
+Mt.Ordeals                                                                    Seed: 127   Index:   7
+  Step  16: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 127   Index:  51
+Take Chocobo to Mysidia                                                       Seed: 127   Index:  64
+Overworld (Mysidia)                                                           Seed: 127   Index:  64
+Town of Baron Serpent Road                                                    Seed: 127   Index:  64
+  Extra Steps: 10
+Credit Warp Fight Search                                                      Seed: 127   Index:  78
+  Overworld (Baron)                                                           Seed: 127   Index:  78
+    Extra Steps: 8
+    Step   2: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step   8: 40 / Imp x4 (7.223s)
+   (Step  34: 41 / FloatEye x1, Eagle x2)
+   (Step  77: 42 / FloatEye x1, Eagle x2)
+   (Step  82: 43 / Imp x3, SwordRat x1)
+   (Step 130: 44 / Imp x3, SwordRat x1)
+   (Step 137: 45 / Imp x3, SwordRat x1)
+
+Encounter Time:      309.003s
+Other Time:          536.816s
+Total Time:          845.819s
+
+Base Total Time:     976.939s
+Time Saved:          131.120s
+
+Optional Steps:      12
+Extra Steps:         202
+Encounters:          40
+
+Base Encounters:     49
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/026.txt
+++ b/data/routes/cw/026.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	26
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49230084
+VARS	FFFFFFFF:10 E302500:50 E302600:18 E307400:2 E307E00:6 E308700:1 E308702:1 E309700:10
+
+Overworld (Kaipo)                                                             Seed:  26   Index:   0
+Overworld (Kaipo)                                                             Seed:  26   Index:   1
+Kaipo                                                                         Seed:  26   Index:  37
+Overworld (Kaipo)                                                             Seed:  26   Index:  37
+  Step  15: 1 / Sand Man x4 (7.242s)
+  Step  23: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step  30: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:  26   Index:  69
+  Step  27: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  26   Index: 101
+Watery Pass-South B1F                                                         Seed:  26   Index: 101
+Watery Pass-South B2F                                                         Seed:  26   Index: 121
+  Step  85: 5 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  26   Index: 211
+Watery Pass-South B2F                                                         Seed:  26   Index: 215
+  Step  24: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  36: 7 / CaveToad x3 (7.014s)
+  Step  38: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  26   Index: 254
+  Step  28: 9 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed:  43   Index:  32
+  Step  15: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:  43   Index:  53
+  Step  20: 11 / Aligator x1, Pike x2 (7.368s)
+  Step  41: 12 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed:  43   Index: 113
+Waterfalls B1F                                                                Seed:  43   Index: 122
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed:  43   Index: 125
+Waterfalls Lake                                                               Seed:  43   Index: 170
+  Step  33: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed:  43   Index: 207
+Waterfalls Lake                                                               Seed:  43   Index: 207
+Overworld (Kaipo)                                                             Seed:  43   Index: 208
+Overworld (Damcyan)                                                           Seed:  43   Index: 219
+Damcyan                                                                       Seed:  43   Index: 223
+  Optional Steps: 0
+  Extra Steps: 50
+Overworld (Damcyan)                                                           Seed:  60   Index:  24
+Antlion B1F                                                                   Seed:  60   Index:  24
+  Step  29: 14 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed:  60   Index:  62
+  Antlion B2F                                                                 Seed:  60   Index:  62
+    Step   6: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  37: 16 / SandWorm x1, Sandpede x1 (6.829s)
+    Step  62: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed:  60   Index: 142
+Battle: Antlion                                                               Seed:  60   Index: 156
+Antlion's Nest                                                                Seed:  60   Index: 156
+Antlion B2F Outward Direct                                                    Seed:  60   Index: 171
+  Antlion B2F                                                                 Seed:  60   Index: 171
+    Step  61: 18 / Basilisk x1, Turtle x1 (7.124s)
+    Step  78: 19 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  60   Index: 251
+  Step   6: 20 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  77   Index:  33
+Overworld (Kaipo)                                                             Seed:  77   Index:  33
+Kaipo Revisited                                                               Seed:  77   Index:  33
+Overworld (Kaipo)                                                             Seed:  77   Index:  33
+Overworld (Damcyan)                                                           Seed:  77   Index:  33
+Mt.Hobs-West                                                                  Seed:  77   Index:  33
+  Extra Steps: 6
+  Step  15: 21 / Gargoyle x2 (8.791s)
+  Step  39: 22 / Gargoyle x1, Cocktric x2 (9.399s)
+  Step  44: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed:  77   Index:  78
+Battle: MomBomb                                                               Seed:  77   Index:  93
+Mt.Hobs Summit                                                                Seed:  77   Index:  93
+Mt.Hobs-East                                                                  Seed:  77   Index:  99
+  Step  19: 24 / Red Bone x1, Skelton x3 (8.007s)
+  Step  28: 25 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  77   Index: 145
+  Step  50: 26 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  77   Index: 229
+  Optional Steps: 10
+  Extra Steps: 8
+Overworld (Fabul)                                                             Seed:  94   Index:  51
+Fabul Boat and Leviatan                                                       Seed:  94   Index:  58
+Overworld (Mysidia)                                                           Seed:  94   Index:  58
+Mysidia                                                                       Seed:  94   Index:  67
+Overworld (Mysidia)                                                           Seed:  94   Index:  67
+Overworld (Mt.Ordeals)                                                        Seed:  94   Index:  77
+  Step  71: 27 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  94   Index: 171
+  Step  10: 28 / Spirit x2, Skelton x2 (8.285s)
+  Step  34: 29 / Lilith x1, Red Bone x2 (9.259s)
+  Step  42: 30 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed:  94   Index: 214
+  Step  16: 31 / Lilith x1, Red Bone x2 (9.259s)
+Recruit Tellah                                                                Seed:  94   Index: 237
+Mt.Ordeals-3rd station                                                        Seed:  94   Index: 237
+Mt.Ordeals-7th station                                                        Seed:  94   Index: 242
+  Step   3: 32 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 111   Index:  28
+  Optional Steps: 1
+  Step   5: 33 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed: 111   Index:  46
+Mt.Ordeals Summit                                                             Seed: 111   Index:  46
+Paladin                                                                       Seed: 111   Index:  50
+Mt.Ordeals Summit                                                             Seed: 111   Index:  50
+  Optional Steps: 1
+  Step  12: 34 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed: 111   Index:  73
+  Step   9: 35 / Revenant x1, Ghoul x3 (8.489s)
+  Step  41: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 111   Index: 115
+  Step   1: 37 / Zombie x2, Ghoul x2 (7.552s)
+  Step  21: 38 / Spirit x2, Soul x2, Red Bone x2 (9.471s)
+Mt.Ordeals                                                                    Seed: 111   Index: 145
+Overworld (Mt.Ordeals)                                                        Seed: 111   Index: 189
+Take Chocobo to Mysidia                                                       Seed: 111   Index: 202
+Overworld (Mysidia)                                                           Seed: 111   Index: 202
+Town of Baron Serpent Road                                                    Seed: 111   Index: 202
+  Extra Steps: 10
+Credit Warp Fight Search                                                      Seed: 111   Index: 216
+  Overworld (Baron)                                                           Seed: 111   Index: 216
+    Extra Steps: 10
+    Step   2: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  10: 40 / Imp x4 (7.223s)
+   (Step  86: 41 / FloatEye x1, Eagle x2)
+   (Step 120: 42 / Imp x3, SwordRat x1)
+   (Step 126: 43 / Imp x3, SwordRat x1)
+   (Step 152: 44 / Imp x3, SwordRat x1)
+   (Step 200: 45 / Imp x3, SwordRat x1)
+   (Step 248: 46 / Imp x3, SwordRat x1)
+   (Step 255: 47 / Eagle x3)
+
+Encounter Time:      312.686s
+Other Time:          506.466s
+Total Time:          819.152s
+
+Base Total Time:     915.717s
+Time Saved:          96.565s
+
+Optional Steps:      12
+Extra Steps:         86
+Encounters:          40
+
+Base Encounters:     49
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/027.txt
+++ b/data/routes/cw/027.txt
@@ -1,0 +1,156 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	27
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49038662
+VARS	FFFFFFFF:10 C307800:1 E000202:14 E302500:7 E302600:46 E307400:2 E307B00:2 E308501:4 E308700:1 E308702:1 E309700:6
+
+Overworld (Kaipo)                                                             Seed:  27   Index:   0
+Overworld (Kaipo)                                                             Seed:  27   Index:   1
+Kaipo                                                                         Seed:  27   Index:  37
+Overworld (Kaipo)                                                             Seed:  27   Index:  37
+  Step  15: 1 / Sand Man x4 (7.242s)
+  Step  23: 2 / SandWorm x1 (7.100s)
+Watery Pass-South B1F                                                         Seed:  27   Index:  69
+  Step  23: 3 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  27: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  27   Index: 101
+Watery Pass-South B1F                                                         Seed:  27   Index: 101
+Watery Pass-South B2F                                                         Seed:  27   Index: 121
+  Step  85: 5 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  27   Index: 211
+Watery Pass-South B2F                                                         Seed:  27   Index: 215
+  Step  24: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  38: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  27   Index: 254
+  Step  28: 8 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed:  44   Index:  32
+  Step  15: 9 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed:  44   Index:  53
+  Step   5: 10 / CaveToad x4 (7.163s)
+  Step  20: 11 / Aligator x1, Pike x2 (7.368s)
+  Step  41: 12 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed:  44   Index: 113
+Waterfalls B1F                                                                Seed:  44   Index: 122
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed:  44   Index: 125
+Waterfalls Lake                                                               Seed:  44   Index: 170
+  Step  33: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed:  44   Index: 207
+Waterfalls Lake                                                               Seed:  44   Index: 207
+Overworld (Kaipo)                                                             Seed:  44   Index: 208
+Overworld (Damcyan)                                                           Seed:  44   Index: 219
+Damcyan                                                                       Seed:  44   Index: 223
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed:  44   Index: 237
+Antlion B1F                                                                   Seed:  44   Index: 237
+Antlion B2F Inward Charm Room Steps                                           Seed:  61   Index:  19
+  Antlion B2F                                                                 Seed:  61   Index:  19
+    Step   5: 14 / Basilisk x1, Imp x3 (6.775s)
+  Antlion B2F Treasure Room                                                   Seed:  61   Index:  52
+    Extra Steps: 2
+  Antlion B2F                                                                 Seed:  61   Index:  54
+    Step  14: 15 / Basilisk x1, Turtle x1 (7.110s)
+    Step  24: 16 / Cream x4 (7.552s)
+    Step  45: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed:  61   Index: 106
+Battle: Antlion                                                               Seed:  61   Index: 120
+Antlion's Nest                                                                Seed:  61   Index: 120
+  Step   4: 18 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B2F Outward Direct                                                    Seed:  61   Index: 135
+  Antlion B2F                                                                 Seed:  61   Index: 135
+Antlion B1F                                                                   Seed:  61   Index: 215
+  Step  17: 19 / Turtle x1, Imp x2 (7.009s)
+  Step  34: 20 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  61   Index: 253
+Overworld (Kaipo)                                                             Seed:  61   Index: 253
+  Extra Steps: 14
+  Step   4: 21 / SandMoth x2, Larva x2 (7.135s)
+  Step  13: 22 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed:  78   Index:  11
+Overworld (Kaipo)                                                             Seed:  78   Index:  11
+Overworld (Damcyan)                                                           Seed:  78   Index:  11
+Mt.Hobs-West                                                                  Seed:  78   Index:  11
+  Step  37: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed:  78   Index:  50
+Battle: MomBomb                                                               Seed:  78   Index:  65
+Mt.Hobs Summit                                                                Seed:  78   Index:  65
+Mt.Hobs-East                                                                  Seed:  78   Index:  71
+  Step   6: 24 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed:  78   Index: 117
+  Step   1: 25 / SwordRat x3, Needler x3 (7.663s)
+  Step  10: 26 / Cocktric x3 (8.241s)
+  Step  78: 27 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  78   Index: 201
+  Optional Steps: 10
+  Extra Steps: 36
+Overworld (Fabul)                                                             Seed:  95   Index:  51
+Fabul Boat and Leviatan                                                       Seed:  95   Index:  58
+Overworld (Mysidia)                                                           Seed:  95   Index:  58
+Mysidia                                                                       Seed:  95   Index:  67
+Overworld (Mysidia)                                                           Seed:  95   Index:  67
+Overworld (Mt.Ordeals)                                                        Seed:  95   Index:  77
+  Step  71: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  95   Index: 171
+  Step  10: 29 / Lilith x1, Red Bone x2 (9.259s)
+  Step  34: 30 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed:  95   Index: 214
+  Step  16: 31 / Lilith x1, Red Bone x2 (9.259s)
+Recruit Tellah                                                                Seed:  95   Index: 237
+Mt.Ordeals-3rd station                                                        Seed:  95   Index: 237
+  Extra Steps: 4
+  Step   8: 32 / Ghoul x1, Red Bone x2, Skelton x2 (8.832s)
+Mt.Ordeals-7th station                                                        Seed:  95   Index: 246
+Mt.Ordeals Summit                                                             Seed: 112   Index:  32
+  Optional Steps: 1
+  Step   1: 33 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed: 112   Index:  50
+Mt.Ordeals Summit                                                             Seed: 112   Index:  50
+Paladin                                                                       Seed: 112   Index:  54
+Mt.Ordeals Summit                                                             Seed: 112   Index:  54
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 112   Index:  77
+  Step   5: 34 / Lilith x1, Red Bone x2 (8.437s)
+  Step  37: 35 / Revenant x1, Ghoul x3 (8.489s)
+  Step  39: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 112   Index: 119
+  Step  17: 37 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 112   Index: 149
+  Step  17: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 112   Index: 193
+Take Chocobo to Mysidia                                                       Seed: 112   Index: 206
+Overworld (Mysidia)                                                           Seed: 112   Index: 206
+Town of Baron Serpent Road                                                    Seed: 112   Index: 206
+  Extra Steps: 6
+Credit Warp Fight Search                                                      Seed: 112   Index: 216
+  Overworld (Baron)                                                           Seed: 112   Index: 216
+    Extra Steps: 10
+    Step   2: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  10: 40 / Imp x4 (7.223s)
+   (Step  86: 41 / FloatEye x1, Eagle x2)
+   (Step 120: 42 / Imp x3, SwordRat x1)
+   (Step 152: 43 / Imp x3, SwordRat x1)
+   (Step 200: 44 / Imp x3, SwordRat x1)
+   (Step 248: 45 / Imp x3, SwordRat x1)
+   (Step 255: 46 / Imp x3, SwordRat x1)
+
+Encounter Time:      306.506s
+Other Time:          509.461s
+Total Time:          815.967s
+
+Base Total Time:     882.609s
+Time Saved:          66.642s
+
+Optional Steps:      13
+Extra Steps:         80
+Encounters:          40
+
+Base Encounters:     45
+Encounters Saved:    5
+
+Number of Variables: 54

--- a/data/routes/cw/028.txt
+++ b/data/routes/cw/028.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	28
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48848265
+VARS	FFFFFFFF:10 E000202:12 E302500:6 E302600:46 E307400:2 E307700:10 E308700:1 E308702:1 E309700:10
+
+Overworld (Kaipo)                                                             Seed:  28   Index:   0
+Overworld (Kaipo)                                                             Seed:  28   Index:   1
+Kaipo                                                                         Seed:  28   Index:  37
+Overworld (Kaipo)                                                             Seed:  28   Index:  37
+  Step  15: 1 / Sand Man x4 (7.242s)
+  Step  23: 2 / SandWorm x1 (7.100s)
+  Step  32: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:  28   Index:  69
+  Step  23: 4 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed:  28   Index: 101
+Watery Pass-South B1F                                                         Seed:  28   Index: 101
+Watery Pass-South B2F                                                         Seed:  28   Index: 121
+  Step  85: 5 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  28   Index: 211
+Watery Pass-South B2F                                                         Seed:  28   Index: 215
+  Step  24: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  38: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  28   Index: 254
+  Step  28: 8 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed:  45   Index:  32
+  Step  15: 9 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed:  45   Index:  53
+  Step   5: 10 / CaveToad x4 (7.163s)
+  Step   8: 11 / Aligator x1, Pike x2 (7.368s)
+  Step  20: 12 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed:  45   Index: 113
+Waterfalls B1F                                                                Seed:  45   Index: 122
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed:  45   Index: 125
+Waterfalls Lake                                                               Seed:  45   Index: 170
+  Step  33: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed:  45   Index: 207
+Waterfalls Lake                                                               Seed:  45   Index: 207
+Overworld (Kaipo)                                                             Seed:  45   Index: 208
+Overworld (Damcyan)                                                           Seed:  45   Index: 219
+Damcyan                                                                       Seed:  45   Index: 223
+  Optional Steps: 0
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed:  45   Index: 236
+Antlion B1F                                                                   Seed:  45   Index: 236
+  Extra Steps: 10
+  Step  44: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  48: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed:  62   Index:  28
+  Antlion B2F                                                                 Seed:  62   Index:  28
+    Step  40: 16 / Cream x4 (7.552s)
+    Step  50: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  71: 18 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:  62   Index: 108
+Battle: Antlion                                                               Seed:  62   Index: 122
+Antlion's Nest                                                                Seed:  62   Index: 122
+  Step   2: 19 / Turtle x2 (7.464s)
+Antlion B2F Outward Direct                                                    Seed:  62   Index: 137
+  Antlion B2F                                                                 Seed:  62   Index: 137
+Antlion B1F                                                                   Seed:  62   Index: 217
+  Step  15: 20 / Turtle x1, Imp x2 (7.009s)
+  Step  32: 21 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed:  62   Index: 255
+Overworld (Kaipo)                                                             Seed:  62   Index: 255
+  Extra Steps: 12
+  Step   2: 22 / Imp x4 (7.024s)
+  Step  11: 23 / Sandpede x1, Sand Man x2 (7.135s)
+Kaipo Revisited                                                               Seed:  79   Index:  11
+Overworld (Kaipo)                                                             Seed:  79   Index:  11
+Overworld (Damcyan)                                                           Seed:  79   Index:  11
+Mt.Hobs-West                                                                  Seed:  79   Index:  11
+  Step  37: 24 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed:  79   Index:  50
+Battle: MomBomb                                                               Seed:  79   Index:  65
+Mt.Hobs Summit                                                                Seed:  79   Index:  65
+Mt.Hobs-East                                                                  Seed:  79   Index:  71
+Overworld (Fabul)                                                             Seed:  79   Index: 117
+  Step   1: 25 / SwordRat x3, Needler x3 (7.663s)
+  Step  10: 26 / Cocktric x3 (8.241s)
+  Step  78: 27 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  79   Index: 201
+  Optional Steps: 10
+  Extra Steps: 36
+Overworld (Fabul)                                                             Seed:  96   Index:  51
+Fabul Boat and Leviatan                                                       Seed:  96   Index:  58
+Overworld (Mysidia)                                                           Seed:  96   Index:  58
+Mysidia                                                                       Seed:  96   Index:  67
+Overworld (Mysidia)                                                           Seed:  96   Index:  67
+Overworld (Mt.Ordeals)                                                        Seed:  96   Index:  77
+  Step  25: 28 / Raven x1 (8.356s)
+  Step  71: 29 / Raven x1, Cocktric x3 (9.100s)
+Mt.Ordeals                                                                    Seed:  96   Index: 171
+  Step  10: 30 / Spirit x2, Skelton x2 (8.285s)
+  Step  34: 31 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed:  96   Index: 214
+  Step  16: 32 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed:  96   Index: 237
+Mt.Ordeals-3rd station                                                        Seed:  96   Index: 237
+Mt.Ordeals-7th station                                                        Seed:  96   Index: 242
+  Step  31: 33 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 113   Index:  28
+  Optional Steps: 1
+  Step   5: 34 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed: 113   Index:  46
+Mt.Ordeals Summit                                                             Seed: 113   Index:  46
+Paladin                                                                       Seed: 113   Index:  50
+Mt.Ordeals Summit                                                             Seed: 113   Index:  50
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 113   Index:  73
+  Step   9: 35 / Revenant x1, Ghoul x3 (8.489s)
+  Step  41: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 113   Index: 115
+  Step   1: 37 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 113   Index: 145
+  Step  21: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 113   Index: 189
+Take Chocobo to Mysidia                                                       Seed: 113   Index: 202
+Overworld (Mysidia)                                                           Seed: 113   Index: 202
+Town of Baron Serpent Road                                                    Seed: 113   Index: 202
+  Extra Steps: 10
+Credit Warp Fight Search                                                      Seed: 113   Index: 216
+  Overworld (Baron)                                                           Seed: 113   Index: 216
+    Extra Steps: 10
+    Step   2: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  10: 40 / Imp x4 (7.223s)
+   (Step  86: 41 / FloatEye x1, Eagle x2)
+   (Step 130: 42 / Imp x3, SwordRat x1)
+   (Step 152: 43 / Imp x3, SwordRat x1)
+   (Step 200: 44 / Imp x3, SwordRat x1)
+   (Step 248: 45 / Imp x3, SwordRat x1)
+   (Step 255: 46 / Imp x3, SwordRat x1)
+
+Encounter Time:      306.333s
+Other Time:          506.466s
+Total Time:          812.799s
+
+Base Total Time:     873.976s
+Time Saved:          61.177s
+
+Optional Steps:      12
+Extra Steps:         86
+Encounters:          40
+
+Base Encounters:     44
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/029.txt
+++ b/data/routes/cw/029.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	29
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48955370
+VARS	FFFFFFFF:10 E000202:10 E000600:8 E302500:8 E302600:10 E305400:38 E307000:12 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  29   Index:   0
+Overworld (Kaipo)                                                             Seed:  29   Index:   1
+  Step   6: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  29   Index:  37
+Overworld (Kaipo)                                                             Seed:  29   Index:  37
+  Step  15: 2 / SandWorm x1 (7.100s)
+  Step  23: 3 / SandMoth x2, Larva x2 (7.049s)
+  Step  32: 4 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  29   Index:  69
+  Step  23: 5 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  29   Index: 101
+Watery Pass-South B1F                                                         Seed:  29   Index: 101
+Watery Pass-South B2F                                                         Seed:  29   Index: 121
+Watery Pass-South B2F Save Room                                               Seed:  29   Index: 211
+  Extra Steps: 38
+Watery Pass-South B2F                                                         Seed:  29   Index: 253
+  Extra Steps: 12
+  Step  29: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  50: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  46   Index:  48
+  Step  10: 8 / Pike x3 (7.152s)
+  Step  13: 9 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed:  46   Index:  82
+Watery Pass-North B1F                                                         Seed:  46   Index: 103
+  Step  22: 10 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed:  46   Index: 163
+Waterfalls B1F                                                                Seed:  46   Index: 172
+Waterfalls B2F                                                                Seed:  46   Index: 173
+  Step  13: 11 / Mad Toad x4 (7.317s)
+  Step  30: 12 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed:  46   Index: 218
+  Step  18: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed:  46   Index: 255
+Waterfalls Lake                                                               Seed:  46   Index: 255
+Overworld (Kaipo)                                                             Seed:  63   Index:   0
+Overworld (Damcyan)                                                           Seed:  63   Index:  11
+Damcyan                                                                       Seed:  63   Index:  15
+  Optional Steps: 0
+  Extra Steps: 8
+Overworld (Damcyan)                                                           Seed:  63   Index:  30
+Antlion B1F                                                                   Seed:  63   Index:  30
+  Step  38: 14 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Direct                                                     Seed:  63   Index:  68
+  Antlion B2F                                                                 Seed:  63   Index:  68
+    Step  10: 15 / Basilisk x1, Turtle x1 (7.110s)
+    Step  56: 16 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed:  63   Index: 148
+Battle: Antlion                                                               Seed:  63   Index: 162
+Antlion's Nest                                                                Seed:  63   Index: 162
+Antlion B2F Outward Direct                                                    Seed:  63   Index: 177
+  Antlion B2F                                                                 Seed:  63   Index: 177
+    Step  55: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  72: 18 / Basilisk x1, Turtle x1 (7.124s)
+    Step  80: 19 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  80   Index:   1
+  Step   9: 20 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  80   Index:  39
+Overworld (Kaipo)                                                             Seed:  80   Index:  39
+  Extra Steps: 10
+  Step   9: 21 / SandMoth x2, Larva x2 (7.135s)
+Kaipo Revisited                                                               Seed:  80   Index:  49
+Overworld (Kaipo)                                                             Seed:  80   Index:  49
+Overworld (Damcyan)                                                           Seed:  80   Index:  49
+Mt.Hobs-West                                                                  Seed:  80   Index:  49
+Mt.Hobs Summit                                                                Seed:  80   Index:  88
+Battle: MomBomb                                                               Seed:  80   Index: 103
+Mt.Hobs Summit                                                                Seed:  80   Index: 103
+Mt.Hobs-East                                                                  Seed:  80   Index: 109
+  Step   9: 22 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  18: 23 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  31: 24 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed:  80   Index: 155
+  Step  40: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  74: 26 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  80   Index: 239
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  97   Index:  53
+Fabul Boat and Leviatan                                                       Seed:  97   Index:  60
+Overworld (Mysidia)                                                           Seed:  97   Index:  60
+Mysidia                                                                       Seed:  97   Index:  69
+Overworld (Mysidia)                                                           Seed:  97   Index:  69
+Overworld (Mt.Ordeals)                                                        Seed:  97   Index:  79
+  Extra Steps: 8
+  Step  12: 27 / Raven x1 (8.356s)
+  Step  23: 28 / Raven x1 (8.356s)
+  Step  69: 29 / Raven x1, Cocktric x3 (9.100s)
+  Step 102: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  97   Index: 181
+  Step  24: 31 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed:  97   Index: 224
+  Step   6: 32 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed:  97   Index: 247
+Mt.Ordeals-3rd station                                                        Seed:  97   Index: 247
+Mt.Ordeals-7th station                                                        Seed:  97   Index: 252
+  Step  21: 33 / Lilith x1 (8.745s)
+  Step  37: 34 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 114   Index:  38
+  Optional Steps: 1
+  Step  11: 35 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed: 114   Index:  56
+Mt.Ordeals Summit                                                             Seed: 114   Index:  56
+Paladin                                                                       Seed: 114   Index:  60
+Mt.Ordeals Summit                                                             Seed: 114   Index:  60
+  Optional Steps: 1
+  Step  22: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed: 114   Index:  83
+  Step  31: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 114   Index: 125
+Mt.Ordeals                                                                    Seed: 114   Index: 155
+  Step  11: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 114   Index: 199
+Take Chocobo to Mysidia                                                       Seed: 114   Index: 212
+Overworld (Mysidia)                                                           Seed: 114   Index: 212
+Town of Baron Serpent Road                                                    Seed: 114   Index: 212
+Credit Warp Fight Search                                                      Seed: 114   Index: 216
+  Overworld (Baron)                                                           Seed: 114   Index: 216
+    Extra Steps: 10
+    Step   2: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  10: 40 / Imp x4 (7.223s)
+   (Step  86: 41 / FloatEye x1, Eagle x2)
+   (Step 119: 42 / Imp x3, SwordRat x1)
+   (Step 130: 43 / Imp x3, SwordRat x1)
+   (Step 200: 44 / Imp x3, SwordRat x1)
+   (Step 248: 45 / Imp x3, SwordRat x1)
+   (Step 255: 46 / Imp x3, SwordRat x1)
+
+Encounter Time:      308.115s
+Other Time:          506.466s
+Total Time:          814.581s
+
+Base Total Time:     887.953s
+Time Saved:          73.372s
+
+Optional Steps:      12
+Extra Steps:         86
+Encounters:          40
+
+Base Encounters:     46
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/030.txt
+++ b/data/routes/cw/030.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	30
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48891371
+VARS	FFFFFFFF:10 E302500:54 E302600:10 E307400:2 E307700:12 E308700:1 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed:  30   Index:   0
+Overworld (Kaipo)                                                             Seed:  30   Index:   1
+  Step   6: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  30   Index:  37
+Overworld (Kaipo)                                                             Seed:  30   Index:  37
+  Step  15: 2 / SandWorm x1 (7.100s)
+  Step  23: 3 / Sand Man x4 (7.242s)
+  Step  32: 4 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  30   Index:  69
+  Step  23: 5 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  30   Index: 101
+Watery Pass-South B1F                                                         Seed:  30   Index: 101
+Watery Pass-South B2F                                                         Seed:  30   Index: 121
+  Step  67: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  30   Index: 211
+Watery Pass-South B2F                                                         Seed:  30   Index: 215
+  Step  38: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  30   Index: 254
+  Step  28: 8 / Pike x3 (7.152s)
+  Step  29: 9 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed:  47   Index:  32
+  Step  15: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:  47   Index:  53
+  Step   5: 11 / TinyMage x2, WaterHag x4 (8.120s)
+  Step   8: 12 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed:  47   Index: 113
+Waterfalls B1F                                                                Seed:  47   Index: 122
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed:  47   Index: 125
+Waterfalls Lake                                                               Seed:  47   Index: 170
+  Step  16: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed:  47   Index: 207
+Waterfalls Lake                                                               Seed:  47   Index: 207
+Overworld (Kaipo)                                                             Seed:  47   Index: 208
+Overworld (Damcyan)                                                           Seed:  47   Index: 219
+Damcyan                                                                       Seed:  47   Index: 223
+  Optional Steps: 0
+  Extra Steps: 54
+Overworld (Damcyan)                                                           Seed:  64   Index:  28
+Antlion B1F                                                                   Seed:  64   Index:  28
+  Extra Steps: 12
+  Step   2: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  40: 15 / Basilisk x1, Imp x3 (6.775s)
+  Step  50: 16 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed:  64   Index:  78
+  Antlion B2F                                                                 Seed:  64   Index:  78
+    Step  46: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed:  64   Index: 158
+Battle: Antlion                                                               Seed:  64   Index: 172
+Antlion's Nest                                                                Seed:  64   Index: 172
+Antlion B2F Outward Direct                                                    Seed:  64   Index: 187
+  Antlion B2F                                                                 Seed:  64   Index: 187
+    Step  45: 18 / Basilisk x1, Turtle x1 (7.124s)
+    Step  63: 19 / Turtle x2 (7.464s)
+    Step  70: 20 / Turtle x2 (7.464s)
+    Step  79: 21 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed:  81   Index:  11
+  Step  37: 22 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed:  81   Index:  49
+Overworld (Kaipo)                                                             Seed:  81   Index:  49
+Kaipo Revisited                                                               Seed:  81   Index:  49
+Overworld (Kaipo)                                                             Seed:  81   Index:  49
+Overworld (Damcyan)                                                           Seed:  81   Index:  49
+Mt.Hobs-West                                                                  Seed:  81   Index:  49
+Mt.Hobs Summit                                                                Seed:  81   Index:  88
+Battle: MomBomb                                                               Seed:  81   Index: 103
+Mt.Hobs Summit                                                                Seed:  81   Index: 103
+Mt.Hobs-East                                                                  Seed:  81   Index: 109
+  Step   9: 23 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  31: 24 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed:  81   Index: 155
+  Step   2: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  40: 26 / Cocktric x3 (8.241s)
+  Step  74: 27 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  81   Index: 239
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  98   Index:  53
+Fabul Boat and Leviatan                                                       Seed:  98   Index:  60
+Overworld (Mysidia)                                                           Seed:  98   Index:  60
+Mysidia                                                                       Seed:  98   Index:  69
+Overworld (Mysidia)                                                           Seed:  98   Index:  69
+Overworld (Mt.Ordeals)                                                        Seed:  98   Index:  79
+  Step  12: 28 / Raven x1 (8.356s)
+  Step  23: 29 / Raven x1, Cocktric x3 (9.100s)
+  Step  69: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  98   Index: 173
+  Step   8: 31 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed:  98   Index: 216
+  Step  14: 32 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed:  98   Index: 239
+Mt.Ordeals-3rd station                                                        Seed:  98   Index: 239
+Mt.Ordeals-7th station                                                        Seed:  98   Index: 244
+  Step  29: 33 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 115   Index:  30
+  Optional Steps: 1
+  Step   3: 34 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed: 115   Index:  48
+Mt.Ordeals Summit                                                             Seed: 115   Index:  48
+  Step   1: 35 / Revenant x1, Ghoul x3 (8.611s)
+Paladin                                                                       Seed: 115   Index:  52
+Mt.Ordeals Summit                                                             Seed: 115   Index:  52
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 115   Index:  75
+  Step  13: 36 / Revenant x1, Ghoul x3 (8.489s)
+  Step  39: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 115   Index: 117
+Mt.Ordeals                                                                    Seed: 115   Index: 147
+  Step  19: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 115   Index: 191
+Take Chocobo to Mysidia                                                       Seed: 115   Index: 204
+Overworld (Mysidia)                                                           Seed: 115   Index: 204
+Town of Baron Serpent Road                                                    Seed: 115   Index: 204
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed: 115   Index: 216
+  Overworld (Baron)                                                           Seed: 115   Index: 216
+    Extra Steps: 10
+    Step   2: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  10: 40 / Imp x4 (7.223s)
+   (Step  86: 41 / Imp x3, SwordRat x1)
+   (Step 119: 42 / Imp x3, SwordRat x1)
+   (Step 130: 43 / Imp x3, SwordRat x1)
+   (Step 151: 44 / Imp x3, SwordRat x1)
+   (Step 248: 45 / Imp x3, SwordRat x1)
+   (Step 255: 46 / Imp x3, SwordRat x1)
+
+Encounter Time:      307.051s
+Other Time:          506.466s
+Total Time:          813.516s
+
+Base Total Time:     956.374s
+Time Saved:          142.858s
+
+Optional Steps:      12
+Extra Steps:         86
+Encounters:          40
+
+Base Encounters:     49
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/031.txt
+++ b/data/routes/cw/031.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	31
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48500828
+VARS	FFFFFFFF:12 C307801:1 E302500:51 E302600:90 E305400:6 E307200:2 E307B01:38 E307F01:14
+
+Overworld (Kaipo)                                                             Seed:  31   Index:   0
+Overworld (Kaipo)                                                             Seed:  31   Index:   1
+  Step   6: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  31   Index:  37
+Overworld (Kaipo)                                                             Seed:  31   Index:  37
+  Step  15: 2 / SandWorm x1 (7.100s)
+  Step  23: 3 / Sand Man x4 (7.242s)
+  Step  32: 4 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  31   Index:  69
+  Step  23: 5 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  31   Index: 101
+Watery Pass-South B1F                                                         Seed:  31   Index: 101
+Watery Pass-South B2F                                                         Seed:  31   Index: 121
+  Step  67: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  31   Index: 211
+  Extra Steps: 6
+Watery Pass-South B2F                                                         Seed:  31   Index: 221
+Watery Pass-South B3F                                                         Seed:  48   Index:   4
+  Step  23: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed:  48   Index:  38
+  Extra Steps: 2
+  Step   9: 8 / Pike x3 (7.152s)
+  Step  20: 9 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  23: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:  48   Index:  61
+Overworld (Kaipo)                                                             Seed:  48   Index: 121
+Waterfalls B1F                                                                Seed:  48   Index: 130
+Waterfalls B2F                                                                Seed:  48   Index: 131
+Waterfalls Lake                                                               Seed:  48   Index: 176
+  Step  10: 11 / Mad Toad x4 (7.317s)
+Battle: Octomamm                                                              Seed:  48   Index: 213
+Waterfalls Lake                                                               Seed:  48   Index: 213
+Overworld (Kaipo)                                                             Seed:  48   Index: 214
+Overworld (Damcyan)                                                           Seed:  48   Index: 225
+Damcyan                                                                       Seed:  48   Index: 229
+  Optional Steps: 1
+  Extra Steps: 50
+Overworld (Damcyan)                                                           Seed:  65   Index:  31
+Antlion B1F                                                                   Seed:  65   Index:  31
+  Step  37: 12 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed:  65   Index:  69
+  Antlion B2F                                                                 Seed:  65   Index:  69
+    Step   9: 13 / Weeper x2 (7.114s)
+    Step  55: 14 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:  65   Index: 149
+Battle: Antlion                                                               Seed:  65   Index: 163
+Antlion's Nest                                                                Seed:  65   Index: 163
+  Step  15: 15 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B2F Outward Charm Room Steps                                          Seed:  65   Index: 178
+  Antlion B2F                                                                 Seed:  65   Index: 178
+  Antlion B2F Treasure Room                                                   Seed:  65   Index: 229
+    Extra Steps: 38
+  Antlion B2F                                                                 Seed:  82   Index:  11
+Antlion B1F                                                                   Seed:  82   Index:  45
+  Step   3: 16 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  82   Index:  83
+Overworld (Kaipo)                                                             Seed:  82   Index:  83
+Kaipo Revisited                                                               Seed:  82   Index:  83
+Overworld (Kaipo)                                                             Seed:  82   Index:  83
+Overworld (Damcyan)                                                           Seed:  82   Index:  83
+Mt.Hobs-West                                                                  Seed:  82   Index:  83
+  Step  35: 17 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed:  82   Index: 122
+Battle: MomBomb                                                               Seed:  82   Index: 137
+Mt.Hobs Summit                                                                Seed:  82   Index: 137
+  Extra Steps: 14
+  Step   3: 18 / Spirit x2, Skelton x2 (8.237s)
+  Step  20: 19 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed:  82   Index: 157
+  Step  38: 20 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed:  82   Index: 203
+  Step  26: 21 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed:  99   Index:  31
+  Optional Steps: 10
+  Extra Steps: 80
+Overworld (Fabul)                                                             Seed:  99   Index: 181
+Fabul Boat and Leviatan                                                       Seed:  99   Index: 188
+Overworld (Mysidia)                                                           Seed:  99   Index: 188
+Mysidia                                                                       Seed:  99   Index: 197
+Overworld (Mysidia)                                                           Seed:  99   Index: 197
+Overworld (Mt.Ordeals)                                                        Seed:  99   Index: 207
+  Step  10: 22 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  23: 23 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  66: 24 / Raven x1 (8.356s)
+  Step  82: 25 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 116   Index:  45
+  Step   4: 26 / Spirit x3, Soul x1 (8.687s)
+  Step  14: 27 / Spirit x2, Skelton x2 (8.285s)
+  Step  43: 28 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 116   Index:  88
+Recruit Tellah                                                                Seed: 116   Index: 111
+Mt.Ordeals-3rd station                                                        Seed: 116   Index: 111
+Mt.Ordeals-7th station                                                        Seed: 116   Index: 116
+Mt.Ordeals Summit                                                             Seed: 116   Index: 158
+  Optional Steps: 0
+  Step   8: 29 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed: 116   Index: 175
+Mt.Ordeals Summit                                                             Seed: 116   Index: 175
+Paladin                                                                       Seed: 116   Index: 179
+Mt.Ordeals Summit                                                             Seed: 116   Index: 179
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 116   Index: 201
+  Step  17: 30 / Revenant x1, Ghoul x3 (8.489s)
+  Step  25: 31 / Lilith x2 (9.169s)
+Mt.Ordeals-3rd station                                                        Seed: 116   Index: 243
+Mt.Ordeals                                                                    Seed: 133   Index:  17
+  Step  29: 32 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 133   Index:  61
+Take Chocobo to Mysidia                                                       Seed: 133   Index:  74
+Overworld (Mysidia)                                                           Seed: 133   Index:  74
+Town of Baron Serpent Road                                                    Seed: 133   Index:  74
+Credit Warp Fight Search                                                      Seed: 133   Index:  78
+  Overworld (Baron)                                                           Seed: 133   Index:  78
+    Extra Steps: 12
+    Step   1: 33 / Imp x4 (7.223s)
+    Step  12: 34 / Imp x4 (7.223s)
+   (Step  33: 35 / FloatEye x2)
+   (Step 130: 36 / FloatEye x2)
+   (Step 159: 37 / FloatEye x1, Eagle x2)
+   (Step 160: 38 / FloatEye x2)
+   (Step 222: 39 / FloatEye x1, Eagle x2)
+   (Step 223: 40 / Imp x4)
+
+Encounter Time:      264.545s
+Other Time:          542.473s
+Total Time:          807.018s
+
+Base Total Time:     882.473s
+Time Saved:          75.455s
+
+Optional Steps:      11
+Extra Steps:         202
+Encounters:          34
+
+Base Encounters:     45
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/032.txt
+++ b/data/routes/cw/032.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	32
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48881171
+VARS	FFFFFFFF:4 E302500:13 E302600:10 E305400:6 E307700:2 E308700:1 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed:  32   Index:   0
+Overworld (Kaipo)                                                             Seed:  32   Index:   1
+  Step   6: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  32   Index:  37
+Overworld (Kaipo)                                                             Seed:  32   Index:  37
+  Step  15: 2 / SandWorm x1 (7.100s)
+  Step  23: 3 / Sand Man x4 (7.242s)
+  Step  32: 4 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  32   Index:  69
+  Step  23: 5 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  32   Index: 101
+Watery Pass-South B1F                                                         Seed:  32   Index: 101
+Watery Pass-South B2F                                                         Seed:  32   Index: 121
+  Step  20: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  67: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed:  32   Index: 211
+  Extra Steps: 6
+Watery Pass-South B2F                                                         Seed:  32   Index: 221
+Watery Pass-South B3F                                                         Seed:  49   Index:   4
+  Step  23: 8 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed:  49   Index:  38
+  Step   9: 9 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  20: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:  49   Index:  59
+  Step   2: 11 / TinyMage x2, WaterHag x4 (8.120s)
+Overworld (Kaipo)                                                             Seed:  49   Index: 119
+Waterfalls B1F                                                                Seed:  49   Index: 128
+Waterfalls B2F                                                                Seed:  49   Index: 129
+  Step  38: 12 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed:  49   Index: 174
+  Step  12: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed:  49   Index: 211
+Waterfalls Lake                                                               Seed:  49   Index: 211
+Overworld (Kaipo)                                                             Seed:  49   Index: 212
+Overworld (Damcyan)                                                           Seed:  49   Index: 223
+Damcyan                                                                       Seed:  49   Index: 227
+  Optional Steps: 1
+  Extra Steps: 12
+Overworld (Damcyan)                                                           Seed:  49   Index: 247
+Antlion B1F                                                                   Seed:  49   Index: 247
+  Extra Steps: 2
+  Step  37: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  39: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed:  66   Index:  31
+  Antlion B2F                                                                 Seed:  66   Index:  31
+    Step  12: 16 / Cream x4 (7.552s)
+    Step  37: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  47: 18 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed:  66   Index: 111
+  Step  13: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed:  66   Index: 125
+Antlion's Nest                                                                Seed:  66   Index: 125
+Antlion B2F Outward Direct                                                    Seed:  66   Index: 140
+  Antlion B2F                                                                 Seed:  66   Index: 140
+    Step  38: 20 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  66   Index: 220
+  Step  30: 21 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed:  83   Index:   2
+Overworld (Kaipo)                                                             Seed:  83   Index:   2
+Kaipo Revisited                                                               Seed:  83   Index:   2
+Overworld (Kaipo)                                                             Seed:  83   Index:   2
+Overworld (Damcyan)                                                           Seed:  83   Index:   2
+Mt.Hobs-West                                                                  Seed:  83   Index:   2
+  Step   6: 22 / Bomb x3 (8.832s)
+  Step   8: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed:  83   Index:  41
+Battle: MomBomb                                                               Seed:  83   Index:  56
+Mt.Hobs Summit                                                                Seed:  83   Index:  56
+Mt.Hobs-East                                                                  Seed:  83   Index:  62
+  Step  23: 24 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed:  83   Index: 108
+  Step  10: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  32: 26 / Cocktric x3 (8.241s)
+  Step  49: 27 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  83   Index: 192
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 100   Index:   6
+Fabul Boat and Leviatan                                                       Seed: 100   Index:  13
+Overworld (Mysidia)                                                           Seed: 100   Index:  13
+Mysidia                                                                       Seed: 100   Index:  22
+Overworld (Mysidia)                                                           Seed: 100   Index:  22
+Overworld (Mt.Ordeals)                                                        Seed: 100   Index:  32
+  Step   7: 28 / Raven x1 (8.356s)
+  Step  18: 29 / Raven x1 (8.356s)
+  Step  19: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  59: 31 / Raven x1 (8.356s)
+  Step  70: 32 / Raven x1 (8.356s)
+  Step  83: 33 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed: 100   Index: 126
+  Step  22: 34 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 100   Index: 169
+  Step  12: 35 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed: 100   Index: 192
+Mt.Ordeals-3rd station                                                        Seed: 100   Index: 192
+Mt.Ordeals-7th station                                                        Seed: 100   Index: 197
+  Step  20: 36 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 100   Index: 239
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 117   Index:   1
+Mt.Ordeals Summit                                                             Seed: 117   Index:   1
+Paladin                                                                       Seed: 117   Index:   5
+Mt.Ordeals Summit                                                             Seed: 117   Index:   5
+  Optional Steps: 1
+  Step  12: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 117   Index:  28
+  Step  21: 38 / Revenant x1, Ghoul x3 (8.489s)
+  Step  31: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 117   Index:  70
+  Step  18: 40 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 117   Index: 100
+Overworld (Mt.Ordeals)                                                        Seed: 117   Index: 144
+Take Chocobo to Mysidia                                                       Seed: 117   Index: 157
+Overworld (Mysidia)                                                           Seed: 117   Index: 157
+Town of Baron Serpent Road                                                    Seed: 117   Index: 157
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed: 117   Index: 165
+  Overworld (Baron)                                                           Seed: 117   Index: 165
+    Extra Steps: 4
+    Step   1: 41 / Imp x3, SwordRat x1 (7.227s)
+    Step   4: 42 / Imp x3, SwordRat x1 (7.227s)
+   (Step  61: 43 / Imp x3, SwordRat x1)
+   (Step 137: 44 / Imp x6)
+   (Step 170: 45 / Eagle x3)
+   (Step 181: 46 / Eagle x3)
+   (Step 202: 47 / Eagle x3)
+
+Encounter Time:      323.919s
+Other Time:          489.427s
+Total Time:          813.347s
+
+Base Total Time:     972.724s
+Time Saved:          159.377s
+
+Optional Steps:      13
+Extra Steps:         28
+Encounters:          42
+
+Base Encounters:     49
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/033.txt
+++ b/data/routes/cw/033.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	33
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48445922
+VARS	FFFFFFFF:12 C307801:1 E000202:2 E302500:7 E302600:66 E305400:26 E307000:4 E307400:34 E307B01:26 E308000:4 E308700:1 E308702:1 E309700:30
+
+Overworld (Kaipo)                                                             Seed:  33   Index:   0
+Overworld (Kaipo)                                                             Seed:  33   Index:   1
+  Step   6: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  33   Index:  37
+Overworld (Kaipo)                                                             Seed:  33   Index:  37
+  Step  23: 2 / SandWorm x1 (7.100s)
+  Step  32: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  33   Index:  69
+  Step  23: 4 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed:  33   Index: 101
+Watery Pass-South B1F                                                         Seed:  33   Index: 101
+Watery Pass-South B2F                                                         Seed:  33   Index: 121
+  Step  20: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  67: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  33   Index: 211
+  Extra Steps: 26
+Watery Pass-South B2F                                                         Seed:  33   Index: 241
+  Extra Steps: 4
+  Step  42: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  50   Index:  28
+  Step  26: 8 / Pike x3 (7.152s)
+  Step  30: 9 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  33: 10 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed:  50   Index:  62
+Watery Pass-North B1F                                                         Seed:  50   Index:  83
+Overworld (Kaipo)                                                             Seed:  50   Index: 143
+Waterfalls B1F                                                                Seed:  50   Index: 152
+  Extra Steps: 34
+Waterfalls B2F                                                                Seed:  50   Index: 187
+Waterfalls Lake                                                               Seed:  50   Index: 232
+  Step  14: 11 / Mad Toad x4 (7.317s)
+Battle: Octomamm                                                              Seed:  67   Index:  13
+Waterfalls Lake                                                               Seed:  67   Index:  13
+Overworld (Kaipo)                                                             Seed:  67   Index:  14
+Overworld (Damcyan)                                                           Seed:  67   Index:  25
+  Step   3: 12 / SandWorm x1, Sandpede x1 (7.206s)
+Damcyan                                                                       Seed:  67   Index:  29
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed:  67   Index:  43
+Antlion B1F                                                                   Seed:  67   Index:  43
+  Step  25: 13 / Turtle x2 (7.487s)
+  Step  35: 14 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Direct                                                     Seed:  67   Index:  81
+  Antlion B2F                                                                 Seed:  67   Index:  81
+    Step  72: 15 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:  67   Index: 161
+Battle: Antlion                                                               Seed:  67   Index: 175
+Antlion's Nest                                                                Seed:  67   Index: 175
+  Step   3: 16 / Cream x4 (7.523s)
+Antlion B2F Outward Charm Room Steps                                          Seed:  67   Index: 190
+  Antlion B2F                                                                 Seed:  67   Index: 190
+  Antlion B2F Treasure Room                                                   Seed:  67   Index: 241
+    Extra Steps: 26
+  Antlion B2F                                                                 Seed:  84   Index:  11
+Antlion B1F                                                                   Seed:  84   Index:  45
+Overworld (Damcyan)                                                           Seed:  84   Index:  83
+Overworld (Kaipo)                                                             Seed:  84   Index:  83
+  Extra Steps: 2
+  Step   2: 17 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed:  84   Index:  85
+Overworld (Kaipo)                                                             Seed:  84   Index:  85
+Overworld (Damcyan)                                                           Seed:  84   Index:  85
+Mt.Hobs-West                                                                  Seed:  84   Index:  85
+  Step  32: 18 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed:  84   Index: 124
+Battle: MomBomb                                                               Seed:  84   Index: 139
+Mt.Hobs Summit                                                                Seed:  84   Index: 139
+  Step   1: 19 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed:  84   Index: 145
+  Extra Steps: 4
+  Step  12: 20 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  50: 21 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  84   Index: 195
+  Step  34: 22 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 101   Index:  23
+  Optional Steps: 10
+  Extra Steps: 56
+Overworld (Fabul)                                                             Seed: 101   Index: 149
+Fabul Boat and Leviatan                                                       Seed: 101   Index: 156
+Overworld (Mysidia)                                                           Seed: 101   Index: 156
+Mysidia                                                                       Seed: 101   Index: 165
+Overworld (Mysidia)                                                           Seed: 101   Index: 165
+Overworld (Mt.Ordeals)                                                        Seed: 101   Index: 175
+  Step   6: 23 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  42: 24 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 118   Index:  13
+  Step   4: 25 / Spirit x2, Skelton x2 (8.285s)
+  Step  36: 26 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 118   Index:  56
+  Step   3: 27 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed: 118   Index:  79
+Mt.Ordeals-3rd station                                                        Seed: 118   Index:  79
+Mt.Ordeals-7th station                                                        Seed: 118   Index:  84
+  Step   4: 28 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 118   Index: 126
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 118   Index: 144
+Mt.Ordeals Summit                                                             Seed: 118   Index: 144
+Paladin                                                                       Seed: 118   Index: 148
+Mt.Ordeals Summit                                                             Seed: 118   Index: 148
+  Optional Steps: 1
+  Step  18: 29 / Ghoul x2, Soul x2 (8.971s)
+  Step  21: 30 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed: 118   Index: 171
+  Step   6: 31 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 118   Index: 213
+  Step  13: 32 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 118   Index: 243
+Overworld (Mt.Ordeals)                                                        Seed: 135   Index:  31
+Take Chocobo to Mysidia                                                       Seed: 135   Index:  44
+Overworld (Mysidia)                                                           Seed: 135   Index:  44
+Town of Baron Serpent Road                                                    Seed: 135   Index:  44
+  Extra Steps: 30
+Credit Warp Fight Search                                                      Seed: 135   Index:  78
+  Overworld (Baron)                                                           Seed: 135   Index:  78
+    Extra Steps: 12
+    Step   1: 33 / Imp x3, SwordRat x1 (7.227s)
+    Step  12: 34 / Imp x4 (7.223s)
+   (Step  33: 35 / FloatEye x1, Eagle x2)
+   (Step  90: 36 / FloatEye x2)
+   (Step 120: 37 / FloatEye x1, Eagle x2)
+   (Step 159: 38 / FloatEye x2)
+   (Step 160: 39 / FloatEye x1, Eagle x2)
+   (Step 203: 40 / Imp x4)
+   (Step 222: 41 / Imp x3, SwordRat x1)
+   (Step 223: 42 / Imp x3, SwordRat x1)
+
+Encounter Time:      264.164s
+Other Time:          541.941s
+Total Time:          806.104s
+
+Base Total Time:     981.803s
+Time Saved:          175.698s
+
+Optional Steps:      13
+Extra Steps:         200
+Encounters:          34
+
+Base Encounters:     49
+Encounters Saved:    15
+
+Number of Variables: 54

--- a/data/routes/cw/034.txt
+++ b/data/routes/cw/034.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	34
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47777464
+VARS	FFFFFFFF:10 C307801:1 E000202:2 E000501:8 E302500:27 E302600:57 E305400:26 E307400:18 E307900:4 E307B01:22 E307F01:12 E308700:1 E308701:14 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  34   Index:   0
+Overworld (Kaipo)                                                             Seed:  34   Index:   1
+  Step   6: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  34   Index:  37
+Overworld (Kaipo)                                                             Seed:  34   Index:  37
+  Step  32: 2 / SandWorm x1 (7.100s)
+Watery Pass-South B1F                                                         Seed:  34   Index:  69
+Recruit Tellah                                                                Seed:  34   Index: 101
+Watery Pass-South B1F                                                         Seed:  34   Index: 101
+  Step  20: 3 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed:  34   Index: 121
+  Step  20: 4 / CaveToad x3 (7.014s)
+  Step  67: 5 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  34   Index: 211
+  Extra Steps: 26
+Watery Pass-South B2F                                                         Seed:  34   Index: 241
+Watery Pass-South B3F                                                         Seed:  51   Index:  24
+  Step   3: 6 / Zombie x4 (7.148s)
+  Step  30: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed:  51   Index:  58
+  Step   3: 8 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed:  51   Index:  79
+  Step  10: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Overworld (Kaipo)                                                             Seed:  51   Index: 139
+Waterfalls B1F                                                                Seed:  51   Index: 148
+  Extra Steps: 18
+Waterfalls B2F                                                                Seed:  51   Index: 167
+  Step  19: 10 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed:  51   Index: 212
+  Step  34: 11 / Mad Toad x4 (7.317s)
+Battle: Octomamm                                                              Seed:  51   Index: 249
+Waterfalls Lake                                                               Seed:  51   Index: 249
+Overworld (Kaipo)                                                             Seed:  51   Index: 250
+Overworld (Damcyan)                                                           Seed:  68   Index:   5
+Damcyan                                                                       Seed:  68   Index:   9
+  Optional Steps: 1
+  Extra Steps: 26
+Overworld (Damcyan)                                                           Seed:  68   Index:  43
+Antlion B1F                                                                   Seed:  68   Index:  43
+  Step  35: 12 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed:  68   Index:  81
+  Antlion B2F                                                                 Seed:  68   Index:  81
+    Step  38: 13 / Weeper x2 (7.114s)
+    Step  72: 14 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:  68   Index: 161
+  Extra Steps: 4
+  Step  17: 15 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed:  68   Index: 179
+Antlion's Nest                                                                Seed:  68   Index: 179
+Antlion B2F Outward Charm Room Steps                                          Seed:  68   Index: 194
+  Antlion B2F                                                                 Seed:  68   Index: 194
+  Antlion B2F Treasure Room                                                   Seed:  68   Index: 245
+    Extra Steps: 22
+  Antlion B2F                                                                 Seed:  85   Index:  11
+Antlion B1F                                                                   Seed:  85   Index:  45
+  Step  31: 16 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  85   Index:  83
+Overworld (Kaipo)                                                             Seed:  85   Index:  83
+  Extra Steps: 2
+  Step   2: 17 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed:  85   Index:  85
+Overworld (Kaipo)                                                             Seed:  85   Index:  85
+Overworld (Damcyan)                                                           Seed:  85   Index:  85
+Mt.Hobs-West                                                                  Seed:  85   Index:  85
+  Step  32: 18 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed:  85   Index: 124
+Battle: MomBomb                                                               Seed:  85   Index: 139
+Mt.Hobs Summit                                                                Seed:  85   Index: 139
+  Extra Steps: 12
+  Step   1: 19 / Skelton x4 (7.819s)
+  Step  18: 20 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed:  85   Index: 157
+Overworld (Fabul)                                                             Seed:  85   Index: 203
+  Step  26: 21 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 102   Index:  31
+  Optional Steps: 9
+  Extra Steps: 48
+Overworld (Fabul)                                                             Seed: 102   Index: 148
+Fabul Boat and Leviatan                                                       Seed: 102   Index: 155
+Overworld (Mysidia)                                                           Seed: 102   Index: 155
+Mysidia                                                                       Seed: 102   Index: 164
+Overworld (Mysidia)                                                           Seed: 102   Index: 164
+  Extra Steps: 8
+Overworld (Mt.Ordeals)                                                        Seed: 102   Index: 182
+  Step  35: 22 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  53: 23 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  91: 24 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed: 119   Index:  20
+  Step  29: 25 / Spirit x2, Skelton x2 (8.285s)
+  Step  39: 26 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed: 119   Index:  63
+Recruit Tellah                                                                Seed: 119   Index:  86
+Mt.Ordeals-3rd station                                                        Seed: 119   Index:  86
+  Step   2: 27 / Ghoul x1, Red Bone x2, Skelton x2 (8.832s)
+Mt.Ordeals-7th station                                                        Seed: 119   Index:  91
+Mt.Ordeals Summit                                                             Seed: 119   Index: 133
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 119   Index: 151
+Mt.Ordeals Summit                                                             Seed: 119   Index: 151
+  Extra Steps: 14
+  Step  15: 28 / Ghoul x2, Soul x2 (8.941s)
+  Step  18: 29 / Ghoul x2, Soul x2 (8.941s)
+Paladin                                                                       Seed: 119   Index: 169
+Mt.Ordeals Summit                                                             Seed: 119   Index: 169
+  Optional Steps: 1
+  Step   8: 30 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed: 119   Index: 192
+  Step  17: 31 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 119   Index: 234
+Mt.Ordeals                                                                    Seed: 136   Index:   8
+Overworld (Mt.Ordeals)                                                        Seed: 136   Index:  52
+Take Chocobo to Mysidia                                                       Seed: 136   Index:  65
+Overworld (Mysidia)                                                           Seed: 136   Index:  65
+Town of Baron Serpent Road                                                    Seed: 136   Index:  65
+Credit Warp Fight Search                                                      Seed: 136   Index:  69
+  Overworld (Baron)                                                           Seed: 136   Index:  69
+    Extra Steps: 10
+    Step   2: 32 / Imp x3 (7.174s)
+    Step  10: 33 / Imp x3, SwordRat x1 (7.227s)
+   (Step  21: 34 / Imp x4)
+   (Step  42: 35 / FloatEye x1, Eagle x2)
+   (Step  99: 36 / FloatEye x2)
+   (Step 129: 37 / FloatEye x1, Eagle x2)
+   (Step 169: 38 / FloatEye x2)
+   (Step 212: 39 / FloatEye x1, Eagle x2)
+   (Step 231: 40 / Imp x4)
+
+Encounter Time:      256.236s
+Other Time:          538.746s
+Total Time:          794.982s
+
+Base Total Time:     978.885s
+Time Saved:          183.904s
+
+Optional Steps:      12
+Extra Steps:         190
+Encounters:          33
+
+Base Encounters:     49
+Encounters Saved:    16
+
+Number of Variables: 54

--- a/data/routes/cw/035.txt
+++ b/data/routes/cw/035.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	35
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49176785
+VARS	FFFFFFFF:10 E302600:18 E305400:6 E307200:2 E307400:12 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  35   Index:   0
+Overworld (Kaipo)                                                             Seed:  35   Index:   1
+  Step   6: 1 / Sand Man x4 (7.172s)
+  Step  30: 2 / SandWorm x1 (6.973s)
+Kaipo                                                                         Seed:  35   Index:  37
+Overworld (Kaipo)                                                             Seed:  35   Index:  37
+  Step  32: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  35   Index:  69
+Recruit Tellah                                                                Seed:  35   Index: 101
+Watery Pass-South B1F                                                         Seed:  35   Index: 101
+  Step  20: 4 / CaveToad x3 (7.014s)
+Watery Pass-South B2F                                                         Seed:  35   Index: 121
+  Step  20: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  67: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  35   Index: 211
+  Extra Steps: 6
+Watery Pass-South B2F                                                         Seed:  35   Index: 221
+  Step  20: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  52   Index:   4
+  Step  23: 8 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed:  52   Index:  38
+  Extra Steps: 2
+  Step  16: 9 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  23: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:  52   Index:  61
+  Step  28: 11 / TinyMage x2, WaterHag x4 (8.120s)
+Overworld (Kaipo)                                                             Seed:  52   Index: 121
+Waterfalls B1F                                                                Seed:  52   Index: 130
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed:  52   Index: 143
+  Step  24: 12 / Zombie x6 (7.489s)
+  Step  43: 13 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed:  52   Index: 188
+Battle: Octomamm                                                              Seed:  52   Index: 225
+Waterfalls Lake                                                               Seed:  52   Index: 225
+Overworld (Kaipo)                                                             Seed:  52   Index: 226
+Overworld (Damcyan)                                                           Seed:  52   Index: 237
+Damcyan                                                                       Seed:  52   Index: 241
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  52   Index: 248
+Antlion B1F                                                                   Seed:  52   Index: 248
+  Step  36: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  38: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed:  69   Index:  30
+  Antlion B2F                                                                 Seed:  69   Index:  30
+    Step  13: 16 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed:  69   Index: 110
+  Step   9: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed:  69   Index: 124
+Antlion's Nest                                                                Seed:  69   Index: 124
+Antlion B2F Outward Direct                                                    Seed:  69   Index: 139
+  Antlion B2F                                                                 Seed:  69   Index: 139
+    Step  14: 18 / Weeper x2 (7.132s)
+    Step  39: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  69   Index: 219
+  Step  12: 20 / Cream x4 (7.523s)
+  Step  31: 21 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed:  86   Index:   1
+Overworld (Kaipo)                                                             Seed:  86   Index:   1
+Kaipo Revisited                                                               Seed:  86   Index:   1
+Overworld (Kaipo)                                                             Seed:  86   Index:   1
+Overworld (Damcyan)                                                           Seed:  86   Index:   1
+Mt.Hobs-West                                                                  Seed:  86   Index:   1
+  Step   7: 22 / Bomb x3 (8.832s)
+  Step  31: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed:  86   Index:  40
+Battle: MomBomb                                                               Seed:  86   Index:  55
+Mt.Hobs Summit                                                                Seed:  86   Index:  55
+Mt.Hobs-East                                                                  Seed:  86   Index:  61
+  Step  15: 24 / Turtle x2 (7.432s)
+  Step  24: 25 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:  86   Index: 107
+  Step  10: 26 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  33: 27 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  50: 28 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  86   Index: 191
+  Optional Steps: 10
+  Extra Steps: 8
+Overworld (Fabul)                                                             Seed: 103   Index:  13
+Fabul Boat and Leviatan                                                       Seed: 103   Index:  20
+Overworld (Mysidia)                                                           Seed: 103   Index:  20
+Mysidia                                                                       Seed: 103   Index:  29
+Overworld (Mysidia)                                                           Seed: 103   Index:  29
+Overworld (Mt.Ordeals)                                                        Seed: 103   Index:  39
+  Step  12: 29 / Raven x1 (8.356s)
+  Step  52: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  63: 31 / Raven x1 (8.356s)
+  Step  76: 32 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 103   Index: 133
+  Step  14: 33 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed: 103   Index: 176
+Recruit Tellah                                                                Seed: 103   Index: 199
+Mt.Ordeals-3rd station                                                        Seed: 103   Index: 199
+Mt.Ordeals-7th station                                                        Seed: 103   Index: 204
+  Step  13: 34 / Lilith x1 (8.745s)
+  Step  31: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 103   Index: 246
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 120   Index:   7
+Mt.Ordeals Summit                                                             Seed: 120   Index:   7
+Paladin                                                                       Seed: 120   Index:  11
+Mt.Ordeals Summit                                                             Seed: 120   Index:  11
+  Optional Steps: 1
+  Step   6: 36 / Revenant x1, Ghoul x3 (8.489s)
+  Step  12: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 120   Index:  34
+  Step  15: 38 / Revenant x1, Ghoul x3 (8.489s)
+  Step  25: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 120   Index:  76
+  Step  12: 40 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 120   Index: 106
+Overworld (Mt.Ordeals)                                                        Seed: 120   Index: 150
+Take Chocobo to Mysidia                                                       Seed: 120   Index: 163
+Overworld (Mysidia)                                                           Seed: 120   Index: 163
+Town of Baron Serpent Road                                                    Seed: 120   Index: 163
+Credit Warp Fight Search                                                      Seed: 120   Index: 167
+  Overworld (Baron)                                                           Seed: 120   Index: 167
+    Extra Steps: 10
+    Step   2: 41 / Imp x3, SwordRat x1 (7.227s)
+    Step  10: 42 / Imp x3, SwordRat x1 (7.227s)
+   (Step  42: 43 / Imp x3, SwordRat x1)
+   (Step 103: 44 / Imp x3)
+   (Step 160: 45 / Eagle x3)
+   (Step 168: 46 / Eagle x3)
+   (Step 200: 47 / Eagle x3)
+
+Encounter Time:      324.579s
+Other Time:          493.687s
+Total Time:          818.265s
+
+Base Total Time:     943.435s
+Time Saved:          125.170s
+
+Optional Steps:      11
+Extra Steps:         38
+Encounters:          42
+
+Base Encounters:     49
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/036.txt
+++ b/data/routes/cw/036.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	36
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49406115
+VARS	FFFFFFFF:10 C307800:1 E302500:1 E302600:4 E305400:6 E307400:14 E307B00:8 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  36   Index:   0
+Overworld (Kaipo)                                                             Seed:  36   Index:   1
+  Step   6: 1 / Sand Man x4 (7.172s)
+  Step  30: 2 / SandWorm x1 (6.973s)
+Kaipo                                                                         Seed:  36   Index:  37
+Overworld (Kaipo)                                                             Seed:  36   Index:  37
+Watery Pass-South B1F                                                         Seed:  36   Index:  69
+Recruit Tellah                                                                Seed:  36   Index: 101
+Watery Pass-South B1F                                                         Seed:  36   Index: 101
+  Step  20: 3 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed:  36   Index: 121
+  Step   2: 4 / CaveToad x3 (7.014s)
+  Step  20: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  67: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  36   Index: 211
+  Extra Steps: 6
+Watery Pass-South B2F                                                         Seed:  36   Index: 221
+  Step  20: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  53   Index:   4
+  Step  11: 8 / CaveToad x3 (7.014s)
+  Step  23: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed:  53   Index:  38
+  Step  16: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:  53   Index:  59
+  Step  30: 11 / TinyMage x2, WaterHag x4 (8.120s)
+Overworld (Kaipo)                                                             Seed:  53   Index: 119
+Waterfalls B1F                                                                Seed:  53   Index: 128
+  Extra Steps: 14
+Waterfalls B2F                                                                Seed:  53   Index: 143
+  Step  24: 12 / Zombie x6 (7.489s)
+  Step  43: 13 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed:  53   Index: 188
+Battle: Octomamm                                                              Seed:  53   Index: 225
+Waterfalls Lake                                                               Seed:  53   Index: 225
+Overworld (Kaipo)                                                             Seed:  53   Index: 226
+Overworld (Damcyan)                                                           Seed:  53   Index: 237
+Damcyan                                                                       Seed:  53   Index: 241
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  53   Index: 249
+Antlion B1F                                                                   Seed:  53   Index: 249
+  Step  37: 14 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Charm Room Steps                                           Seed:  70   Index:  31
+  Antlion B2F                                                                 Seed:  70   Index:  31
+    Step  12: 15 / Basilisk x1, Turtle x1 (7.110s)
+  Antlion B2F Treasure Room                                                   Seed:  70   Index:  64
+    Extra Steps: 8
+  Antlion B2F                                                                 Seed:  70   Index:  72
+    Step  47: 16 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed:  70   Index: 124
+Battle: Antlion                                                               Seed:  70   Index: 138
+Antlion's Nest                                                                Seed:  70   Index: 138
+  Step  15: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed:  70   Index: 153
+  Antlion B2F                                                                 Seed:  70   Index: 153
+    Step  25: 18 / Weeper x2 (7.132s)
+    Step  78: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  70   Index: 233
+  Step  17: 20 / Cream x4 (7.523s)
+  Step  31: 21 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed:  87   Index:  15
+Overworld (Kaipo)                                                             Seed:  87   Index:  15
+Kaipo Revisited                                                               Seed:  87   Index:  15
+Overworld (Kaipo)                                                             Seed:  87   Index:  15
+Overworld (Damcyan)                                                           Seed:  87   Index:  15
+Mt.Hobs-West                                                                  Seed:  87   Index:  15
+  Step  17: 22 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed:  87   Index:  54
+Battle: MomBomb                                                               Seed:  87   Index:  69
+Mt.Hobs Summit                                                                Seed:  87   Index:  69
+Mt.Hobs-East                                                                  Seed:  87   Index:  75
+  Step   1: 23 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  10: 24 / Turtle x2 (7.432s)
+  Step  42: 25 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:  87   Index: 121
+  Step  19: 26 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  36: 27 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  87   Index: 205
+  Optional Steps: 4
+Overworld (Fabul)                                                             Seed: 104   Index:  13
+Fabul Boat and Leviatan                                                       Seed: 104   Index:  20
+Overworld (Mysidia)                                                           Seed: 104   Index:  20
+Mysidia                                                                       Seed: 104   Index:  29
+Overworld (Mysidia)                                                           Seed: 104   Index:  29
+Overworld (Mt.Ordeals)                                                        Seed: 104   Index:  39
+  Step  12: 28 / Raven x1 (8.356s)
+  Step  23: 29 / Raven x1 (8.356s)
+  Step  52: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  63: 31 / Raven x1 (8.356s)
+  Step  76: 32 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 104   Index: 133
+  Step  14: 33 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed: 104   Index: 176
+Recruit Tellah                                                                Seed: 104   Index: 199
+Mt.Ordeals-3rd station                                                        Seed: 104   Index: 199
+Mt.Ordeals-7th station                                                        Seed: 104   Index: 204
+  Step  13: 34 / Lilith x1 (8.745s)
+  Step  31: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 104   Index: 246
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 121   Index:   7
+Mt.Ordeals Summit                                                             Seed: 121   Index:   7
+Paladin                                                                       Seed: 121   Index:  11
+Mt.Ordeals Summit                                                             Seed: 121   Index:  11
+  Optional Steps: 1
+  Step  12: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed: 121   Index:  34
+  Step  15: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  25: 38 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 121   Index:  76
+  Step  12: 39 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 121   Index: 106
+Overworld (Mt.Ordeals)                                                        Seed: 121   Index: 150
+  Step   5: 40 / Needler x2, SwordRat x2 (8.094s)
+Take Chocobo to Mysidia                                                       Seed: 121   Index: 163
+Overworld (Mysidia)                                                           Seed: 121   Index: 163
+Town of Baron Serpent Road                                                    Seed: 121   Index: 163
+Credit Warp Fight Search                                                      Seed: 121   Index: 167
+  Overworld (Baron)                                                           Seed: 121   Index: 167
+    Extra Steps: 10
+    Step   2: 41 / Imp x3, SwordRat x1 (7.227s)
+    Step  10: 42 / Imp x3, SwordRat x1 (7.227s)
+   (Step  42: 43 / Imp x3, SwordRat x1)
+   (Step 103: 44 / Imp x3)
+   (Step 160: 45 / Eagle x3)
+   (Step 200: 46 / Eagle x3)
+
+Encounter Time:      323.802s
+Other Time:          498.279s
+Total Time:          822.081s
+
+Base Total Time:     939.630s
+Time Saved:          117.549s
+
+Optional Steps:      6
+Extra Steps:         38
+Encounters:          42
+
+Base Encounters:     49
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/037.txt
+++ b/data/routes/cw/037.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	37
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48832184
+VARS	FFFFFFFF:10 C307800:1 E305400:6 E307400:14 E307B00:14
+
+Overworld (Kaipo)                                                             Seed:  37   Index:   0
+Overworld (Kaipo)                                                             Seed:  37   Index:   1
+  Step  30: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  37   Index:  37
+Overworld (Kaipo)                                                             Seed:  37   Index:  37
+Watery Pass-South B1F                                                         Seed:  37   Index:  69
+  Step  25: 2 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:  37   Index: 101
+Watery Pass-South B1F                                                         Seed:  37   Index: 101
+  Step  20: 3 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed:  37   Index: 121
+  Step   2: 4 / CaveToad x3 (7.014s)
+  Step  20: 5 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  37   Index: 211
+  Extra Steps: 6
+Watery Pass-South B2F                                                         Seed:  37   Index: 221
+  Step  20: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed:  54   Index:   4
+  Step  11: 7 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed:  54   Index:  38
+  Step  15: 8 / CaveToad x3 (7.014s)
+  Step  16: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B1F                                                         Seed:  54   Index:  59
+  Step  30: 10 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed:  54   Index: 119
+Waterfalls B1F                                                                Seed:  54   Index: 128
+  Extra Steps: 14
+Waterfalls B2F                                                                Seed:  54   Index: 143
+  Step  24: 11 / TinyMage x4 (7.558s)
+Waterfalls Lake                                                               Seed:  54   Index: 188
+Battle: Octomamm                                                              Seed:  54   Index: 225
+Waterfalls Lake                                                               Seed:  54   Index: 225
+Overworld (Kaipo)                                                             Seed:  54   Index: 226
+Overworld (Damcyan)                                                           Seed:  54   Index: 237
+Damcyan                                                                       Seed:  54   Index: 241
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  54   Index: 248
+Antlion B1F                                                                   Seed:  54   Index: 248
+Antlion B2F Inward Charm Room Steps                                           Seed:  71   Index:  30
+  Antlion B2F                                                                 Seed:  71   Index:  30
+    Step  13: 12 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+  Antlion B2F Treasure Room                                                   Seed:  71   Index:  63
+    Extra Steps: 14
+  Antlion B2F                                                                 Seed:  71   Index:  77
+    Step  42: 13 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed:  71   Index: 129
+Battle: Antlion                                                               Seed:  71   Index: 143
+Antlion's Nest                                                                Seed:  71   Index: 143
+  Step  10: 14 / Basilisk x1, Imp x3 (6.783s)
+Antlion B2F Outward Direct                                                    Seed:  71   Index: 158
+  Antlion B2F                                                                 Seed:  71   Index: 158
+    Step  20: 15 / Basilisk x1, Turtle x1 (7.124s)
+    Step  73: 16 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed:  71   Index: 238
+  Step  12: 17 / Cream x4 (7.523s)
+  Step  26: 18 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed:  88   Index:  20
+Overworld (Kaipo)                                                             Seed:  88   Index:  20
+Kaipo Revisited                                                               Seed:  88   Index:  20
+Overworld (Kaipo)                                                             Seed:  88   Index:  20
+Overworld (Damcyan)                                                           Seed:  88   Index:  20
+Mt.Hobs-West                                                                  Seed:  88   Index:  20
+  Step  12: 19 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed:  88   Index:  59
+Battle: MomBomb                                                               Seed:  88   Index:  74
+Mt.Hobs Summit                                                                Seed:  88   Index:  74
+  Step   2: 20 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed:  88   Index:  80
+  Step   5: 21 / Gargoyle x2 (7.630s)
+  Step  37: 22 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed:  88   Index: 126
+  Step  14: 23 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  31: 24 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed:  88   Index: 210
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 105   Index:  14
+Fabul Boat and Leviatan                                                       Seed: 105   Index:  21
+Overworld (Mysidia)                                                           Seed: 105   Index:  21
+Mysidia                                                                       Seed: 105   Index:  30
+Overworld (Mysidia)                                                           Seed: 105   Index:  30
+Overworld (Mt.Ordeals)                                                        Seed: 105   Index:  40
+  Step  11: 25 / Raven x1 (8.356s)
+  Step  22: 26 / Raven x1 (8.356s)
+  Step  51: 27 / Raven x1 (8.356s)
+  Step  62: 28 / Raven x1 (8.356s)
+  Step  75: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 105   Index: 134
+  Step   2: 30 / Red Bone x1, Skelton x3 (8.067s)
+  Step  13: 31 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 105   Index: 177
+Recruit Tellah                                                                Seed: 105   Index: 200
+Mt.Ordeals-3rd station                                                        Seed: 105   Index: 200
+Mt.Ordeals-7th station                                                        Seed: 105   Index: 205
+  Step  12: 32 / Ghoul x2, Soul x2 (9.197s)
+  Step  30: 33 / Soul x3, Ghoul x1, Revenant x1 (9.933s)
+Mt.Ordeals Summit                                                             Seed: 105   Index: 247
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 122   Index:   8
+Mt.Ordeals Summit                                                             Seed: 122   Index:   8
+Paladin                                                                       Seed: 122   Index:  12
+Mt.Ordeals Summit                                                             Seed: 122   Index:  12
+  Optional Steps: 0
+  Step  11: 34 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed: 122   Index:  34
+  Step  25: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 122   Index:  76
+  Step  10: 36 / Spirit x2, Soul x2, Red Bone x2 (9.471s)
+  Step  12: 37 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 122   Index: 106
+Overworld (Mt.Ordeals)                                                        Seed: 122   Index: 150
+  Step   5: 38 / SwordRat x2, Imp x2, TinyMage x2 (7.453s)
+Take Chocobo to Mysidia                                                       Seed: 122   Index: 163
+Overworld (Mysidia)                                                           Seed: 122   Index: 163
+Town of Baron Serpent Road                                                    Seed: 122   Index: 163
+Credit Warp Fight Search                                                      Seed: 122   Index: 167
+  Overworld (Baron)                                                           Seed: 122   Index: 167
+    Extra Steps: 10
+    Step   2: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  10: 40 / Imp x4 (7.223s)
+   (Step  42: 41 / Imp x3, SwordRat x1)
+   (Step 103: 42 / Imp x3, SwordRat x1)
+   (Step 160: 43 / Imp x3, SwordRat x1)
+   (Step 241: 44 / Imp x3)
+
+Encounter Time:      312.655s
+Other Time:          499.877s
+Total Time:          812.532s
+
+Base Total Time:     968.981s
+Time Saved:          156.450s
+
+Optional Steps:      0
+Extra Steps:         44
+Encounters:          40
+
+Base Encounters:     49
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/038.txt
+++ b/data/routes/cw/038.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	38
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50074978
+VARS	FFFFFFFF:10 C307800:1 E307200:2 E307400:18 E307B00:14
+
+Overworld (Kaipo)                                                             Seed:  38   Index:   0
+Overworld (Kaipo)                                                             Seed:  38   Index:   1
+  Step  30: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  38   Index:  37
+Overworld (Kaipo)                                                             Seed:  38   Index:  37
+Watery Pass-South B1F                                                         Seed:  38   Index:  69
+  Step   4: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  25: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  38   Index: 101
+Watery Pass-South B1F                                                         Seed:  38   Index: 101
+  Step  20: 4 / CaveToad x3 (7.014s)
+Watery Pass-South B2F                                                         Seed:  38   Index: 121
+  Step   2: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  20: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  38   Index: 211
+Watery Pass-South B2F                                                         Seed:  38   Index: 215
+  Step  26: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed:  38   Index: 254
+  Step  17: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  55   Index:  32
+  Extra Steps: 2
+  Step  21: 9 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  22: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:  55   Index:  55
+  Step  34: 11 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  44: 12 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed:  55   Index: 115
+Waterfalls B1F                                                                Seed:  55   Index: 124
+  Extra Steps: 18
+Waterfalls B2F                                                                Seed:  55   Index: 143
+  Step  24: 13 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed:  55   Index: 188
+Battle: Octomamm                                                              Seed:  55   Index: 225
+Waterfalls Lake                                                               Seed:  55   Index: 225
+Overworld (Kaipo)                                                             Seed:  55   Index: 226
+Overworld (Damcyan)                                                           Seed:  55   Index: 237
+Damcyan                                                                       Seed:  55   Index: 241
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  55   Index: 248
+Antlion B1F                                                                   Seed:  55   Index: 248
+Antlion B2F Inward Charm Room Steps                                           Seed:  72   Index:  30
+  Antlion B2F                                                                 Seed:  72   Index:  30
+    Step  13: 14 / Basilisk x1, Imp x3 (6.775s)
+  Antlion B2F Treasure Room                                                   Seed:  72   Index:  63
+    Extra Steps: 14
+  Antlion B2F                                                                 Seed:  72   Index:  77
+    Step  42: 15 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:  72   Index: 129
+Battle: Antlion                                                               Seed:  72   Index: 143
+Antlion's Nest                                                                Seed:  72   Index: 143
+  Step  10: 16 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed:  72   Index: 158
+  Antlion B2F                                                                 Seed:  72   Index: 158
+    Step  20: 17 / Basilisk x1, Turtle x1 (7.124s)
+    Step  73: 18 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed:  72   Index: 238
+  Step   9: 19 / Cream x4 (7.523s)
+  Step  26: 20 / Cream x4 (7.523s)
+  Step  38: 21 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed:  89   Index:  20
+Overworld (Kaipo)                                                             Seed:  89   Index:  20
+Kaipo Revisited                                                               Seed:  89   Index:  20
+Overworld (Kaipo)                                                             Seed:  89   Index:  20
+Overworld (Damcyan)                                                           Seed:  89   Index:  20
+Mt.Hobs-West                                                                  Seed:  89   Index:  20
+  Step  12: 22 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed:  89   Index:  59
+Battle: MomBomb                                                               Seed:  89   Index:  74
+Mt.Hobs Summit                                                                Seed:  89   Index:  74
+  Step   2: 23 / GrayBomb x2, Bomb x2 (8.430s)
+Mt.Hobs-East                                                                  Seed:  89   Index:  80
+  Step   5: 24 / Turtle x2 (7.432s)
+  Step  37: 25 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:  89   Index: 126
+  Step  14: 26 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  31: 27 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  89   Index: 210
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 106   Index:  14
+Fabul Boat and Leviatan                                                       Seed: 106   Index:  21
+Overworld (Mysidia)                                                           Seed: 106   Index:  21
+Mysidia                                                                       Seed: 106   Index:  30
+Overworld (Mysidia)                                                           Seed: 106   Index:  30
+Overworld (Mt.Ordeals)                                                        Seed: 106   Index:  40
+  Step  11: 28 / Raven x1 (8.356s)
+  Step  22: 29 / Raven x1 (8.356s)
+  Step  51: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  75: 31 / Raven x1 (8.356s)
+  Step  76: 32 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 106   Index: 134
+  Step   2: 33 / Lilith x1, Red Bone x2 (9.259s)
+  Step  13: 34 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 106   Index: 177
+Recruit Tellah                                                                Seed: 106   Index: 200
+Mt.Ordeals-3rd station                                                        Seed: 106   Index: 200
+Mt.Ordeals-7th station                                                        Seed: 106   Index: 205
+  Step  12: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  30: 36 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 106   Index: 247
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 123   Index:   8
+Mt.Ordeals Summit                                                             Seed: 123   Index:   8
+Paladin                                                                       Seed: 123   Index:  12
+Mt.Ordeals Summit                                                             Seed: 123   Index:  12
+  Optional Steps: 0
+  Step  11: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 123   Index:  34
+  Step  25: 38 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 123   Index:  76
+  Step   4: 39 / Ghoul x2, Soul x2 (8.971s)
+  Step  10: 40 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals                                                                    Seed: 123   Index: 106
+Overworld (Mt.Ordeals)                                                        Seed: 123   Index: 150
+  Step   5: 41 / Imp Cap. x4, Imp x2 (8.400s)
+Take Chocobo to Mysidia                                                       Seed: 123   Index: 163
+Overworld (Mysidia)                                                           Seed: 123   Index: 163
+Town of Baron Serpent Road                                                    Seed: 123   Index: 163
+Credit Warp Fight Search                                                      Seed: 123   Index: 167
+  Overworld (Baron)                                                           Seed: 123   Index: 167
+    Extra Steps: 10
+    Step   2: 42 / Imp x3, SwordRat x1 (7.227s)
+    Step  10: 43 / Imp x3, SwordRat x1 (7.227s)
+   (Step  42: 44 / Imp x3)
+   (Step 103: 45 / Eagle x3)
+   (Step 160: 46 / Eagle x3)
+   (Step 199: 47 / Imp x4)
+   (Step 241: 48 / Imp x3)
+
+Encounter Time:      333.334s
+Other Time:          499.877s
+Total Time:          833.211s
+
+Base Total Time:     922.233s
+Time Saved:          89.022s
+
+Optional Steps:      0
+Extra Steps:         44
+Encounters:          43
+
+Base Encounters:     50
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/039.txt
+++ b/data/routes/cw/039.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	39
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49569155
+VARS	FFFFFFFF:24 E302500:1 E302600:2 E307200:2 E307400:18 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  39   Index:   0
+Overworld (Kaipo)                                                             Seed:  39   Index:   1
+  Step  30: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  39   Index:  37
+Overworld (Kaipo)                                                             Seed:  39   Index:  37
+Watery Pass-South B1F                                                         Seed:  39   Index:  69
+  Step   4: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  25: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  39   Index: 101
+Watery Pass-South B1F                                                         Seed:  39   Index: 101
+  Step  20: 4 / CaveToad x3 (7.014s)
+Watery Pass-South B2F                                                         Seed:  39   Index: 121
+  Step   2: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  82: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  39   Index: 211
+Watery Pass-South B2F                                                         Seed:  39   Index: 215
+  Step  26: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed:  39   Index: 254
+  Step  17: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  56   Index:  32
+  Extra Steps: 2
+  Step  21: 9 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  22: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:  56   Index:  55
+  Step  34: 11 / Zombie x4 (7.148s)
+  Step  44: 12 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  56   Index: 115
+Waterfalls B1F                                                                Seed:  56   Index: 124
+  Extra Steps: 18
+Waterfalls B2F                                                                Seed:  56   Index: 143
+  Step  24: 13 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed:  56   Index: 188
+Battle: Octomamm                                                              Seed:  56   Index: 225
+Waterfalls Lake                                                               Seed:  56   Index: 225
+Overworld (Kaipo)                                                             Seed:  56   Index: 226
+Overworld (Damcyan)                                                           Seed:  56   Index: 237
+Damcyan                                                                       Seed:  56   Index: 241
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  56   Index: 249
+Antlion B1F                                                                   Seed:  56   Index: 249
+Antlion B2F Inward Direct                                                     Seed:  73   Index:  31
+  Antlion B2F                                                                 Seed:  73   Index:  31
+    Step  12: 14 / Basilisk x1, Imp x3 (6.775s)
+    Step  41: 15 / Basilisk x1, Turtle x1 (7.110s)
+    Step  46: 16 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed:  73   Index: 111
+  Step   8: 17 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed:  73   Index: 125
+Antlion's Nest                                                                Seed:  73   Index: 125
+  Step   2: 18 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed:  73   Index: 140
+  Antlion B2F                                                                 Seed:  73   Index: 140
+    Step  13: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  73   Index: 220
+  Step  11: 20 / Cream x4 (7.523s)
+  Step  27: 21 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed:  90   Index:   2
+Overworld (Kaipo)                                                             Seed:  90   Index:   2
+Kaipo Revisited                                                               Seed:  90   Index:   2
+Overworld (Kaipo)                                                             Seed:  90   Index:   2
+Overworld (Damcyan)                                                           Seed:  90   Index:   2
+Mt.Hobs-West                                                                  Seed:  90   Index:   2
+  Step  18: 22 / Bomb x3 (8.832s)
+  Step  30: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed:  90   Index:  41
+Battle: MomBomb                                                               Seed:  90   Index:  56
+Mt.Hobs Summit                                                                Seed:  90   Index:  56
+Mt.Hobs-East                                                                  Seed:  90   Index:  62
+  Step  14: 24 / Turtle x2 (7.432s)
+  Step  23: 25 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:  90   Index: 108
+  Step   9: 26 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  49: 27 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  90   Index: 192
+  Optional Steps: 2
+Overworld (Fabul)                                                             Seed:  90   Index: 254
+Fabul Boat and Leviatan                                                       Seed: 107   Index:   5
+Overworld (Mysidia)                                                           Seed: 107   Index:   5
+  Step   7: 28 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 107   Index:  14
+Overworld (Mysidia)                                                           Seed: 107   Index:  14
+Overworld (Mt.Ordeals)                                                        Seed: 107   Index:  24
+  Step  27: 29 / Raven x1 (8.356s)
+  Step  38: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  58: 31 / Raven x1 (8.356s)
+  Step  91: 32 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  92: 33 / Raven x1, Cocktric x3 (9.100s)
+Mt.Ordeals                                                                    Seed: 107   Index: 118
+  Step  18: 34 / Skelton x3, Red Bone x2 (8.244s)
+  Step  29: 35 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed: 107   Index: 161
+Recruit Tellah                                                                Seed: 107   Index: 184
+Mt.Ordeals-3rd station                                                        Seed: 107   Index: 184
+Mt.Ordeals-7th station                                                        Seed: 107   Index: 189
+Mt.Ordeals Summit                                                             Seed: 107   Index: 231
+  Optional Steps: 1
+  Step   4: 36 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed: 107   Index: 249
+Mt.Ordeals Summit                                                             Seed: 107   Index: 249
+Paladin                                                                       Seed: 107   Index: 253
+Mt.Ordeals Summit                                                             Seed: 107   Index: 253
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 124   Index:  20
+  Step   3: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 124   Index:  62
+  Step  18: 38 / Spirit x2, Soul x2, Red Bone x2 (9.471s)
+  Step  24: 39 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed: 124   Index:  92
+  Step  20: 40 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 124   Index: 136
+Take Chocobo to Mysidia                                                       Seed: 124   Index: 149
+Overworld (Mysidia)                                                           Seed: 124   Index: 149
+Town of Baron Serpent Road                                                    Seed: 124   Index: 149
+Credit Warp Fight Search                                                      Seed: 124   Index: 153
+  Overworld (Baron)                                                           Seed: 124   Index: 153
+    Extra Steps: 24
+    Step   2: 41 / Imp x3, SwordRat x1 (7.227s)
+    Step  24: 42 / Imp x3, SwordRat x1 (7.227s)
+   (Step  56: 43 / Imp x3, SwordRat x1)
+   (Step 117: 44 / Imp x3)
+   (Step 174: 45 / Eagle x3)
+   (Step 213: 46 / Eagle x3)
+   (Step 245: 47 / Imp x4)
+   (Step 255: 48 / Imp x3)
+
+Encounter Time:      325.783s
+Other Time:          499.012s
+Total Time:          824.794s
+
+Base Total Time:     925.495s
+Time Saved:          100.701s
+
+Optional Steps:      5
+Extra Steps:         44
+Encounters:          42
+
+Base Encounters:     47
+Encounters Saved:    5
+
+Number of Variables: 54

--- a/data/routes/cw/040.txt
+++ b/data/routes/cw/040.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	40
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47875300
+VARS	FFFFFFFF:6 E302500:1 E302600:3 E307400:20 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  40   Index:   0
+Overworld (Kaipo)                                                             Seed:  40   Index:   1
+  Step  30: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  40   Index:  37
+Overworld (Kaipo)                                                             Seed:  40   Index:  37
+Watery Pass-South B1F                                                         Seed:  40   Index:  69
+  Step   4: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  25: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  40   Index: 101
+Watery Pass-South B1F                                                         Seed:  40   Index: 101
+  Step  20: 4 / CaveToad x3 (7.014s)
+Watery Pass-South B2F                                                         Seed:  40   Index: 121
+  Step   2: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step   4: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  82: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  40   Index: 211
+Watery Pass-South B2F                                                         Seed:  40   Index: 215
+Watery Pass-South B3F                                                         Seed:  40   Index: 254
+  Step  17: 8 / CaveToad x3 (7.014s)
+  Step  26: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed:  57   Index:  32
+  Step  21: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:  57   Index:  53
+  Step   1: 11 / Zombie x4 (7.148s)
+  Step  36: 12 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  46: 13 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  57   Index: 113
+Waterfalls B1F                                                                Seed:  57   Index: 122
+  Extra Steps: 20
+Waterfalls B2F                                                                Seed:  57   Index: 143
+Waterfalls Lake                                                               Seed:  57   Index: 188
+Battle: Octomamm                                                              Seed:  57   Index: 225
+Waterfalls Lake                                                               Seed:  57   Index: 225
+Overworld (Kaipo)                                                             Seed:  57   Index: 226
+Overworld (Damcyan)                                                           Seed:  57   Index: 237
+Damcyan                                                                       Seed:  57   Index: 241
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  57   Index: 249
+Antlion B1F                                                                   Seed:  57   Index: 249
+  Step   8: 14 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Direct                                                     Seed:  74   Index:  31
+  Antlion B2F                                                                 Seed:  74   Index:  31
+    Step  41: 15 / Basilisk x1, Turtle x1 (7.110s)
+    Step  46: 16 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed:  74   Index: 111
+  Step   8: 17 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed:  74   Index: 125
+Antlion's Nest                                                                Seed:  74   Index: 125
+  Step   2: 18 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed:  74   Index: 140
+  Antlion B2F                                                                 Seed:  74   Index: 140
+    Step  13: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  74   Index: 220
+  Step  11: 20 / Cream x4 (7.523s)
+  Step  27: 21 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed:  91   Index:   2
+Overworld (Kaipo)                                                             Seed:  91   Index:   2
+Kaipo Revisited                                                               Seed:  91   Index:   2
+Overworld (Kaipo)                                                             Seed:  91   Index:   2
+Overworld (Damcyan)                                                           Seed:  91   Index:   2
+Mt.Hobs-West                                                                  Seed:  91   Index:   2
+  Step  18: 22 / Bomb x3 (8.832s)
+  Step  30: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed:  91   Index:  41
+Battle: MomBomb                                                               Seed:  91   Index:  56
+Mt.Hobs Summit                                                                Seed:  91   Index:  56
+Mt.Hobs-East                                                                  Seed:  91   Index:  62
+  Step  14: 24 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  91   Index: 108
+  Step   9: 25 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  91   Index: 192
+  Optional Steps: 3
+Overworld (Fabul)                                                             Seed:  91   Index: 255
+Fabul Boat and Leviatan                                                       Seed: 108   Index:   6
+Overworld (Mysidia)                                                           Seed: 108   Index:   6
+  Step   6: 26 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 108   Index:  15
+Overworld (Mysidia)                                                           Seed: 108   Index:  15
+Overworld (Mt.Ordeals)                                                        Seed: 108   Index:  25
+  Step  37: 27 / Raven x1 (8.356s)
+  Step  57: 28 / Raven x1 (8.356s)
+  Step  89: 29 / Raven x1 (8.356s)
+  Step  90: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  91: 31 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 108   Index: 119
+  Step  17: 32 / Red Bone x1, Skelton x3 (8.067s)
+  Step  28: 33 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed: 108   Index: 162
+Recruit Tellah                                                                Seed: 108   Index: 185
+Mt.Ordeals-3rd station                                                        Seed: 108   Index: 185
+Mt.Ordeals-7th station                                                        Seed: 108   Index: 190
+Mt.Ordeals Summit                                                             Seed: 108   Index: 232
+  Optional Steps: 1
+  Step   3: 34 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed: 108   Index: 250
+Mt.Ordeals Summit                                                             Seed: 108   Index: 250
+Paladin                                                                       Seed: 108   Index: 254
+Mt.Ordeals Summit                                                             Seed: 108   Index: 254
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 125   Index:  21
+  Step   2: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 125   Index:  63
+  Step  17: 36 / Spirit x2, Soul x2, Red Bone x2 (9.471s)
+  Step  23: 37 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 125   Index:  93
+  Step  19: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 125   Index: 137
+Take Chocobo to Mysidia                                                       Seed: 125   Index: 150
+Overworld (Mysidia)                                                           Seed: 125   Index: 150
+Town of Baron Serpent Road                                                    Seed: 125   Index: 150
+Credit Warp Fight Search                                                      Seed: 125   Index: 154
+  Overworld (Baron)                                                           Seed: 125   Index: 154
+    Extra Steps: 6
+    Step   1: 39 / Imp x3, SwordRat x1 (7.227s)
+    Step   6: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  55: 41 / Imp x3, SwordRat x1)
+   (Step 116: 42 / Imp x3, SwordRat x1)
+   (Step 173: 43 / Imp x3, SwordRat x1)
+   (Step 212: 44 / Imp x3)
+   (Step 244: 45 / Eagle x3)
+   (Step 254: 46 / Eagle x3)
+
+Encounter Time:      307.182s
+Other Time:          489.427s
+Total Time:          796.610s
+
+Base Total Time:     820.413s
+Time Saved:          23.803s
+
+Optional Steps:      6
+Extra Steps:         26
+Encounters:          40
+
+Base Encounters:     42
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/041.txt
+++ b/data/routes/cw/041.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	41
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48013119
+VARS	FFFFFFFF:6 E000202:6 E302500:4 E302600:9 E308702:1 E309700:6
+
+Overworld (Kaipo)                                                             Seed:  41   Index:   0
+Overworld (Kaipo)                                                             Seed:  41   Index:   1
+  Step  25: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  30: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  41   Index:  37
+Overworld (Kaipo)                                                             Seed:  41   Index:  37
+Watery Pass-South B1F                                                         Seed:  41   Index:  69
+  Step   4: 3 / Pike x3 (6.935s)
+  Step  25: 4 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed:  41   Index: 101
+Watery Pass-South B1F                                                         Seed:  41   Index: 101
+Watery Pass-South B2F                                                         Seed:  41   Index: 121
+  Step   2: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step   4: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  82: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  41   Index: 211
+Watery Pass-South B2F                                                         Seed:  41   Index: 215
+Watery Pass-South B3F                                                         Seed:  41   Index: 254
+  Step  17: 8 / CaveToad x3 (7.014s)
+  Step  26: 9 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed:  58   Index:  32
+  Step  21: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:  58   Index:  53
+  Step  36: 11 / Zombie x4 (7.148s)
+  Step  46: 12 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  58   Index: 113
+Waterfalls B1F                                                                Seed:  58   Index: 122
+Waterfalls B2F                                                                Seed:  58   Index: 123
+  Step  20: 13 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed:  58   Index: 168
+Battle: Octomamm                                                              Seed:  58   Index: 205
+Waterfalls Lake                                                               Seed:  58   Index: 205
+Overworld (Kaipo)                                                             Seed:  58   Index: 206
+Overworld (Damcyan)                                                           Seed:  58   Index: 217
+Damcyan                                                                       Seed:  58   Index: 221
+  Optional Steps: 0
+  Extra Steps: 4
+Overworld (Damcyan)                                                           Seed:  58   Index: 232
+Antlion B1F                                                                   Seed:  58   Index: 232
+  Step  17: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  25: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed:  75   Index:  14
+  Antlion B2F                                                                 Seed:  75   Index:  14
+    Step  34: 16 / Cream x4 (7.552s)
+    Step  58: 17 / Basilisk x1, Turtle x1 (7.110s)
+    Step  63: 18 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed:  75   Index:  94
+Battle: Antlion                                                               Seed:  75   Index: 108
+Antlion's Nest                                                                Seed:  75   Index: 108
+  Step  11: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed:  75   Index: 123
+  Antlion B2F                                                                 Seed:  75   Index: 123
+    Step   4: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  75   Index: 203
+  Step  28: 21 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed:  75   Index: 241
+Overworld (Kaipo)                                                             Seed:  75   Index: 241
+  Extra Steps: 6
+  Step   6: 22 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed:  75   Index: 247
+Overworld (Kaipo)                                                             Seed:  75   Index: 247
+Overworld (Damcyan)                                                           Seed:  75   Index: 247
+Mt.Hobs-West                                                                  Seed:  75   Index: 247
+  Step  29: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed:  92   Index:  30
+  Step   2: 24 / Spirit x2, Skelton x2 (9.087s)
+Battle: MomBomb                                                               Seed:  92   Index:  45
+Mt.Hobs Summit                                                                Seed:  92   Index:  45
+  Step   5: 25 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed:  92   Index:  51
+  Step  25: 26 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed:  92   Index:  97
+  Step  20: 27 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  92   Index: 181
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed:  92   Index: 250
+Fabul Boat and Leviatan                                                       Seed: 109   Index:   1
+Overworld (Mysidia)                                                           Seed: 109   Index:   1
+Mysidia                                                                       Seed: 109   Index:  10
+Overworld (Mysidia)                                                           Seed: 109   Index:  10
+  Step   2: 28 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 109   Index:  20
+  Step  13: 29 / Raven x1 (8.356s)
+  Step  42: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  62: 31 / Raven x1 (8.356s)
+  Step  94: 32 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 109   Index: 114
+  Step   2: 33 / Lilith x1, Red Bone x2 (9.259s)
+  Step  22: 34 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 109   Index: 157
+Recruit Tellah                                                                Seed: 109   Index: 180
+Mt.Ordeals-3rd station                                                        Seed: 109   Index: 180
+Mt.Ordeals-7th station                                                        Seed: 109   Index: 185
+Mt.Ordeals Summit                                                             Seed: 109   Index: 227
+  Optional Steps: 0
+  Step   8: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed: 109   Index: 244
+Mt.Ordeals Summit                                                             Seed: 109   Index: 244
+Paladin                                                                       Seed: 109   Index: 248
+Mt.Ordeals Summit                                                             Seed: 109   Index: 248
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 126   Index:  15
+  Step   8: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 126   Index:  57
+  Step  23: 37 / Zombie x2, Ghoul x2 (7.552s)
+  Step  29: 38 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 126   Index:  87
+  Step  25: 39 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 126   Index: 131
+Take Chocobo to Mysidia                                                       Seed: 126   Index: 144
+Overworld (Mysidia)                                                           Seed: 126   Index: 144
+Town of Baron Serpent Road                                                    Seed: 126   Index: 144
+  Extra Steps: 6
+Credit Warp Fight Search                                                      Seed: 126   Index: 154
+  Overworld (Baron)                                                           Seed: 126   Index: 154
+    Extra Steps: 6
+    Step   1: 40 / Imp x3, SwordRat x1 (7.227s)
+    Step   6: 41 / Imp x3, SwordRat x1 (7.227s)
+   (Step  61: 42 / Imp x3, SwordRat x1)
+   (Step 116: 43 / Imp x3, SwordRat x1)
+   (Step 209: 44 / Imp x3)
+   (Step 212: 45 / Eagle x3)
+   (Step 244: 46 / Eagle x3)
+   (Step 254: 47 / Imp x4)
+
+Encounter Time:      310.541s
+Other Time:          488.362s
+Total Time:          798.903s
+
+Base Total Time:     826.916s
+Time Saved:          28.013s
+
+Optional Steps:      10
+Extra Steps:         22
+Encounters:          41
+
+Base Encounters:     43
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/042.txt
+++ b/data/routes/cw/042.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	42
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47838309
+VARS	FFFFFFFF:6 E302500:1 E302600:3 E307400:20 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  42   Index:   0
+Overworld (Kaipo)                                                             Seed:  42   Index:   1
+  Step  25: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  30: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  42   Index:  37
+Overworld (Kaipo)                                                             Seed:  42   Index:  37
+Watery Pass-South B1F                                                         Seed:  42   Index:  69
+  Step   4: 3 / Pike x3 (6.935s)
+  Step  25: 4 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed:  42   Index: 101
+Watery Pass-South B1F                                                         Seed:  42   Index: 101
+Watery Pass-South B2F                                                         Seed:  42   Index: 121
+  Step   2: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step   4: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  82: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  42   Index: 211
+Watery Pass-South B2F                                                         Seed:  42   Index: 215
+  Step  21: 8 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  42   Index: 254
+  Step  17: 9 / Pike x3 (7.152s)
+  Step  26: 10 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed:  59   Index:  32
+  Step  21: 11 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed:  59   Index:  53
+  Step  46: 12 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  59   Index: 113
+Waterfalls B1F                                                                Seed:  59   Index: 122
+  Extra Steps: 20
+Waterfalls B2F                                                                Seed:  59   Index: 143
+Waterfalls Lake                                                               Seed:  59   Index: 188
+Battle: Octomamm                                                              Seed:  59   Index: 225
+Waterfalls Lake                                                               Seed:  59   Index: 225
+Overworld (Kaipo)                                                             Seed:  59   Index: 226
+  Step   6: 13 / SandWorm x1 (7.264s)
+Overworld (Damcyan)                                                           Seed:  59   Index: 237
+Damcyan                                                                       Seed:  59   Index: 241
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  59   Index: 249
+Antlion B1F                                                                   Seed:  59   Index: 249
+  Step   8: 14 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Direct                                                     Seed:  76   Index:  31
+  Antlion B2F                                                                 Seed:  76   Index:  31
+    Step  17: 15 / Basilisk x1, Turtle x1 (7.110s)
+    Step  41: 16 / Cream x4 (7.552s)
+    Step  46: 17 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:  76   Index: 111
+  Step   7: 18 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed:  76   Index: 125
+Antlion's Nest                                                                Seed:  76   Index: 125
+  Step   2: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed:  76   Index: 140
+  Antlion B2F                                                                 Seed:  76   Index: 140
+Antlion B1F                                                                   Seed:  76   Index: 220
+  Step  11: 20 / Cream x4 (7.523s)
+  Step  27: 21 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed:  93   Index:   2
+Overworld (Kaipo)                                                             Seed:  93   Index:   2
+Kaipo Revisited                                                               Seed:  93   Index:   2
+Overworld (Kaipo)                                                             Seed:  93   Index:   2
+Overworld (Damcyan)                                                           Seed:  93   Index:   2
+Mt.Hobs-West                                                                  Seed:  93   Index:   2
+  Step  18: 22 / Bomb x3 (8.832s)
+  Step  30: 23 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed:  93   Index:  41
+  Step   9: 24 / Spirit x2, Skelton x2 (9.087s)
+Battle: MomBomb                                                               Seed:  93   Index:  56
+Mt.Hobs Summit                                                                Seed:  93   Index:  56
+Mt.Hobs-East                                                                  Seed:  93   Index:  62
+Overworld (Fabul)                                                             Seed:  93   Index: 108
+  Step   9: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  40: 26 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed:  93   Index: 192
+  Optional Steps: 3
+Overworld (Fabul)                                                             Seed:  93   Index: 255
+Fabul Boat and Leviatan                                                       Seed: 110   Index:   6
+Overworld (Mysidia)                                                           Seed: 110   Index:   6
+  Step   6: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.462s)
+Mysidia                                                                       Seed: 110   Index:  15
+Overworld (Mysidia)                                                           Seed: 110   Index:  15
+Overworld (Mt.Ordeals)                                                        Seed: 110   Index:  25
+  Step   8: 28 / Raven x1 (8.356s)
+  Step  37: 29 / Raven x1 (8.356s)
+  Step  57: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  89: 31 / Raven x1 (8.356s)
+  Step  91: 32 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 110   Index: 119
+  Step  17: 33 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed: 110   Index: 162
+Recruit Tellah                                                                Seed: 110   Index: 185
+Mt.Ordeals-3rd station                                                        Seed: 110   Index: 185
+Mt.Ordeals-7th station                                                        Seed: 110   Index: 190
+  Step  28: 34 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 110   Index: 232
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 110   Index: 250
+Mt.Ordeals Summit                                                             Seed: 110   Index: 250
+Paladin                                                                       Seed: 110   Index: 254
+Mt.Ordeals Summit                                                             Seed: 110   Index: 254
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 127   Index:  21
+  Step   2: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 127   Index:  63
+  Step  17: 36 / Spirit x2, Soul x2, Red Bone x2 (9.471s)
+  Step  23: 37 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 127   Index:  93
+  Step  19: 38 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 127   Index: 137
+Take Chocobo to Mysidia                                                       Seed: 127   Index: 150
+Overworld (Mysidia)                                                           Seed: 127   Index: 150
+Town of Baron Serpent Road                                                    Seed: 127   Index: 150
+Credit Warp Fight Search                                                      Seed: 127   Index: 154
+  Overworld (Baron)                                                           Seed: 127   Index: 154
+    Extra Steps: 6
+    Step   1: 39 / Imp x3, SwordRat x1 (7.227s)
+    Step   6: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  54: 41 / Imp x3, SwordRat x1)
+   (Step  61: 42 / Imp x3, SwordRat x1)
+   (Step 209: 43 / Imp x3, SwordRat x1)
+   (Step 212: 44 / Imp x3)
+   (Step 244: 45 / Eagle x3)
+   (Step 254: 46 / Eagle x3)
+
+Encounter Time:      306.567s
+Other Time:          489.427s
+Total Time:          795.994s
+
+Base Total Time:     966.532s
+Time Saved:          170.537s
+
+Optional Steps:      6
+Extra Steps:         26
+Encounters:          40
+
+Base Encounters:     47
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/043.txt
+++ b/data/routes/cw/043.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	43
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48076390
+VARS	FFFFFFFF:8 E000200:2 E302500:1 E302600:12 E308700:1 E308702:1 E309700:62
+
+Overworld (Kaipo)                                                             Seed:  43   Index:   0
+Overworld (Kaipo)                                                             Seed:  43   Index:   1
+  Step  25: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  43   Index:  37
+Overworld (Kaipo)                                                             Seed:  43   Index:  37
+  Step  10: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed:  43   Index:  69
+  Step   4: 3 / Pike x3 (6.935s)
+  Step  25: 4 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed:  43   Index: 101
+Watery Pass-South B1F                                                         Seed:  43   Index: 101
+Watery Pass-South B2F                                                         Seed:  43   Index: 121
+  Step   4: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  82: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  43   Index: 211
+Watery Pass-South B2F                                                         Seed:  43   Index: 215
+  Step  21: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed:  43   Index: 254
+  Step  26: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  60   Index:  32
+  Step  21: 9 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed:  60   Index:  53
+  Step  15: 10 / CaveToad x4 (7.163s)
+  Step  46: 11 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed:  60   Index: 113
+  Extra Steps: 2
+  Step  11: 12 / Sand Man x4 (7.310s)
+Waterfalls B1F                                                                Seed:  60   Index: 124
+Waterfalls B2F                                                                Seed:  60   Index: 125
+Waterfalls Lake                                                               Seed:  60   Index: 170
+Battle: Octomamm                                                              Seed:  60   Index: 207
+Waterfalls Lake                                                               Seed:  60   Index: 207
+Overworld (Kaipo)                                                             Seed:  60   Index: 208
+Overworld (Damcyan)                                                           Seed:  60   Index: 219
+Damcyan                                                                       Seed:  60   Index: 223
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  60   Index: 231
+Antlion B1F                                                                   Seed:  60   Index: 231
+  Step   1: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+  Step  18: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  26: 15 / Turtle x2 (7.487s)
+Antlion B2F Inward Direct                                                     Seed:  77   Index:  13
+  Antlion B2F                                                                 Seed:  77   Index:  13
+    Step  35: 16 / Cream x4 (7.552s)
+    Step  59: 17 / Basilisk x1, Turtle x1 (7.110s)
+    Step  64: 18 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed:  77   Index:  93
+Battle: Antlion                                                               Seed:  77   Index: 107
+Antlion's Nest                                                                Seed:  77   Index: 107
+  Step  11: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed:  77   Index: 122
+  Antlion B2F                                                                 Seed:  77   Index: 122
+    Step   5: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  73: 21 / SandWorm x1, Sandpede x1 (6.848s)
+Antlion B1F                                                                   Seed:  77   Index: 202
+Overworld (Damcyan)                                                           Seed:  77   Index: 240
+Overworld (Kaipo)                                                             Seed:  77   Index: 240
+Kaipo Revisited                                                               Seed:  77   Index: 240
+Overworld (Kaipo)                                                             Seed:  77   Index: 240
+Overworld (Damcyan)                                                           Seed:  77   Index: 240
+Mt.Hobs-West                                                                  Seed:  77   Index: 240
+  Step   7: 22 / Bomb x3 (8.832s)
+  Step  36: 23 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed:  94   Index:  23
+Battle: MomBomb                                                               Seed:  94   Index:  38
+Mt.Hobs Summit                                                                Seed:  94   Index:  38
+Mt.Hobs-East                                                                  Seed:  94   Index:  44
+  Step   6: 24 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  94   Index:  90
+  Step  58: 25 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  94   Index: 174
+  Optional Steps: 10
+  Extra Steps: 2
+Overworld (Fabul)                                                             Seed:  94   Index: 246
+Fabul Boat and Leviatan                                                       Seed:  94   Index: 253
+Overworld (Mysidia)                                                           Seed:  94   Index: 253
+Mysidia                                                                       Seed: 111   Index:   6
+Overworld (Mysidia)                                                           Seed: 111   Index:   6
+Overworld (Mt.Ordeals)                                                        Seed: 111   Index:  16
+  Step  17: 26 / Raven x1 (8.356s)
+  Step  46: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  66: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 111   Index: 110
+  Step   4: 29 / Spirit x2, Skelton x2 (8.285s)
+  Step   6: 30 / Red Bone x1, Skelton x3 (8.067s)
+  Step  26: 31 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 111   Index: 153
+Recruit Tellah                                                                Seed: 111   Index: 176
+Mt.Ordeals-3rd station                                                        Seed: 111   Index: 176
+Mt.Ordeals-7th station                                                        Seed: 111   Index: 181
+  Step  37: 32 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 111   Index: 223
+  Optional Steps: 1
+  Step   3: 33 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed: 111   Index: 241
+Mt.Ordeals Summit                                                             Seed: 111   Index: 241
+Paladin                                                                       Seed: 111   Index: 245
+Mt.Ordeals Summit                                                             Seed: 111   Index: 245
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 128   Index:  12
+  Step  34: 34 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed: 128   Index:  54
+  Step  26: 35 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 128   Index:  84
+  Step   2: 36 / Red Bone x1, Skelton x3 (7.844s)
+  Step  28: 37 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 128   Index: 128
+Take Chocobo to Mysidia                                                       Seed: 128   Index: 141
+Overworld (Mysidia)                                                           Seed: 128   Index: 141
+Town of Baron Serpent Road                                                    Seed: 128   Index: 141
+  Extra Steps: 62
+Credit Warp Fight Search                                                      Seed: 128   Index: 207
+  Overworld (Baron)                                                           Seed: 128   Index: 207
+    Extra Steps: 8
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step   8: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step 156: 40 / Imp x3, SwordRat x1)
+   (Step 159: 41 / Imp x3, SwordRat x1)
+   (Step 191: 42 / Imp x3, SwordRat x1)
+   (Step 201: 43 / Eagle x3)
+   (Step 223: 44 / Imp x3)
+
+Encounter Time:      297.217s
+Other Time:          502.739s
+Total Time:          799.956s
+
+Base Total Time:     837.576s
+Time Saved:          37.620s
+
+Optional Steps:      13
+Extra Steps:         74
+Encounters:          39
+
+Base Encounters:     41
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/044.txt
+++ b/data/routes/cw/044.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	44
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48438561
+VARS	FFFFFFFF:8 E000501:2 E000600:10 E302500:3 E302600:54 E307400:2 E308700:1 E308701:2 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed:  44   Index:   0
+Overworld (Kaipo)                                                             Seed:  44   Index:   1
+  Step  25: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  44   Index:  37
+Overworld (Kaipo)                                                             Seed:  44   Index:  37
+  Step  10: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step  21: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  44   Index:  69
+  Step   4: 4 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed:  44   Index: 101
+Watery Pass-South B1F                                                         Seed:  44   Index: 101
+Watery Pass-South B2F                                                         Seed:  44   Index: 121
+  Step   4: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  82: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  44   Index: 211
+Watery Pass-South B2F                                                         Seed:  44   Index: 215
+  Step  21: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed:  44   Index: 254
+  Step  26: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  61   Index:  32
+  Step  21: 9 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed:  61   Index:  53
+  Step  15: 10 / CaveToad x4 (7.163s)
+  Step  25: 11 / Zombie x4 (7.148s)
+  Step  46: 12 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  61   Index: 113
+Waterfalls B1F                                                                Seed:  61   Index: 122
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed:  61   Index: 125
+Waterfalls Lake                                                               Seed:  61   Index: 170
+Battle: Octomamm                                                              Seed:  61   Index: 207
+Waterfalls Lake                                                               Seed:  61   Index: 207
+Overworld (Kaipo)                                                             Seed:  61   Index: 208
+Overworld (Damcyan)                                                           Seed:  61   Index: 219
+Damcyan                                                                       Seed:  61   Index: 223
+  Optional Steps: 1
+  Extra Steps: 2
+Overworld (Damcyan)                                                           Seed:  61   Index: 233
+Antlion B1F                                                                   Seed:  61   Index: 233
+  Step  16: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+  Step  24: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  33: 15 / Turtle x2 (7.487s)
+Antlion B2F Inward Direct                                                     Seed:  78   Index:  15
+  Antlion B2F                                                                 Seed:  78   Index:  15
+    Step  33: 16 / Cream x4 (7.552s)
+    Step  62: 17 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:  78   Index:  95
+Battle: Antlion                                                               Seed:  78   Index: 109
+Antlion's Nest                                                                Seed:  78   Index: 109
+  Step   9: 18 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed:  78   Index: 124
+  Antlion B2F                                                                 Seed:  78   Index: 124
+    Step   3: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  71: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  78   Index: 204
+Overworld (Damcyan)                                                           Seed:  78   Index: 242
+Overworld (Kaipo)                                                             Seed:  78   Index: 242
+Kaipo Revisited                                                               Seed:  78   Index: 242
+Overworld (Kaipo)                                                             Seed:  78   Index: 242
+Overworld (Damcyan)                                                           Seed:  78   Index: 242
+Mt.Hobs-West                                                                  Seed:  78   Index: 242
+  Step   5: 21 / GrayBomb x2, Bomb x2 (10.938s)
+  Step  34: 22 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed:  95   Index:  25
+  Step  14: 23 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed:  95   Index:  40
+Mt.Hobs Summit                                                                Seed:  95   Index:  40
+Mt.Hobs-East                                                                  Seed:  95   Index:  46
+  Step   4: 24 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  95   Index:  92
+  Step  56: 25 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  95   Index: 176
+  Optional Steps: 10
+  Extra Steps: 44
+Overworld (Fabul)                                                             Seed: 112   Index:  34
+Fabul Boat and Leviatan                                                       Seed: 112   Index:  41
+Overworld (Mysidia)                                                           Seed: 112   Index:  41
+Mysidia                                                                       Seed: 112   Index:  50
+Overworld (Mysidia)                                                           Seed: 112   Index:  50
+  Extra Steps: 2
+Overworld (Mt.Ordeals)                                                        Seed: 112   Index:  62
+  Extra Steps: 10
+  Step  20: 26 / Raven x1 (8.356s)
+  Step  52: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  54: 28 / Raven x1 (8.356s)
+  Step  74: 29 / Raven x1 (8.356s)
+  Step 104: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 112   Index: 166
+Mt.Ordeals-3rd station                                                        Seed: 112   Index: 209
+  Step   9: 31 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+  Step  17: 32 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed: 112   Index: 232
+Mt.Ordeals-3rd station                                                        Seed: 112   Index: 232
+Mt.Ordeals-7th station                                                        Seed: 112   Index: 237
+Mt.Ordeals Summit                                                             Seed: 129   Index:  23
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 129   Index:  41
+Mt.Ordeals Summit                                                             Seed: 129   Index:  41
+  Extra Steps: 2
+  Step   5: 33 / Ghoul x2, Soul x2 (8.941s)
+Paladin                                                                       Seed: 129   Index:  47
+Mt.Ordeals Summit                                                             Seed: 129   Index:  47
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 129   Index:  70
+  Step  10: 34 / Lilith x1 (8.563s)
+  Step  16: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  42: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 129   Index: 112
+Mt.Ordeals                                                                    Seed: 129   Index: 142
+  Step  18: 37 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 129   Index: 186
+Take Chocobo to Mysidia                                                       Seed: 129   Index: 199
+Overworld (Mysidia)                                                           Seed: 129   Index: 199
+Town of Baron Serpent Road                                                    Seed: 129   Index: 199
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed: 129   Index: 207
+  Overworld (Baron)                                                           Seed: 129   Index: 207
+    Extra Steps: 8
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step   8: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  30: 40 / Imp x3, SwordRat x1)
+   (Step  94: 41 / Imp x3, SwordRat x1)
+   (Step 156: 42 / Imp x3, SwordRat x1)
+   (Step 159: 43 / Eagle x3)
+   (Step 191: 44 / Imp x3)
+   (Step 223: 45 / Eagle x3)
+
+Encounter Time:      303.243s
+Other Time:          502.739s
+Total Time:          805.982s
+
+Base Total Time:     933.387s
+Time Saved:          127.405s
+
+Optional Steps:      13
+Extra Steps:         74
+Encounters:          39
+
+Base Encounters:     47
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/045.txt
+++ b/data/routes/cw/045.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	45
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48422365
+VARS	FFFFFFFF:8 E000501:2 E000600:10 E302500:37 E302600:20 E307400:2 E308700:1 E308701:2 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed:  45   Index:   0
+Overworld (Kaipo)                                                             Seed:  45   Index:   1
+  Step  25: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  45   Index:  37
+Overworld (Kaipo)                                                             Seed:  45   Index:  37
+  Step  10: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step  21: 3 / Sand Man x4 (7.242s)
+  Step  24: 4 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  45   Index:  69
+Recruit Tellah                                                                Seed:  45   Index: 101
+Watery Pass-South B1F                                                         Seed:  45   Index: 101
+Watery Pass-South B2F                                                         Seed:  45   Index: 121
+  Step   4: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  82: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  45   Index: 211
+Watery Pass-South B2F                                                         Seed:  45   Index: 215
+  Step  21: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed:  45   Index: 254
+  Step  26: 8 / CaveToad x3 (7.014s)
+  Step  30: 9 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed:  62   Index:  32
+Watery Pass-North B1F                                                         Seed:  62   Index:  53
+  Step  15: 10 / CaveToad x4 (7.163s)
+  Step  25: 11 / Zombie x4 (7.148s)
+  Step  46: 12 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  62   Index: 113
+Waterfalls B1F                                                                Seed:  62   Index: 122
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed:  62   Index: 125
+Waterfalls Lake                                                               Seed:  62   Index: 170
+Battle: Octomamm                                                              Seed:  62   Index: 207
+Waterfalls Lake                                                               Seed:  62   Index: 207
+Overworld (Kaipo)                                                             Seed:  62   Index: 208
+Overworld (Damcyan)                                                           Seed:  62   Index: 219
+Damcyan                                                                       Seed:  62   Index: 223
+  Optional Steps: 1
+  Extra Steps: 36
+Overworld (Damcyan)                                                           Seed:  79   Index:  11
+Antlion B1F                                                                   Seed:  79   Index:  11
+  Step  37: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Direct                                                     Seed:  79   Index:  49
+  Antlion B2F                                                                 Seed:  79   Index:  49
+    Step  69: 14 / Basilisk x1, Imp x3 (6.775s)
+    Step  78: 15 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed:  79   Index: 129
+Battle: Antlion                                                               Seed:  79   Index: 143
+Antlion's Nest                                                                Seed:  79   Index: 143
+Antlion B2F Outward Direct                                                    Seed:  79   Index: 158
+  Antlion B2F                                                                 Seed:  79   Index: 158
+    Step  37: 16 / Cream x4 (7.523s)
+    Step  71: 17 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed:  79   Index: 238
+  Step   9: 18 / Turtle x2 (7.464s)
+  Step  38: 19 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed:  96   Index:  20
+Overworld (Kaipo)                                                             Seed:  96   Index:  20
+Kaipo Revisited                                                               Seed:  96   Index:  20
+Overworld (Kaipo)                                                             Seed:  96   Index:  20
+Overworld (Damcyan)                                                           Seed:  96   Index:  20
+Mt.Hobs-West                                                                  Seed:  96   Index:  20
+  Step  19: 20 / Bomb x3 (8.832s)
+  Step  30: 21 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  96   Index:  59
+Battle: MomBomb                                                               Seed:  96   Index:  74
+Mt.Hobs Summit                                                                Seed:  96   Index:  74
+Mt.Hobs-East                                                                  Seed:  96   Index:  80
+  Step  22: 22 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed:  96   Index: 126
+  Step  22: 23 / Cocktric x3 (8.241s)
+  Step  55: 24 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  79: 25 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  96   Index: 210
+  Optional Steps: 10
+  Extra Steps: 10
+Overworld (Fabul)                                                             Seed: 113   Index:  34
+Fabul Boat and Leviatan                                                       Seed: 113   Index:  41
+Overworld (Mysidia)                                                           Seed: 113   Index:  41
+Mysidia                                                                       Seed: 113   Index:  50
+Overworld (Mysidia)                                                           Seed: 113   Index:  50
+  Extra Steps: 2
+Overworld (Mt.Ordeals)                                                        Seed: 113   Index:  62
+  Extra Steps: 10
+  Step  20: 26 / Raven x1 (8.356s)
+  Step  52: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  54: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  74: 29 / Raven x1 (8.356s)
+  Step 104: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 113   Index: 166
+Mt.Ordeals-3rd station                                                        Seed: 113   Index: 209
+  Step   9: 31 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+  Step  17: 32 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed: 113   Index: 232
+Mt.Ordeals-3rd station                                                        Seed: 113   Index: 232
+Mt.Ordeals-7th station                                                        Seed: 113   Index: 237
+Mt.Ordeals Summit                                                             Seed: 130   Index:  23
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 130   Index:  41
+Mt.Ordeals Summit                                                             Seed: 130   Index:  41
+  Extra Steps: 2
+  Step   5: 33 / Ghoul x2, Soul x2 (8.941s)
+Paladin                                                                       Seed: 130   Index:  47
+Mt.Ordeals Summit                                                             Seed: 130   Index:  47
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 130   Index:  70
+  Step  10: 34 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+  Step  20: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  42: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 130   Index: 112
+Mt.Ordeals                                                                    Seed: 130   Index: 142
+  Step  18: 37 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 130   Index: 186
+Take Chocobo to Mysidia                                                       Seed: 130   Index: 199
+Overworld (Mysidia)                                                           Seed: 130   Index: 199
+Town of Baron Serpent Road                                                    Seed: 130   Index: 199
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed: 130   Index: 207
+  Overworld (Baron)                                                           Seed: 130   Index: 207
+    Extra Steps: 8
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step   8: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  30: 40 / Imp x3, SwordRat x1)
+   (Step  94: 41 / Imp x3, SwordRat x1)
+   (Step 156: 42 / Imp x3, SwordRat x1)
+   (Step 191: 43 / Eagle x3)
+   (Step 198: 44 / Imp x3)
+   (Step 223: 45 / Eagle x3)
+
+Encounter Time:      302.974s
+Other Time:          502.739s
+Total Time:          805.712s
+
+Base Total Time:     964.449s
+Time Saved:          158.736s
+
+Optional Steps:      13
+Extra Steps:         74
+Encounters:          39
+
+Base Encounters:     47
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/046.txt
+++ b/data/routes/cw/046.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	46
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48350034
+VARS	FFFFFFFF:8 E302500:27 E302600:44 E307400:2 E307802:2 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed:  46   Index:   0
+Overworld (Kaipo)                                                             Seed:  46   Index:   1
+  Step  25: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  46   Index:  37
+Overworld (Kaipo)                                                             Seed:  46   Index:  37
+  Step  10: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step  21: 3 / Sand Man x4 (7.242s)
+  Step  24: 4 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  46   Index:  69
+Recruit Tellah                                                                Seed:  46   Index: 101
+Watery Pass-South B1F                                                         Seed:  46   Index: 101
+Watery Pass-South B2F                                                         Seed:  46   Index: 121
+  Step   4: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  65: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  46   Index: 211
+Watery Pass-South B2F                                                         Seed:  46   Index: 215
+  Step  21: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed:  46   Index: 254
+  Step  26: 8 / CaveToad x3 (7.014s)
+  Step  30: 9 / Pike x3 (7.152s)
+  Step  32: 10 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed:  63   Index:  32
+Watery Pass-North B1F                                                         Seed:  63   Index:  53
+  Step  15: 11 / Zombie x4 (7.148s)
+  Step  25: 12 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  63   Index: 113
+Waterfalls B1F                                                                Seed:  63   Index: 122
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed:  63   Index: 125
+Waterfalls Lake                                                               Seed:  63   Index: 170
+Battle: Octomamm                                                              Seed:  63   Index: 207
+Waterfalls Lake                                                               Seed:  63   Index: 207
+Overworld (Kaipo)                                                             Seed:  63   Index: 208
+Overworld (Damcyan)                                                           Seed:  63   Index: 219
+Damcyan                                                                       Seed:  63   Index: 223
+  Optional Steps: 1
+  Extra Steps: 26
+Overworld (Damcyan)                                                           Seed:  80   Index:   1
+Antlion B1F                                                                   Seed:  80   Index:   1
+  Step   9: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Direct                                                     Seed:  80   Index:  39
+  Antlion B2F                                                                 Seed:  80   Index:  39
+    Step   9: 14 / Basilisk x1, Imp x3 (6.775s)
+    Step  79: 15 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed:  80   Index: 119
+  Step   8: 16 / Cream x4 (7.552s)
+Battle: Antlion                                                               Seed:  80   Index: 133
+Antlion's Nest                                                                Seed:  80   Index: 133
+  Step   7: 17 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B2F Outward Direct                                                    Seed:  80   Index: 148
+  Antlion B2F                                                                 Seed:  80   Index: 148
+    Extra Steps: 2
+    Step  47: 18 / Weeper x2 (7.132s)
+    Step  81: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  80   Index: 230
+Overworld (Damcyan)                                                           Seed:  97   Index:  12
+Overworld (Kaipo)                                                             Seed:  97   Index:  12
+Kaipo Revisited                                                               Seed:  97   Index:  12
+Overworld (Kaipo)                                                             Seed:  97   Index:  12
+Overworld (Damcyan)                                                           Seed:  97   Index:  12
+Mt.Hobs-West                                                                  Seed:  97   Index:  12
+  Step  27: 20 / Bomb x3 (8.832s)
+  Step  38: 21 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  97   Index:  51
+Battle: MomBomb                                                               Seed:  97   Index:  66
+Mt.Hobs Summit                                                                Seed:  97   Index:  66
+Mt.Hobs-East                                                                  Seed:  97   Index:  72
+  Step  19: 22 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  30: 23 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed:  97   Index: 118
+  Step  30: 24 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  63: 25 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  97   Index: 202
+  Optional Steps: 10
+  Extra Steps: 34
+Overworld (Fabul)                                                             Seed: 114   Index:  50
+Fabul Boat and Leviatan                                                       Seed: 114   Index:  57
+Overworld (Mysidia)                                                           Seed: 114   Index:  57
+Mysidia                                                                       Seed: 114   Index:  66
+Overworld (Mysidia)                                                           Seed: 114   Index:  66
+Overworld (Mt.Ordeals)                                                        Seed: 114   Index:  76
+  Step   6: 26 / Raven x1 (8.356s)
+  Step  38: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  40: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  60: 29 / Raven x1 (8.356s)
+  Step  90: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 114   Index: 170
+Mt.Ordeals-3rd station                                                        Seed: 114   Index: 213
+  Step   5: 31 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+  Step  13: 32 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed: 114   Index: 236
+Mt.Ordeals-3rd station                                                        Seed: 114   Index: 236
+Mt.Ordeals-7th station                                                        Seed: 114   Index: 241
+Mt.Ordeals Summit                                                             Seed: 131   Index:  27
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 131   Index:  45
+Mt.Ordeals Summit                                                             Seed: 131   Index:  45
+  Step   1: 33 / Ghoul x2, Soul x2 (8.941s)
+Paladin                                                                       Seed: 131   Index:  49
+Mt.Ordeals Summit                                                             Seed: 131   Index:  49
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 131   Index:  72
+  Step   7: 34 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+  Step  18: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  40: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 131   Index: 114
+Mt.Ordeals                                                                    Seed: 131   Index: 144
+  Step  16: 37 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 131   Index: 188
+Take Chocobo to Mysidia                                                       Seed: 131   Index: 201
+Overworld (Mysidia)                                                           Seed: 131   Index: 201
+Town of Baron Serpent Road                                                    Seed: 131   Index: 201
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 131   Index: 207
+  Overworld (Baron)                                                           Seed: 131   Index: 207
+    Extra Steps: 8
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step   8: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  30: 40 / Imp x6)
+   (Step  93: 41 / Imp x3, SwordRat x1)
+   (Step  94: 42 / Imp x3, SwordRat x1)
+   (Step 156: 43 / Eagle x3)
+   (Step 198: 44 / Imp x3)
+   (Step 223: 45 / Eagle x3)
+
+Encounter Time:      301.770s
+Other Time:          502.739s
+Total Time:          804.509s
+
+Base Total Time:     844.445s
+Time Saved:          39.936s
+
+Optional Steps:      13
+Extra Steps:         74
+Encounters:          39
+
+Base Encounters:     42
+Encounters Saved:    3
+
+Number of Variables: 54

--- a/data/routes/cw/047.txt
+++ b/data/routes/cw/047.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	47
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48374676
+VARS	FFFFFFFF:8 E302500:27 E302600:44 E307400:2 E307802:2 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed:  47   Index:   0
+Overworld (Kaipo)                                                             Seed:  47   Index:   1
+  Step  25: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  26: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  47   Index:  37
+Overworld (Kaipo)                                                             Seed:  47   Index:  37
+  Step  10: 3 / Sand Man x4 (7.242s)
+  Step  21: 4 / Sandpede x1, Sand Man x2 (7.096s)
+  Step  24: 5 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  47   Index:  69
+Recruit Tellah                                                                Seed:  47   Index: 101
+Watery Pass-South B1F                                                         Seed:  47   Index: 101
+Watery Pass-South B2F                                                         Seed:  47   Index: 121
+  Step  65: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  47   Index: 211
+Watery Pass-South B2F                                                         Seed:  47   Index: 215
+  Step  21: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed:  47   Index: 254
+  Step  30: 8 / CaveToad x3 (7.014s)
+  Step  32: 9 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed:  64   Index:  32
+Watery Pass-North B1F                                                         Seed:  64   Index:  53
+  Step  15: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  25: 11 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed:  64   Index: 113
+Waterfalls B1F                                                                Seed:  64   Index: 122
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed:  64   Index: 125
+Waterfalls Lake                                                               Seed:  64   Index: 170
+Battle: Octomamm                                                              Seed:  64   Index: 207
+Waterfalls Lake                                                               Seed:  64   Index: 207
+Overworld (Kaipo)                                                             Seed:  64   Index: 208
+Overworld (Damcyan)                                                           Seed:  64   Index: 219
+Damcyan                                                                       Seed:  64   Index: 223
+  Optional Steps: 1
+  Extra Steps: 26
+Overworld (Damcyan)                                                           Seed:  81   Index:   1
+Antlion B1F                                                                   Seed:  81   Index:   1
+  Step   9: 12 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed:  81   Index:  39
+  Antlion B2F                                                                 Seed:  81   Index:  39
+    Step   9: 13 / SandWorm x2 (6.841s)
+    Step  79: 14 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:  81   Index: 119
+Battle: Antlion                                                               Seed:  81   Index: 133
+Antlion's Nest                                                                Seed:  81   Index: 133
+  Step   7: 15 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed:  81   Index: 148
+  Antlion B2F                                                                 Seed:  81   Index: 148
+    Extra Steps: 2
+    Step   9: 16 / Cream x4 (7.523s)
+    Step  47: 17 / Basilisk x1, Turtle x1 (7.124s)
+    Step  81: 18 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed:  81   Index: 230
+Overworld (Damcyan)                                                           Seed:  98   Index:  12
+Overworld (Kaipo)                                                             Seed:  98   Index:  12
+Kaipo Revisited                                                               Seed:  98   Index:  12
+Overworld (Kaipo)                                                             Seed:  98   Index:  12
+Overworld (Damcyan)                                                           Seed:  98   Index:  12
+Mt.Hobs-West                                                                  Seed:  98   Index:  12
+  Step  27: 19 / Bomb x3 (8.832s)
+  Step  38: 20 / Bomb x3 (8.832s)
+  Step  39: 21 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  98   Index:  51
+Battle: MomBomb                                                               Seed:  98   Index:  66
+Mt.Hobs Summit                                                                Seed:  98   Index:  66
+Mt.Hobs-East                                                                  Seed:  98   Index:  72
+  Step  19: 22 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  30: 23 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed:  98   Index: 118
+  Step  30: 24 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  63: 25 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  98   Index: 202
+  Optional Steps: 10
+  Extra Steps: 34
+Overworld (Fabul)                                                             Seed: 115   Index:  50
+Fabul Boat and Leviatan                                                       Seed: 115   Index:  57
+Overworld (Mysidia)                                                           Seed: 115   Index:  57
+Mysidia                                                                       Seed: 115   Index:  66
+Overworld (Mysidia)                                                           Seed: 115   Index:  66
+Overworld (Mt.Ordeals)                                                        Seed: 115   Index:  76
+  Step   6: 26 / Raven x1 (8.356s)
+  Step  12: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  38: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  40: 29 / Raven x1 (8.356s)
+  Step  90: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 115   Index: 170
+Mt.Ordeals-3rd station                                                        Seed: 115   Index: 213
+  Step   5: 31 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+  Step  13: 32 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed: 115   Index: 236
+Mt.Ordeals-3rd station                                                        Seed: 115   Index: 236
+Mt.Ordeals-7th station                                                        Seed: 115   Index: 241
+Mt.Ordeals Summit                                                             Seed: 132   Index:  27
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 132   Index:  45
+Mt.Ordeals Summit                                                             Seed: 132   Index:  45
+  Step   1: 33 / Ghoul x2, Soul x2 (8.941s)
+Paladin                                                                       Seed: 132   Index:  49
+Mt.Ordeals Summit                                                             Seed: 132   Index:  49
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 132   Index:  72
+  Step   7: 34 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+  Step  18: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  39: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 132   Index: 114
+Mt.Ordeals                                                                    Seed: 132   Index: 144
+  Step  16: 37 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 132   Index: 188
+Take Chocobo to Mysidia                                                       Seed: 132   Index: 201
+Overworld (Mysidia)                                                           Seed: 132   Index: 201
+Town of Baron Serpent Road                                                    Seed: 132   Index: 201
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 132   Index: 207
+  Overworld (Baron)                                                           Seed: 132   Index: 207
+    Extra Steps: 8
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step   8: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  30: 40 / Imp x6)
+   (Step  93: 41 / Imp x3, SwordRat x1)
+   (Step  94: 42 / Eagle x3)
+   (Step 132: 43 / Eagle x3)
+   (Step 156: 44 / Imp x3)
+   (Step 198: 45 / Eagle x3)
+
+Encounter Time:      302.180s
+Other Time:          502.739s
+Total Time:          804.919s
+
+Base Total Time:     925.025s
+Time Saved:          120.106s
+
+Optional Steps:      13
+Extra Steps:         74
+Encounters:          39
+
+Base Encounters:     46
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/048.txt
+++ b/data/routes/cw/048.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	48
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48481372
+VARS	FFFFFFFF:2 E302500:36 E302600:46 E307400:2 E308400:4 E308700:1 E308702:1 E309700:18
+
+Overworld (Kaipo)                                                             Seed:  48   Index:   0
+Overworld (Kaipo)                                                             Seed:  48   Index:   1
+  Step  25: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  26: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  48   Index:  37
+Overworld (Kaipo)                                                             Seed:  48   Index:  37
+  Step  10: 3 / Sand Man x4 (7.242s)
+  Step  21: 4 / Sandpede x1, Sand Man x2 (7.096s)
+  Step  24: 5 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  48   Index:  69
+Recruit Tellah                                                                Seed:  48   Index: 101
+Watery Pass-South B1F                                                         Seed:  48   Index: 101
+Watery Pass-South B2F                                                         Seed:  48   Index: 121
+  Step  65: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  48   Index: 211
+Watery Pass-South B2F                                                         Seed:  48   Index: 215
+  Step  21: 7 / Pike x2, EvilShel x2 (7.149s)
+  Step  31: 8 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  48   Index: 254
+  Step  30: 9 / Pike x3 (7.152s)
+  Step  32: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B2F                                                         Seed:  65   Index:  32
+Watery Pass-North B1F                                                         Seed:  65   Index:  53
+  Step  15: 11 / Zombie x4 (7.148s)
+  Step  25: 12 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  65   Index: 113
+Waterfalls B1F                                                                Seed:  65   Index: 122
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed:  65   Index: 125
+Waterfalls Lake                                                               Seed:  65   Index: 170
+  Step   8: 13 / Mad Toad x4 (7.317s)
+Battle: Octomamm                                                              Seed:  65   Index: 207
+Waterfalls Lake                                                               Seed:  65   Index: 207
+Overworld (Kaipo)                                                             Seed:  65   Index: 208
+Overworld (Damcyan)                                                           Seed:  65   Index: 219
+Damcyan                                                                       Seed:  65   Index: 223
+  Optional Steps: 0
+  Extra Steps: 36
+Overworld (Damcyan)                                                           Seed:  82   Index:  10
+Antlion B1F                                                                   Seed:  82   Index:  10
+  Step  38: 14 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  82   Index:  48
+  Antlion B2F                                                                 Seed:  82   Index:  48
+    Step  70: 15 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed:  82   Index: 128
+  Step  12: 16 / Basilisk x1, Imp x3 (6.775s)
+Battle: Antlion                                                               Seed:  82   Index: 142
+Antlion's Nest                                                                Seed:  82   Index: 142
+  Step  15: 17 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B2F Outward Direct                                                    Seed:  82   Index: 157
+  Antlion B2F                                                                 Seed:  82   Index: 157
+    Step  38: 18 / SandWorm x2 (6.858s)
+    Step  72: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  82   Index: 237
+Overworld (Damcyan)                                                           Seed:  99   Index:  19
+Overworld (Kaipo)                                                             Seed:  99   Index:  19
+Kaipo Revisited                                                               Seed:  99   Index:  19
+Overworld (Kaipo)                                                             Seed:  99   Index:  19
+Overworld (Damcyan)                                                           Seed:  99   Index:  19
+Mt.Hobs-West                                                                  Seed:  99   Index:  19
+  Step  20: 20 / Bomb x3 (8.832s)
+  Step  31: 21 / Skelton x4 (8.683s)
+  Step  32: 22 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed:  99   Index:  58
+Battle: MomBomb                                                               Seed:  99   Index:  73
+Mt.Hobs Summit                                                                Seed:  99   Index:  73
+Mt.Hobs-East                                                                  Seed:  99   Index:  79
+  Step  12: 23 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  23: 24 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  99   Index: 125
+  Step  23: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  56: 26 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  80: 27 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed:  99   Index: 209
+  Optional Steps: 10
+  Extra Steps: 36
+Overworld (Fabul)                                                             Seed: 116   Index:  59
+Fabul Boat and Leviatan                                                       Seed: 116   Index:  66
+Overworld (Mysidia)                                                           Seed: 116   Index:  66
+Mysidia                                                                       Seed: 116   Index:  75
+Overworld (Mysidia)                                                           Seed: 116   Index:  75
+Overworld (Mt.Ordeals)                                                        Seed: 116   Index:  85
+  Step   3: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  29: 29 / Raven x1 (8.356s)
+  Step  81: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 116   Index: 179
+  Extra Steps: 4
+  Step  39: 31 / Spirit x2, Skelton x2 (8.285s)
+  Step  47: 32 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 116   Index: 226
+Recruit Tellah                                                                Seed: 116   Index: 249
+Mt.Ordeals-3rd station                                                        Seed: 116   Index: 249
+Mt.Ordeals-7th station                                                        Seed: 116   Index: 254
+Mt.Ordeals Summit                                                             Seed: 133   Index:  40
+  Optional Steps: 1
+  Step   6: 33 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed: 133   Index:  58
+Mt.Ordeals Summit                                                             Seed: 133   Index:  58
+Paladin                                                                       Seed: 133   Index:  62
+Mt.Ordeals Summit                                                             Seed: 133   Index:  62
+  Optional Steps: 1
+  Step  17: 34 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-7th station                                                        Seed: 133   Index:  85
+  Step   5: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  26: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 133   Index: 127
+Mt.Ordeals                                                                    Seed: 133   Index: 157
+Overworld (Mt.Ordeals)                                                        Seed: 133   Index: 201
+  Step   7: 37 / Imp Cap. x4, Imp x2 (8.400s)
+Take Chocobo to Mysidia                                                       Seed: 133   Index: 214
+Overworld (Mysidia)                                                           Seed: 133   Index: 214
+Town of Baron Serpent Road                                                    Seed: 133   Index: 214
+  Extra Steps: 18
+Credit Warp Fight Search                                                      Seed: 133   Index: 236
+  Overworld (Baron)                                                           Seed: 133   Index: 236
+    Extra Steps: 2
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step   2: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  64: 40 / Imp x3)
+   (Step  65: 41 / Imp x3, SwordRat x1)
+   (Step 103: 42 / Eagle x3)
+   (Step 169: 43 / Eagle x3)
+   (Step 193: 44 / Imp x3)
+   (Step 236: 45 / Imp x4)
+
+Encounter Time:      299.164s
+Other Time:          507.531s
+Total Time:          806.694s
+
+Base Total Time:     902.518s
+Time Saved:          95.824s
+
+Optional Steps:      12
+Extra Steps:         98
+Encounters:          39
+
+Base Encounters:     47
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/049.txt
+++ b/data/routes/cw/049.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	49
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48913808
+VARS	FFFFFFFF:2 E302500:24 E302600:1 E305400:120 E307200:6 E307400:18 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  49   Index:   0
+Overworld (Kaipo)                                                             Seed:  49   Index:   1
+  Step  26: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  49   Index:  37
+Overworld (Kaipo)                                                             Seed:  49   Index:  37
+  Step  10: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step  21: 3 / Sand Man x4 (7.242s)
+  Step  24: 4 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  49   Index:  69
+Recruit Tellah                                                                Seed:  49   Index: 101
+Watery Pass-South B1F                                                         Seed:  49   Index: 101
+Watery Pass-South B2F                                                         Seed:  49   Index: 121
+  Step  46: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  65: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  49   Index: 211
+  Extra Steps: 120
+Watery Pass-South B2F                                                         Seed:  66   Index:  79
+Watery Pass-South B3F                                                         Seed:  66   Index: 118
+Watery Pass-North B2F                                                         Seed:  66   Index: 152
+  Extra Steps: 6
+  Step  26: 7 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:  66   Index: 179
+Overworld (Kaipo)                                                             Seed:  66   Index: 239
+Waterfalls B1F                                                                Seed:  66   Index: 248
+  Extra Steps: 18
+Waterfalls B2F                                                                Seed:  83   Index:  11
+Waterfalls Lake                                                               Seed:  83   Index:  56
+  Step  29: 8 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed:  83   Index:  93
+Waterfalls Lake                                                               Seed:  83   Index:  93
+Overworld (Kaipo)                                                             Seed:  83   Index:  94
+Overworld (Damcyan)                                                           Seed:  83   Index: 105
+Damcyan                                                                       Seed:  83   Index: 109
+  Optional Steps: 0
+  Extra Steps: 24
+Overworld (Damcyan)                                                           Seed:  83   Index: 140
+Antlion B1F                                                                   Seed:  83   Index: 140
+  Step  17: 9 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed:  83   Index: 178
+  Antlion B2F                                                                 Seed:  83   Index: 178
+    Step  17: 10 / Basilisk x1, Turtle x1 (7.110s)
+    Step  51: 11 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 100   Index:   2
+Battle: Antlion                                                               Seed: 100   Index:  16
+Antlion's Nest                                                                Seed: 100   Index:  16
+Antlion B2F Outward Direct                                                    Seed: 100   Index:  31
+  Antlion B2F                                                                 Seed: 100   Index:  31
+    Step   8: 12 / Basilisk x1, Turtle x1 (7.124s)
+    Step  20: 13 / SandWorm x2 (6.858s)
+    Step  60: 14 / Turtle x2 (7.464s)
+    Step  71: 15 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 100   Index: 111
+  Step   4: 16 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  37: 17 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed: 100   Index: 149
+Overworld (Kaipo)                                                             Seed: 100   Index: 149
+Kaipo Revisited                                                               Seed: 100   Index: 149
+Overworld (Kaipo)                                                             Seed: 100   Index: 149
+Overworld (Damcyan)                                                           Seed: 100   Index: 149
+Mt.Hobs-West                                                                  Seed: 100   Index: 149
+  Step  32: 18 / GrayBomb x2, Bomb x2 (10.938s)
+Mt.Hobs Summit                                                                Seed: 100   Index: 188
+Battle: MomBomb                                                               Seed: 100   Index: 203
+Mt.Hobs Summit                                                                Seed: 100   Index: 203
+Mt.Hobs-East                                                                  Seed: 100   Index: 209
+  Step   8: 19 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 100   Index: 255
+  Step  18: 20 / Cocktric x3 (8.241s)
+  Step  34: 21 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  50: 22 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  60: 23 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 117   Index:  83
+  Optional Steps: 1
+Overworld (Fabul)                                                             Seed: 117   Index: 144
+Fabul Boat and Leviatan                                                       Seed: 117   Index: 151
+Overworld (Mysidia)                                                           Seed: 117   Index: 151
+Mysidia                                                                       Seed: 117   Index: 160
+Overworld (Mysidia)                                                           Seed: 117   Index: 160
+  Step   6: 24 / Needler x2, SwordRat x2 (8.097s)
+  Step   9: 25 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 117   Index: 170
+  Step  48: 26 / Raven x1 (8.356s)
+  Step  56: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 134   Index:   8
+  Step  38: 28 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 134   Index:  51
+Recruit Tellah                                                                Seed: 134   Index:  74
+Mt.Ordeals-3rd station                                                        Seed: 134   Index:  74
+  Step   5: 29 / Ghoul x1, Red Bone x2, Skelton x2 (8.832s)
+Mt.Ordeals-7th station                                                        Seed: 134   Index:  79
+  Step  11: 30 / Revenant x1, Ghoul x3 (8.914s)
+  Step  32: 31 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 134   Index: 121
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 134   Index: 139
+Mt.Ordeals Summit                                                             Seed: 134   Index: 139
+Paladin                                                                       Seed: 134   Index: 143
+Mt.Ordeals Summit                                                             Seed: 134   Index: 143
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 134   Index: 166
+  Step   2: 32 / Revenant x1, Ghoul x3 (8.489s)
+  Step  42: 33 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 134   Index: 208
+  Step  29: 34 / Lilith x1, Red Bone x2 (8.437s)
+  Step  30: 35 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 134   Index: 238
+Overworld (Mt.Ordeals)                                                        Seed: 151   Index:  26
+Take Chocobo to Mysidia                                                       Seed: 151   Index:  39
+Overworld (Mysidia)                                                           Seed: 151   Index:  39
+Town of Baron Serpent Road                                                    Seed: 151   Index:  39
+Credit Warp Fight Search                                                      Seed: 151   Index:  43
+  Overworld (Baron)                                                           Seed: 151   Index:  43
+    Extra Steps: 2
+    Step   1: 36 / FloatEye x1, Eagle x2 (7.365s)
+    Step   2: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step  40: 38 / FloatEye x1, Eagle x2)
+   (Step  62: 39 / Imp x3, SwordRat x1)
+   (Step 106: 40 / Imp x3)
+   (Step 130: 41 / Imp x3, SwordRat x1)
+   (Step 200: 42 / Eagle x3)
+   (Step 218: 43 / Eagle x3)
+   (Step 224: 44 / Imp x3)
+
+Encounter Time:      287.190s
+Other Time:          526.699s
+Total Time:          813.890s
+
+Base Total Time:     885.233s
+Time Saved:          71.343s
+
+Optional Steps:      3
+Extra Steps:         170
+Encounters:          37
+
+Base Encounters:     45
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/050.txt
+++ b/data/routes/cw/050.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	50
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48639954
+VARS	FFFFFFFF:2 C307800:1 E302600:10 E305400:32 E307100:4 E307300:4 E307B00:34 E308000:15 E308700:1 E308701:2 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  50   Index:   0
+Overworld (Kaipo)                                                             Seed:  50   Index:   1
+  Step  26: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  50   Index:  37
+Overworld (Kaipo)                                                             Seed:  50   Index:  37
+  Step  10: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step  17: 3 / Sand Man x4 (7.242s)
+  Step  21: 4 / Imp x4 (6.944s)
+  Step  24: 5 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  50   Index:  69
+Recruit Tellah                                                                Seed:  50   Index: 101
+Watery Pass-South B1F                                                         Seed:  50   Index: 101
+Watery Pass-South B2F                                                         Seed:  50   Index: 121
+  Step  46: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  65: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  50   Index: 211
+  Extra Steps: 32
+Watery Pass-South B2F                                                         Seed:  50   Index: 247
+  Step  37: 8 / Pike x3 (7.152s)
+  Step  39: 9 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  67   Index:  30
+  Extra Steps: 4
+  Step  13: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B2F                                                         Seed:  67   Index:  68
+  Step  10: 11 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed:  67   Index:  89
+  Extra Steps: 4
+  Step  64: 12 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  67   Index: 153
+Waterfalls B1F                                                                Seed:  67   Index: 162
+Waterfalls B2F                                                                Seed:  67   Index: 163
+  Step  15: 13 / TinyMage x4 (7.558s)
+Waterfalls Lake                                                               Seed:  67   Index: 208
+Battle: Octomamm                                                              Seed:  67   Index: 245
+Waterfalls Lake                                                               Seed:  67   Index: 245
+Overworld (Kaipo)                                                             Seed:  67   Index: 246
+  Step   4: 14 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed:  84   Index:   1
+Damcyan                                                                       Seed:  84   Index:   5
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  84   Index:  12
+Antlion B1F                                                                   Seed:  84   Index:  12
+Antlion B2F Inward Charm Room Steps                                           Seed:  84   Index:  50
+  Antlion B2F                                                                 Seed:  84   Index:  50
+  Antlion B2F Treasure Room                                                   Seed:  84   Index:  83
+    Extra Steps: 34
+  Antlion B2F                                                                 Seed:  84   Index: 117
+    Step  23: 15 / Weeper x2 (7.114s)
+    Step  40: 16 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:  84   Index: 169
+Battle: Antlion                                                               Seed:  84   Index: 183
+Antlion's Nest                                                                Seed:  84   Index: 183
+  Step  12: 17 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B2F Outward Direct                                                    Seed:  84   Index: 198
+  Antlion B2F                                                                 Seed:  84   Index: 198
+    Step  31: 18 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 101   Index:  22
+  Step  17: 19 / Cream x4 (7.523s)
+  Step  29: 20 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed: 101   Index:  60
+Overworld (Kaipo)                                                             Seed: 101   Index:  60
+Kaipo Revisited                                                               Seed: 101   Index:  60
+Overworld (Kaipo)                                                             Seed: 101   Index:  60
+Overworld (Damcyan)                                                           Seed: 101   Index:  60
+Mt.Hobs-West                                                                  Seed: 101   Index:  60
+  Step  31: 21 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 101   Index:  99
+  Step   3: 22 / Cocktric x3 (9.055s)
+Battle: MomBomb                                                               Seed: 101   Index: 114
+Mt.Hobs Summit                                                                Seed: 101   Index: 114
+  Step   1: 23 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed: 101   Index: 120
+  Extra Steps: 15
+  Step  27: 24 / Gargoyle x2 (7.630s)
+  Step  61: 25 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 101   Index: 181
+  Step  36: 26 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 118   Index:   9
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 118   Index:  79
+Fabul Boat and Leviatan                                                       Seed: 118   Index:  86
+Overworld (Mysidia)                                                           Seed: 118   Index:  86
+  Step   2: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.462s)
+Mysidia                                                                       Seed: 118   Index:  95
+Overworld (Mysidia)                                                           Seed: 118   Index:  95
+Overworld (Mt.Ordeals)                                                        Seed: 118   Index: 105
+  Step  61: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  64: 29 / Raven x1 (8.356s)
+  Step  72: 30 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 118   Index: 199
+  Step  27: 31 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 118   Index: 242
+Recruit Tellah                                                                Seed: 135   Index:   9
+Mt.Ordeals-3rd station                                                        Seed: 135   Index:   9
+Mt.Ordeals-7th station                                                        Seed: 135   Index:  14
+  Step  32: 32 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 135   Index:  56
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 135   Index:  74
+Mt.Ordeals Summit                                                             Seed: 135   Index:  74
+  Extra Steps: 2
+  Step   5: 33 / Ghoul x2, Soul x2 (8.941s)
+Paladin                                                                       Seed: 135   Index:  80
+Mt.Ordeals Summit                                                             Seed: 135   Index:  80
+  Optional Steps: 1
+  Step  10: 34 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-7th station                                                        Seed: 135   Index: 103
+  Step   8: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 135   Index: 145
+  Step  23: 36 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 135   Index: 175
+  Step  23: 37 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 135   Index: 219
+Take Chocobo to Mysidia                                                       Seed: 135   Index: 232
+Overworld (Mysidia)                                                           Seed: 135   Index: 232
+Town of Baron Serpent Road                                                    Seed: 135   Index: 232
+Credit Warp Fight Search                                                      Seed: 135   Index: 236
+  Overworld (Baron)                                                           Seed: 135   Index: 236
+    Extra Steps: 2
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step   2: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  45: 40 / Imp x3)
+   (Step  64: 41 / Imp x3, SwordRat x1)
+   (Step  65: 42 / Eagle x3)
+   (Step 103: 43 / Eagle x3)
+   (Step 125: 44 / Imp x3)
+   (Step 169: 45 / Imp x4)
+   (Step 193: 46 / Imp x4)
+
+Encounter Time:      298.275s
+Other Time:          511.058s
+Total Time:          809.333s
+
+Base Total Time:     875.341s
+Time Saved:          66.008s
+
+Optional Steps:      12
+Extra Steps:         93
+Encounters:          39
+
+Base Encounters:     46
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/051.txt
+++ b/data/routes/cw/051.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	51
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50067672
+VARS	FFFFFFFF:20 C307800:1 E000202:2 E302500:29 E305400:84 E307B00:2 E308502:8 E308700:1 E308702:1 E309700:20
+
+Overworld (Kaipo)                                                             Seed:  51   Index:   0
+Overworld (Kaipo)                                                             Seed:  51   Index:   1
+  Step  26: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  51   Index:  37
+Overworld (Kaipo)                                                             Seed:  51   Index:  37
+  Step  17: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step  21: 3 / Sandpede x1, Sand Man x2 (7.096s)
+  Step  24: 4 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  51   Index:  69
+  Step  20: 5 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:  51   Index: 101
+Watery Pass-South B1F                                                         Seed:  51   Index: 101
+Watery Pass-South B2F                                                         Seed:  51   Index: 121
+  Step  46: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  65: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  51   Index: 211
+  Extra Steps: 84
+Watery Pass-South B2F                                                         Seed:  68   Index:  43
+Watery Pass-South B3F                                                         Seed:  68   Index:  82
+Watery Pass-North B2F                                                         Seed:  68   Index: 116
+  Step   3: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed:  68   Index: 137
+  Step  16: 9 / Zombie x4 (7.148s)
+  Step  41: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  68   Index: 197
+Waterfalls B1F                                                                Seed:  68   Index: 206
+Waterfalls B2F                                                                Seed:  68   Index: 207
+  Step  43: 11 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed:  68   Index: 252
+  Step  12: 12 / Aligator x2 (7.544s)
+  Step  14: 13 / TinyMage x4 (7.558s)
+Battle: Octomamm                                                              Seed:  85   Index:  33
+Waterfalls Lake                                                               Seed:  85   Index:  33
+Overworld (Kaipo)                                                             Seed:  85   Index:  34
+Overworld (Damcyan)                                                           Seed:  85   Index:  45
+Damcyan                                                                       Seed:  85   Index:  49
+  Optional Steps: 1
+  Extra Steps: 28
+Overworld (Damcyan)                                                           Seed:  85   Index:  85
+Antlion B1F                                                                   Seed:  85   Index:  85
+  Step  32: 14 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Charm Room Steps                                           Seed:  85   Index: 123
+  Antlion B2F                                                                 Seed:  85   Index: 123
+    Step  17: 15 / Weeper x2 (7.114s)
+  Antlion B2F Treasure Room                                                   Seed:  85   Index: 156
+    Extra Steps: 2
+  Antlion B2F                                                                 Seed:  85   Index: 158
+Antlion's Nest                                                                Seed:  85   Index: 210
+Battle: Antlion                                                               Seed:  85   Index: 224
+Antlion's Nest                                                                Seed:  85   Index: 224
+  Step   5: 16 / Basilisk x1, Imp x3 (6.783s)
+Antlion B2F Outward Direct                                                    Seed:  85   Index: 239
+  Antlion B2F                                                                 Seed:  85   Index: 239
+    Step  56: 17 / Basilisk x1, Turtle x1 (7.124s)
+    Step  68: 18 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 102   Index:  63
+  Step  28: 19 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed: 102   Index: 101
+Overworld (Kaipo)                                                             Seed: 102   Index: 101
+  Extra Steps: 2
+  Step   1: 20 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed: 102   Index: 103
+Overworld (Kaipo)                                                             Seed: 102   Index: 103
+Overworld (Damcyan)                                                           Seed: 102   Index: 103
+Mt.Hobs-West                                                                  Seed: 102   Index: 103
+  Step  12: 21 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 102   Index: 142
+  Step   5: 22 / Cocktric x3 (9.055s)
+Battle: MomBomb                                                               Seed: 102   Index: 157
+Mt.Hobs Summit                                                                Seed: 102   Index: 157
+Mt.Hobs-East                                                                  Seed: 102   Index: 163
+Overworld (Fabul)                                                             Seed: 102   Index: 209
+  Step   8: 23 / Cocktric x3 (8.241s)
+  Step  26: 24 / SwordRat x3, Needler x3 (7.663s)
+  Step  64: 25 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 119   Index:  37
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 119   Index:  97
+Fabul Boat and Leviatan                                                       Seed: 119   Index: 104
+Overworld (Mysidia)                                                           Seed: 119   Index: 104
+Mysidia                                                                       Seed: 119   Index: 113
+Overworld (Mysidia)                                                           Seed: 119   Index: 113
+Overworld (Mt.Ordeals)                                                        Seed: 119   Index: 123
+  Step  43: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  46: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  54: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  86: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 119   Index: 217
+Mt.Ordeals-3rd station                                                        Seed: 136   Index:   4
+Recruit Tellah                                                                Seed: 136   Index:  27
+Mt.Ordeals-3rd station                                                        Seed: 136   Index:  27
+Mt.Ordeals-7th station                                                        Seed: 136   Index:  32
+  Step  39: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 136   Index:  74
+  Optional Steps: 1
+  Step   5: 31 / Ghoul x2, Soul x2 (9.197s)
+  Step  16: 32 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed: 136   Index:  92
+Mt.Ordeals Summit                                                             Seed: 136   Index:  92
+Paladin                                                                       Seed: 136   Index:  96
+Mt.Ordeals Summit                                                             Seed: 136   Index:  96
+  Optional Steps: 1
+  Step  15: 33 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed: 136   Index: 119
+Mt.Ordeals-3rd station                                                        Seed: 136   Index: 161
+  Extra Steps: 8
+  Step   7: 34 / Lilith x1, Red Bone x2 (8.437s)
+  Step  37: 35 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 136   Index: 199
+  Step  38: 36 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+  Step  39: 37 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 136   Index: 243
+Take Chocobo to Mysidia                                                       Seed: 153   Index:   0
+Overworld (Mysidia)                                                           Seed: 153   Index:   0
+Town of Baron Serpent Road                                                    Seed: 153   Index:   0
+  Extra Steps: 20
+Credit Warp Fight Search                                                      Seed: 153   Index:  24
+  Overworld (Baron)                                                           Seed: 153   Index:  24
+    Extra Steps: 20
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step  20: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  59: 40 / Imp x3)
+   (Step  81: 41 / Eagle x3)
+   (Step 125: 42 / Eagle x3)
+   (Step 149: 43 / Eagle x3)
+   (Step 187: 44 / Imp x3)
+   (Step 237: 45 / Imp x4)
+
+Encounter Time:      298.603s
+Other Time:          534.486s
+Total Time:          833.089s
+
+Base Total Time:     875.241s
+Time Saved:          42.152s
+
+Optional Steps:      3
+Extra Steps:         164
+Encounters:          39
+
+Base Encounters:     46
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/052.txt
+++ b/data/routes/cw/052.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	52
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	51137336
+VARS	FFFFFFFF:32 E302500:1 E302600:8 E307700:22 E307802:8
+
+Overworld (Kaipo)                                                             Seed:  52   Index:   0
+Overworld (Kaipo)                                                             Seed:  52   Index:   1
+  Step  26: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  52   Index:  37
+Overworld (Kaipo)                                                             Seed:  52   Index:  37
+  Step  17: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step  24: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  52   Index:  69
+  Step  20: 4 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  52   Index: 101
+Watery Pass-South B1F                                                         Seed:  52   Index: 101
+Watery Pass-South B2F                                                         Seed:  52   Index: 121
+  Step  22: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  46: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  65: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  52   Index: 211
+Watery Pass-South B2F                                                         Seed:  52   Index: 215
+  Step  31: 8 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  52   Index: 254
+  Step  32: 9 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed:  69   Index:  32
+  Step  11: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B1F                                                         Seed:  69   Index:  53
+Overworld (Kaipo)                                                             Seed:  69   Index: 113
+  Step   6: 11 / SandMoth x2, Larva x2 (7.163s)
+Waterfalls B1F                                                                Seed:  69   Index: 122
+Waterfalls B2F                                                                Seed:  69   Index: 123
+  Step  30: 12 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed:  69   Index: 168
+  Step  10: 13 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed:  69   Index: 205
+Waterfalls Lake                                                               Seed:  69   Index: 205
+Overworld (Kaipo)                                                             Seed:  69   Index: 206
+Overworld (Damcyan)                                                           Seed:  69   Index: 217
+Damcyan                                                                       Seed:  69   Index: 221
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  69   Index: 229
+Antlion B1F                                                                   Seed:  69   Index: 229
+  Extra Steps: 22
+  Step   2: 14 / Turtle x1, Imp x2 (7.044s)
+  Step  21: 15 / Turtle x2 (7.487s)
+  Step  35: 16 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  59: 17 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed:  86   Index:  33
+  Antlion B2F                                                                 Seed:  86   Index:  33
+    Step  43: 18 / SandWorm x2 (6.841s)
+    Step  52: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed:  86   Index: 113
+  Step   4: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed:  86   Index: 127
+Antlion's Nest                                                                Seed:  86   Index: 127
+  Step  13: 21 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed:  86   Index: 142
+  Antlion B2F                                                                 Seed:  86   Index: 142
+    Extra Steps: 8
+    Step  15: 22 / Basilisk x1, Turtle x1 (7.124s)
+    Step  87: 23 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  86   Index: 230
+  Step  38: 24 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed: 103   Index:  12
+Overworld (Kaipo)                                                             Seed: 103   Index:  12
+Kaipo Revisited                                                               Seed: 103   Index:  12
+Overworld (Kaipo)                                                             Seed: 103   Index:  12
+Overworld (Damcyan)                                                           Seed: 103   Index:  12
+Mt.Hobs-West                                                                  Seed: 103   Index:  12
+  Step  39: 25 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 103   Index:  51
+Battle: MomBomb                                                               Seed: 103   Index:  66
+Mt.Hobs Summit                                                                Seed: 103   Index:  66
+Mt.Hobs-East                                                                  Seed: 103   Index:  72
+  Step  19: 26 / Turtle x2 (7.432s)
+  Step  30: 27 / Gargoyle x2 (7.630s)
+  Step  43: 28 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 103   Index: 118
+  Step  29: 29 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  63: 30 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 103   Index: 202
+  Optional Steps: 8
+Overworld (Fabul)                                                             Seed: 120   Index:  14
+  Step   3: 31 / Imp Cap. x3, Needler x1 (7.956s)
+Fabul Boat and Leviatan                                                       Seed: 120   Index:  21
+Overworld (Mysidia)                                                           Seed: 120   Index:  21
+  Step   2: 32 / SwordRat x2, Imp x2, TinyMage x2 (7.462s)
+Mysidia                                                                       Seed: 120   Index:  30
+Overworld (Mysidia)                                                           Seed: 120   Index:  30
+Overworld (Mt.Ordeals)                                                        Seed: 120   Index:  40
+  Step   9: 33 / Raven x1 (8.356s)
+  Step  19: 34 / Raven x1, Cocktric x3 (9.100s)
+  Step  48: 35 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 120   Index: 134
+  Step  35: 36 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  43: 37 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 120   Index: 177
+Recruit Tellah                                                                Seed: 120   Index: 200
+Mt.Ordeals-3rd station                                                        Seed: 120   Index: 200
+Mt.Ordeals-7th station                                                        Seed: 120   Index: 205
+  Step   4: 38 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 120   Index: 247
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 137   Index:   8
+Mt.Ordeals Summit                                                             Seed: 137   Index:   8
+Paladin                                                                       Seed: 137   Index:  12
+Mt.Ordeals Summit                                                             Seed: 137   Index:  12
+  Optional Steps: 0
+  Step   2: 39 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed: 137   Index:  34
+  Step  37: 40 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 137   Index:  76
+  Step   3: 41 / Revenant x1, Ghoul x3 (8.489s)
+  Step  14: 42 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed: 137   Index: 106
+  Step   5: 43 / Soul x2, Red Bone x2 (8.881s)
+Overworld (Mt.Ordeals)                                                        Seed: 137   Index: 150
+Take Chocobo to Mysidia                                                       Seed: 137   Index: 163
+Overworld (Mysidia)                                                           Seed: 137   Index: 163
+Town of Baron Serpent Road                                                    Seed: 137   Index: 163
+Credit Warp Fight Search                                                      Seed: 137   Index: 167
+  Overworld (Baron)                                                           Seed: 137   Index: 167
+    Extra Steps: 32
+    Step   1: 44 / Imp x3 (7.174s)
+    Step  31: 45 / Imp x4 (7.223s)
+   (Step  71: 46 / Imp x4)
+   (Step 114: 47 / Imp x4)
+   (Step 133: 48 / FloatEye x2)
+   (Step 172: 49 / Imp x3)
+   (Step 194: 50 / Imp x3, SwordRat x1)
+   (Step 243: 51 / Imp x3)
+
+Encounter Time:      344.954s
+Other Time:          505.933s
+Total Time:          850.888s
+
+Base Total Time:     870.599s
+Time Saved:          19.712s
+
+Optional Steps:      9
+Extra Steps:         62
+Encounters:          45
+
+Base Encounters:     45
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/053.txt
+++ b/data/routes/cw/053.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	53
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48340212
+VARS	FFFFFFFF:4 E000500:14 E302500:30 E302600:48 E307300:6 E308502:2 E308700:1 E308702:1 E309700:6
+
+Overworld (Kaipo)                                                             Seed:  53   Index:   0
+Overworld (Kaipo)                                                             Seed:  53   Index:   1
+  Step  14: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  26: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  53   Index:  37
+Overworld (Kaipo)                                                             Seed:  53   Index:  37
+  Step  17: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  53   Index:  69
+  Step  20: 4 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  53   Index: 101
+Watery Pass-South B1F                                                         Seed:  53   Index: 101
+Watery Pass-South B2F                                                         Seed:  53   Index: 121
+  Step  22: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  46: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  53   Index: 211
+Watery Pass-South B2F                                                         Seed:  53   Index: 215
+  Step  31: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed:  53   Index: 254
+Watery Pass-North B2F                                                         Seed:  70   Index:  32
+  Step  11: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed:  70   Index:  53
+  Extra Steps: 6
+  Step  19: 9 / Zombie x4 (7.148s)
+  Step  66: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  70   Index: 119
+Waterfalls B1F                                                                Seed:  70   Index: 128
+Waterfalls B2F                                                                Seed:  70   Index: 129
+  Step  24: 11 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed:  70   Index: 174
+  Step   4: 12 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed:  70   Index: 211
+Waterfalls Lake                                                               Seed:  70   Index: 211
+Overworld (Kaipo)                                                             Seed:  70   Index: 212
+Overworld (Damcyan)                                                           Seed:  70   Index: 223
+Damcyan                                                                       Seed:  70   Index: 227
+  Optional Steps: 0
+  Extra Steps: 30
+Overworld (Damcyan)                                                           Seed:  87   Index:   8
+Antlion B1F                                                                   Seed:  87   Index:   8
+  Step  24: 13 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed:  87   Index:  46
+  Antlion B2F                                                                 Seed:  87   Index:  46
+    Step  30: 14 / Turtle x2 (7.487s)
+    Step  39: 15 / Weeper x2 (7.114s)
+    Step  71: 16 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:  87   Index: 126
+  Step  14: 17 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed:  87   Index: 140
+Antlion's Nest                                                                Seed:  87   Index: 140
+Antlion B2F Outward Direct                                                    Seed:  87   Index: 155
+  Antlion B2F                                                                 Seed:  87   Index: 155
+    Step   2: 18 / SandWorm x2 (6.858s)
+    Step  58: 19 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed:  87   Index: 235
+  Step  33: 20 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed: 104   Index:  17
+Overworld (Kaipo)                                                             Seed: 104   Index:  17
+Kaipo Revisited                                                               Seed: 104   Index:  17
+Overworld (Kaipo)                                                             Seed: 104   Index:  17
+Overworld (Damcyan)                                                           Seed: 104   Index:  17
+Mt.Hobs-West                                                                  Seed: 104   Index:  17
+  Step  34: 21 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 104   Index:  56
+  Step   6: 22 / Cocktric x3 (9.055s)
+Battle: MomBomb                                                               Seed: 104   Index:  71
+Mt.Hobs Summit                                                                Seed: 104   Index:  71
+Mt.Hobs-East                                                                  Seed: 104   Index:  77
+  Step  14: 23 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  38: 24 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 104   Index: 123
+  Step  24: 25 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 104   Index: 207
+  Optional Steps: 10
+  Extra Steps: 38
+Overworld (Fabul)                                                             Seed: 121   Index:  59
+Fabul Boat and Leviatan                                                       Seed: 121   Index:  66
+Overworld (Mysidia)                                                           Seed: 121   Index:  66
+  Extra Steps: 14
+  Step  22: 26 / Needler x2, SwordRat x2 (8.011s)
+Mysidia                                                                       Seed: 121   Index:  89
+Overworld (Mysidia)                                                           Seed: 121   Index:  89
+Overworld (Mt.Ordeals)                                                        Seed: 121   Index:  99
+  Step  56: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  67: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  70: 29 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  78: 30 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 121   Index: 193
+  Step  16: 31 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 121   Index: 236
+Recruit Tellah                                                                Seed: 138   Index:   3
+Mt.Ordeals-3rd station                                                        Seed: 138   Index:   3
+Mt.Ordeals-7th station                                                        Seed: 138   Index:   8
+  Step   6: 32 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 138   Index:  50
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 138   Index:  68
+Mt.Ordeals Summit                                                             Seed: 138   Index:  68
+  Step   3: 33 / Ghoul x2, Soul x2 (8.941s)
+Paladin                                                                       Seed: 138   Index:  72
+Mt.Ordeals Summit                                                             Seed: 138   Index:  72
+  Optional Steps: 1
+  Step   7: 34 / Lilith x2 (9.169s)
+Mt.Ordeals-7th station                                                        Seed: 138   Index:  95
+  Step  16: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 138   Index: 137
+  Extra Steps: 2
+  Step  31: 36 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 138   Index: 169
+  Step  29: 37 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 138   Index: 213
+Take Chocobo to Mysidia                                                       Seed: 138   Index: 226
+Overworld (Mysidia)                                                           Seed: 138   Index: 226
+Town of Baron Serpent Road                                                    Seed: 138   Index: 226
+  Extra Steps: 6
+Credit Warp Fight Search                                                      Seed: 138   Index: 236
+  Overworld (Baron)                                                           Seed: 138   Index: 236
+    Extra Steps: 4
+    Step   2: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step   4: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  45: 40 / Imp x3)
+   (Step 103: 41 / Eagle x3)
+   (Step 125: 42 / Eagle x3)
+   (Step 174: 43 / Eagle x3)
+   (Step 193: 44 / Imp x3)
+   (Step 205: 45 / Imp x4)
+   (Step 231: 46 / Imp x4)
+
+Encounter Time:      295.750s
+Other Time:          508.596s
+Total Time:          804.346s
+
+Base Total Time:     868.017s
+Time Saved:          63.672s
+
+Optional Steps:      12
+Extra Steps:         100
+Encounters:          39
+
+Base Encounters:     45
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/054.txt
+++ b/data/routes/cw/054.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	54
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50439086
+VARS	FFFFFFFF:4 E302500:55 E302600:52 E307300:6 E309700:119
+
+Overworld (Kaipo)                                                             Seed:  54   Index:   0
+Overworld (Kaipo)                                                             Seed:  54   Index:   1
+  Step  14: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  26: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  54   Index:  37
+Overworld (Kaipo)                                                             Seed:  54   Index:  37
+  Step  16: 3 / Sandpede x1, Sand Man x2 (7.096s)
+  Step  17: 4 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  54   Index:  69
+  Step  20: 5 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:  54   Index: 101
+Watery Pass-South B1F                                                         Seed:  54   Index: 101
+Watery Pass-South B2F                                                         Seed:  54   Index: 121
+  Step  22: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  46: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  54   Index: 211
+Watery Pass-South B2F                                                         Seed:  54   Index: 215
+  Step  31: 8 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  54   Index: 254
+Watery Pass-North B2F                                                         Seed:  71   Index:  32
+  Step  11: 9 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed:  71   Index:  53
+  Extra Steps: 6
+  Step  19: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  24: 11 / Zombie x4 (7.148s)
+  Step  66: 12 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  71   Index: 119
+Waterfalls B1F                                                                Seed:  71   Index: 128
+Waterfalls B2F                                                                Seed:  71   Index: 129
+  Step  24: 13 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed:  71   Index: 174
+  Step   4: 14 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed:  71   Index: 211
+Waterfalls Lake                                                               Seed:  71   Index: 211
+Overworld (Kaipo)                                                             Seed:  71   Index: 212
+Overworld (Damcyan)                                                           Seed:  71   Index: 223
+Damcyan                                                                       Seed:  71   Index: 227
+  Optional Steps: 1
+  Extra Steps: 54
+Overworld (Damcyan)                                                           Seed:  88   Index:  33
+Antlion B1F                                                                   Seed:  88   Index:  33
+Antlion B2F Inward Direct                                                     Seed:  88   Index:  71
+  Antlion B2F                                                                 Seed:  88   Index:  71
+    Step   5: 15 / Weeper x2 (7.114s)
+    Step  14: 16 / Basilisk x1, Imp x3 (6.775s)
+    Step  46: 17 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed:  88   Index: 151
+  Step   6: 18 / SandWorm x2 (6.841s)
+Battle: Antlion                                                               Seed:  88   Index: 165
+Antlion's Nest                                                                Seed:  88   Index: 165
+Antlion B2F Outward Direct                                                    Seed:  88   Index: 180
+  Antlion B2F                                                                 Seed:  88   Index: 180
+    Step  33: 19 / Basilisk x1, Turtle x1 (7.124s)
+    Step  65: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 105   Index:   4
+  Step   8: 21 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 105   Index:  42
+Overworld (Kaipo)                                                             Seed: 105   Index:  42
+Kaipo Revisited                                                               Seed: 105   Index:  42
+Overworld (Kaipo)                                                             Seed: 105   Index:  42
+Overworld (Damcyan)                                                           Seed: 105   Index:  42
+Mt.Hobs-West                                                                  Seed: 105   Index:  42
+  Step   9: 22 / Cocktric x3 (9.055s)
+  Step  20: 23 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 105   Index:  81
+Battle: MomBomb                                                               Seed: 105   Index:  96
+Mt.Hobs Summit                                                                Seed: 105   Index:  96
+Mt.Hobs-East                                                                  Seed: 105   Index: 102
+  Step  13: 24 / Gargoyle x2 (7.630s)
+  Step  34: 25 / Gargoyle x2 (7.630s)
+  Step  45: 26 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 105   Index: 148
+  Step  69: 27 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 105   Index: 232
+  Optional Steps: 10
+  Extra Steps: 42
+Overworld (Fabul)                                                             Seed: 122   Index:  88
+Fabul Boat and Leviatan                                                       Seed: 122   Index:  95
+Overworld (Mysidia)                                                           Seed: 122   Index:  95
+Mysidia                                                                       Seed: 122   Index: 104
+Overworld (Mysidia)                                                           Seed: 122   Index: 104
+Overworld (Mt.Ordeals)                                                        Seed: 122   Index: 114
+  Step  41: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  55: 29 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  63: 30 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 122   Index: 208
+  Step   1: 31 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 122   Index: 251
+  Step  19: 32 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed: 139   Index:  18
+Mt.Ordeals-3rd station                                                        Seed: 139   Index:  18
+Mt.Ordeals-7th station                                                        Seed: 139   Index:  23
+Mt.Ordeals Summit                                                             Seed: 139   Index:  65
+  Optional Steps: 0
+  Step   6: 33 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed: 139   Index:  82
+Mt.Ordeals Summit                                                             Seed: 139   Index:  82
+Paladin                                                                       Seed: 139   Index:  86
+Mt.Ordeals Summit                                                             Seed: 139   Index:  86
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 139   Index: 108
+  Step   3: 34 / Lilith x2 (9.169s)
+Mt.Ordeals-3rd station                                                        Seed: 139   Index: 150
+  Step   2: 35 / Ghoul x2, Soul x2 (8.971s)
+  Step  18: 36 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 139   Index: 180
+  Step  18: 37 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 139   Index: 224
+Take Chocobo to Mysidia                                                       Seed: 139   Index: 237
+Overworld (Mysidia)                                                           Seed: 139   Index: 237
+Town of Baron Serpent Road                                                    Seed: 139   Index: 237
+  Extra Steps: 119
+Credit Warp Fight Search                                                      Seed: 156   Index: 104
+  Overworld (Baron)                                                           Seed: 156   Index: 104
+    Extra Steps: 4
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step   4: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  50: 40 / Imp x3)
+   (Step  69: 41 / Eagle x3)
+   (Step  81: 42 / Eagle x3)
+   (Step 107: 43 / Eagle x3)
+   (Step 156: 44 / Imp x3)
+   (Step 194: 45 / Imp x4)
+   (Step 247: 46 / Imp x4)
+
+Encounter Time:      297.129s
+Other Time:          542.140s
+Total Time:          839.269s
+
+Base Total Time:     929.549s
+Time Saved:          90.280s
+
+Optional Steps:      11
+Extra Steps:         225
+Encounters:          39
+
+Base Encounters:     50
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/055.txt
+++ b/data/routes/cw/055.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	55
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49144953
+VARS	FFFFFFFF:42 C307801:1 E302500:54 E302600:8 E307300:6 E307700:6 E307B01:32
+
+Overworld (Kaipo)                                                             Seed:  55   Index:   0
+Overworld (Kaipo)                                                             Seed:  55   Index:   1
+  Step  14: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  55   Index:  37
+Overworld (Kaipo)                                                             Seed:  55   Index:  37
+  Step  16: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step  17: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  55   Index:  69
+  Step  20: 4 / Pike x2, EvilShel x2 (6.952s)
+  Step  30: 5 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:  55   Index: 101
+Watery Pass-South B1F                                                         Seed:  55   Index: 101
+Watery Pass-South B2F                                                         Seed:  55   Index: 121
+  Step  22: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  46: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  55   Index: 211
+Watery Pass-South B2F                                                         Seed:  55   Index: 215
+Watery Pass-South B3F                                                         Seed:  55   Index: 254
+Watery Pass-North B2F                                                         Seed:  72   Index:  32
+  Step  11: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed:  72   Index:  53
+  Extra Steps: 6
+  Step  19: 9 / Zombie x4 (7.148s)
+  Step  24: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  66: 11 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed:  72   Index: 119
+Waterfalls B1F                                                                Seed:  72   Index: 128
+Waterfalls B2F                                                                Seed:  72   Index: 129
+  Step  24: 12 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed:  72   Index: 174
+  Step   4: 13 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed:  72   Index: 211
+Waterfalls Lake                                                               Seed:  72   Index: 211
+Overworld (Kaipo)                                                             Seed:  72   Index: 212
+Overworld (Damcyan)                                                           Seed:  72   Index: 223
+Damcyan                                                                       Seed:  72   Index: 227
+  Optional Steps: 0
+  Extra Steps: 54
+Overworld (Damcyan)                                                           Seed:  89   Index:  32
+Antlion B1F                                                                   Seed:  89   Index:  32
+  Extra Steps: 6
+  Step  44: 14 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  89   Index:  76
+  Antlion B2F                                                                 Seed:  89   Index:  76
+    Step   9: 15 / Weeper x2 (7.114s)
+    Step  41: 16 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:  89   Index: 156
+Battle: Antlion                                                               Seed:  89   Index: 170
+Antlion's Nest                                                                Seed:  89   Index: 170
+Antlion B2F Outward Charm Room Steps                                          Seed:  89   Index: 185
+  Antlion B2F                                                                 Seed:  89   Index: 185
+    Step  28: 17 / Weeper x2 (7.132s)
+  Antlion B2F Treasure Room                                                   Seed:  89   Index: 236
+    Extra Steps: 32
+  Antlion B2F                                                                 Seed: 106   Index:  12
+Antlion B1F                                                                   Seed: 106   Index:  46
+  Step  16: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed: 106   Index:  84
+Overworld (Kaipo)                                                             Seed: 106   Index:  84
+Kaipo Revisited                                                               Seed: 106   Index:  84
+Overworld (Kaipo)                                                             Seed: 106   Index:  84
+Overworld (Damcyan)                                                           Seed: 106   Index:  84
+Mt.Hobs-West                                                                  Seed: 106   Index:  84
+  Step  31: 19 / Cocktric x3 (9.055s)
+  Step  32: 20 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 106   Index: 123
+  Step  13: 21 / Gargoyle x1, Cocktric x2 (9.399s)
+Battle: MomBomb                                                               Seed: 106   Index: 138
+Mt.Hobs Summit                                                                Seed: 106   Index: 138
+Mt.Hobs-East                                                                  Seed: 106   Index: 144
+  Step   3: 22 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 106   Index: 190
+  Step  27: 23 / Cocktric x3 (8.241s)
+  Step  45: 24 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed: 123   Index:  18
+  Optional Steps: 8
+Overworld (Fabul)                                                             Seed: 123   Index:  86
+  Step   2: 25 / Imp Cap. x3, Needler x3 (8.499s)
+Fabul Boat and Leviatan                                                       Seed: 123   Index:  93
+Overworld (Mysidia)                                                           Seed: 123   Index:  93
+Mysidia                                                                       Seed: 123   Index: 102
+Overworld (Mysidia)                                                           Seed: 123   Index: 102
+Overworld (Mt.Ordeals)                                                        Seed: 123   Index: 112
+  Step  43: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  57: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  65: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 123   Index: 206
+  Step   3: 29 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 123   Index: 249
+  Step  21: 30 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed: 140   Index:  16
+Mt.Ordeals-3rd station                                                        Seed: 140   Index:  16
+Mt.Ordeals-7th station                                                        Seed: 140   Index:  21
+Mt.Ordeals Summit                                                             Seed: 140   Index:  63
+  Optional Steps: 0
+  Step   8: 31 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed: 140   Index:  80
+Mt.Ordeals Summit                                                             Seed: 140   Index:  80
+Paladin                                                                       Seed: 140   Index:  84
+Mt.Ordeals Summit                                                             Seed: 140   Index:  84
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 140   Index: 106
+  Step   4: 32 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 140   Index: 148
+  Step   4: 33 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+  Step  20: 34 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 140   Index: 178
+  Step  20: 35 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 140   Index: 222
+Take Chocobo to Mysidia                                                       Seed: 140   Index: 235
+Overworld (Mysidia)                                                           Seed: 140   Index: 235
+Town of Baron Serpent Road                                                    Seed: 140   Index: 235
+Credit Warp Fight Search                                                      Seed: 140   Index: 239
+  Overworld (Baron)                                                           Seed: 140   Index: 239
+    Extra Steps: 42
+    Step   1: 36 / FloatEye x1, Eagle x2 (7.365s)
+    Step  42: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step 122: 38 / FloatEye x1, Eagle x2)
+   (Step 125: 39 / Imp x3, SwordRat x1)
+   (Step 171: 40 / Imp x3)
+   (Step 202: 41 / Eagle x3)
+   (Step 228: 42 / Eagle x3)
+
+Encounter Time:      283.782s
+Other Time:          533.954s
+Total Time:          817.736s
+
+Base Total Time:     861.603s
+Time Saved:          43.867s
+
+Optional Steps:      8
+Extra Steps:         140
+Encounters:          37
+
+Base Encounters:     46
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/056.txt
+++ b/data/routes/cw/056.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	56
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49613957
+VARS	FFFFFFFF:32 C307801:1 E302500:141 E302600:78 E307400:4 E307701:2 E307B01:4
+
+Overworld (Kaipo)                                                             Seed:  56   Index:   0
+Overworld (Kaipo)                                                             Seed:  56   Index:   1
+  Step  14: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  56   Index:  37
+Overworld (Kaipo)                                                             Seed:  56   Index:  37
+  Step  16: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step  17: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  56   Index:  69
+  Step  20: 4 / Pike x2, EvilShel x2 (6.952s)
+  Step  30: 5 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:  56   Index: 101
+Watery Pass-South B1F                                                         Seed:  56   Index: 101
+Watery Pass-South B2F                                                         Seed:  56   Index: 121
+  Step  22: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  56   Index: 211
+Watery Pass-South B2F                                                         Seed:  56   Index: 215
+  Step  34: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed:  56   Index: 254
+Watery Pass-North B2F                                                         Seed:  73   Index:  32
+  Step  11: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed:  73   Index:  53
+  Step  19: 9 / Zombie x4 (7.148s)
+  Step  24: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed:  73   Index: 113
+  Step   6: 11 / SandMoth x2, Larva x2 (7.163s)
+Waterfalls B1F                                                                Seed:  73   Index: 122
+  Extra Steps: 4
+Waterfalls B2F                                                                Seed:  73   Index: 127
+  Step  26: 12 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed:  73   Index: 172
+Battle: Octomamm                                                              Seed:  73   Index: 209
+Waterfalls Lake                                                               Seed:  73   Index: 209
+Overworld (Kaipo)                                                             Seed:  73   Index: 210
+Overworld (Damcyan)                                                           Seed:  73   Index: 221
+Damcyan                                                                       Seed:  73   Index: 225
+  Optional Steps: 1
+  Extra Steps: 140
+Overworld (Damcyan)                                                           Seed:  90   Index: 117
+Antlion B1F                                                                   Seed:  90   Index: 117
+Antlion B2F Inward Direct                                                     Seed:  90   Index: 155
+  Antlion B2F                                                                 Seed:  90   Index: 155
+    Step  50: 13 / Cream x4 (7.552s)
+    Step  58: 14 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  90   Index: 235
+  Step  10: 15 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed:  90   Index: 249
+Antlion's Nest                                                                Seed:  90   Index: 249
+Antlion B2F Outward Charm Room Steps                                          Seed: 107   Index:   8
+  Antlion B2F                                                                 Seed: 107   Index:   8
+    Step   4: 16 / Basilisk x1, Imp x3 (6.783s)
+  Antlion B2F Treasure Room                                                   Seed: 107   Index:  59
+    Extra Steps: 4
+  Antlion B2F                                                                 Seed: 107   Index:  63
+    Step  19: 17 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 107   Index:  97
+  Extra Steps: 2
+  Step  18: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Step  19: 19 / Basilisk x1, Imp x3 (6.783s)
+  Step  39: 20 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed: 107   Index: 137
+Overworld (Kaipo)                                                             Seed: 107   Index: 137
+Kaipo Revisited                                                               Seed: 107   Index: 137
+Overworld (Kaipo)                                                             Seed: 107   Index: 137
+Overworld (Damcyan)                                                           Seed: 107   Index: 137
+Mt.Hobs-West                                                                  Seed: 107   Index: 137
+  Step  10: 21 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 107   Index: 176
+Battle: MomBomb                                                               Seed: 107   Index: 191
+Mt.Hobs Summit                                                                Seed: 107   Index: 191
+Mt.Hobs-East                                                                  Seed: 107   Index: 197
+  Step  38: 22 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 107   Index: 243
+  Step  36: 23 / Cocktric x3 (8.241s)
+  Step  72: 24 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed: 124   Index:  71
+  Optional Steps: 10
+  Extra Steps: 68
+Overworld (Fabul)                                                             Seed: 124   Index: 209
+Fabul Boat and Leviatan                                                       Seed: 124   Index: 216
+Overworld (Mysidia)                                                           Seed: 124   Index: 216
+Mysidia                                                                       Seed: 124   Index: 225
+Overworld (Mysidia)                                                           Seed: 124   Index: 225
+Overworld (Mt.Ordeals)                                                        Seed: 124   Index: 235
+  Step  35: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  92: 26 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed: 141   Index:  73
+  Step  37: 27 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 141   Index: 116
+Recruit Tellah                                                                Seed: 141   Index: 139
+Mt.Ordeals-3rd station                                                        Seed: 141   Index: 139
+  Step   3: 28 / Spirit x2, Soul x2, Red Bone x2 (9.695s)
+Mt.Ordeals-7th station                                                        Seed: 141   Index: 144
+  Step   8: 29 / Revenant x1, Ghoul x3 (8.914s)
+  Step  24: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 141   Index: 186
+  Optional Steps: 0
+  Step  12: 31 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed: 141   Index: 203
+Mt.Ordeals Summit                                                             Seed: 141   Index: 203
+Paladin                                                                       Seed: 141   Index: 207
+Mt.Ordeals Summit                                                             Seed: 141   Index: 207
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 141   Index: 229
+  Step  11: 32 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 158   Index:  15
+  Step  10: 33 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 158   Index:  45
+Overworld (Mt.Ordeals)                                                        Seed: 158   Index:  89
+Take Chocobo to Mysidia                                                       Seed: 158   Index: 102
+Overworld (Mysidia)                                                           Seed: 158   Index: 102
+Town of Baron Serpent Road                                                    Seed: 158   Index: 102
+Credit Warp Fight Search                                                      Seed: 158   Index: 106
+  Overworld (Baron)                                                           Seed: 158   Index: 106
+    Extra Steps: 32
+    Step   2: 34 / Imp x3 (7.174s)
+    Step  32: 35 / Imp x3, SwordRat x1 (7.227s)
+   (Step  48: 36 / FloatEye x1, Eagle x2)
+   (Step  79: 37 / Imp x3, SwordRat x1)
+   (Step 105: 38 / FloatEye x1, Eagle x2)
+   (Step 142: 39 / Imp x3, SwordRat x1)
+   (Step 154: 40 / Imp x3)
+   (Step 192: 41 / Eagle x3)
+
+Encounter Time:      264.963s
+Other Time:          560.577s
+Total Time:          825.540s
+
+Base Total Time:     851.210s
+Time Saved:          25.671s
+
+Optional Steps:      11
+Extra Steps:         250
+Encounters:          35
+
+Base Encounters:     46
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/057.txt
+++ b/data/routes/cw/057.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	57
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50080279
+VARS	FFFFFFFF:34 C307801:1 E302500:15 E302600:46 E307000:4 E307701:2 E307B01:130
+
+Overworld (Kaipo)                                                             Seed:  57   Index:   0
+Overworld (Kaipo)                                                             Seed:  57   Index:   1
+  Step  14: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  23: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  57   Index:  37
+Overworld (Kaipo)                                                             Seed:  57   Index:  37
+  Step  16: 3 / Sandpede x1, Sand Man x2 (7.096s)
+  Step  17: 4 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  57   Index:  69
+  Step  20: 5 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  30: 6 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  57   Index: 101
+Watery Pass-South B1F                                                         Seed:  57   Index: 101
+Watery Pass-South B2F                                                         Seed:  57   Index: 121
+  Step  22: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed:  57   Index: 211
+Watery Pass-South B2F                                                         Seed:  57   Index: 215
+  Extra Steps: 4
+  Step  34: 8 / Pike x3 (7.152s)
+  Step  42: 9 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  74   Index:   2
+Watery Pass-North B2F                                                         Seed:  74   Index:  36
+Watery Pass-North B1F                                                         Seed:  74   Index:  57
+  Step  15: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  20: 11 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed:  74   Index: 117
+  Step   2: 12 / SandMoth x2, Larva x2 (7.163s)
+Waterfalls B1F                                                                Seed:  74   Index: 126
+Waterfalls B2F                                                                Seed:  74   Index: 127
+  Step  26: 13 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed:  74   Index: 172
+Battle: Octomamm                                                              Seed:  74   Index: 209
+Waterfalls Lake                                                               Seed:  74   Index: 209
+Overworld (Kaipo)                                                             Seed:  74   Index: 210
+Overworld (Damcyan)                                                           Seed:  74   Index: 221
+Damcyan                                                                       Seed:  74   Index: 225
+  Optional Steps: 1
+  Extra Steps: 14
+Overworld (Damcyan)                                                           Seed:  74   Index: 247
+Antlion B1F                                                                   Seed:  74   Index: 247
+  Step  29: 14 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  91   Index:  29
+  Antlion B2F                                                                 Seed:  91   Index:  29
+    Step   3: 15 / Weeper x2 (7.114s)
+    Step  47: 16 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:  91   Index: 109
+  Step   8: 17 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed:  91   Index: 123
+Antlion's Nest                                                                Seed:  91   Index: 123
+Antlion B2F Outward Charm Room Steps                                          Seed:  91   Index: 138
+  Antlion B2F                                                                 Seed:  91   Index: 138
+  Antlion B2F Treasure Room                                                   Seed:  91   Index: 189
+    Extra Steps: 130
+  Antlion B2F                                                                 Seed: 108   Index:  63
+    Step  19: 18 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed: 108   Index:  97
+  Extra Steps: 2
+  Step  17: 19 / Basilisk x1, Imp x3 (6.783s)
+  Step  19: 20 / Basilisk x1, Imp x3 (6.783s)
+  Step  39: 21 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 108   Index: 137
+Overworld (Kaipo)                                                             Seed: 108   Index: 137
+Kaipo Revisited                                                               Seed: 108   Index: 137
+Overworld (Kaipo)                                                             Seed: 108   Index: 137
+Overworld (Damcyan)                                                           Seed: 108   Index: 137
+Mt.Hobs-West                                                                  Seed: 108   Index: 137
+  Step  10: 22 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 108   Index: 176
+Battle: MomBomb                                                               Seed: 108   Index: 191
+Mt.Hobs Summit                                                                Seed: 108   Index: 191
+Mt.Hobs-East                                                                  Seed: 108   Index: 197
+  Step  38: 23 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 108   Index: 243
+  Step  36: 24 / SwordRat x3, Needler x3 (7.663s)
+  Step  72: 25 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 125   Index:  71
+  Optional Steps: 10
+  Extra Steps: 36
+Overworld (Fabul)                                                             Seed: 125   Index: 177
+Fabul Boat and Leviatan                                                       Seed: 125   Index: 184
+Overworld (Mysidia)                                                           Seed: 125   Index: 184
+Mysidia                                                                       Seed: 125   Index: 193
+Overworld (Mysidia)                                                           Seed: 125   Index: 193
+Overworld (Mt.Ordeals)                                                        Seed: 125   Index: 203
+  Step   6: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  67: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 142   Index:  41
+  Step  30: 28 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 142   Index:  84
+Recruit Tellah                                                                Seed: 142   Index: 107
+Mt.Ordeals-3rd station                                                        Seed: 142   Index: 107
+  Step   3: 29 / Spirit x2, Soul x2, Red Bone x2 (9.695s)
+Mt.Ordeals-7th station                                                        Seed: 142   Index: 112
+  Step  30: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  40: 31 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 142   Index: 154
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 142   Index: 171
+Mt.Ordeals Summit                                                             Seed: 142   Index: 171
+  Step   3: 32 / Revenant x1, Ghoul x3 (8.611s)
+Paladin                                                                       Seed: 142   Index: 175
+Mt.Ordeals Summit                                                             Seed: 142   Index: 175
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 142   Index: 197
+  Step   1: 33 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 142   Index: 239
+  Step   1: 34 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 159   Index:  13
+  Step  12: 35 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 159   Index:  57
+Take Chocobo to Mysidia                                                       Seed: 159   Index:  70
+Overworld (Mysidia)                                                           Seed: 159   Index:  70
+Town of Baron Serpent Road                                                    Seed: 159   Index:  70
+Credit Warp Fight Search                                                      Seed: 159   Index:  74
+  Overworld (Baron)                                                           Seed: 159   Index:  74
+    Extra Steps: 34
+    Step   1: 36 / FloatEye x1, Eagle x2 (7.365s)
+    Step  34: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step  64: 38 / FloatEye x1, Eagle x2)
+   (Step  80: 39 / Imp x3, SwordRat x1)
+   (Step 111: 40 / Imp x3)
+   (Step 137: 41 / Eagle x3)
+   (Step 174: 42 / Eagle x3)
+   (Step 186: 43 / Eagle x3)
+   (Step 224: 44 / FloatEye x2)
+
+Encounter Time:      280.177s
+Other Time:          553.122s
+Total Time:          833.299s
+
+Base Total Time:     859.788s
+Time Saved:          26.489s
+
+Optional Steps:      11
+Extra Steps:         220
+Encounters:          37
+
+Base Encounters:     47
+Encounters Saved:    10
+
+Number of Variables: 54

--- a/data/routes/cw/058.txt
+++ b/data/routes/cw/058.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	58
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49100676
+VARS	FFFFFFFF:34 C307801:1 E302500:15 E302600:30 E307000:4 E307700:4 E307701:2 E307B01:126 E308700:1 E308702:1 E309700:14
+
+Overworld (Kaipo)                                                             Seed:  58   Index:   0
+Overworld (Kaipo)                                                             Seed:  58   Index:   1
+  Step  14: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  23: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed:  58   Index:  37
+Overworld (Kaipo)                                                             Seed:  58   Index:  37
+  Step  16: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  58   Index:  69
+  Step  30: 4 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  58   Index: 101
+Watery Pass-South B1F                                                         Seed:  58   Index: 101
+Watery Pass-South B2F                                                         Seed:  58   Index: 121
+  Step  22: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  58   Index: 211
+Watery Pass-South B2F                                                         Seed:  58   Index: 215
+  Extra Steps: 4
+  Step  17: 6 / Pike x3 (7.152s)
+  Step  34: 7 / Pike x2, EvilShel x2 (7.149s)
+  Step  42: 8 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  75   Index:   2
+Watery Pass-North B2F                                                         Seed:  75   Index:  36
+  Step  12: 9 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed:  75   Index:  57
+  Step  15: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  20: 11 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed:  75   Index: 117
+  Step   2: 12 / SandMoth x2, Larva x2 (7.163s)
+Waterfalls B1F                                                                Seed:  75   Index: 126
+Waterfalls B2F                                                                Seed:  75   Index: 127
+Waterfalls Lake                                                               Seed:  75   Index: 172
+Battle: Octomamm                                                              Seed:  75   Index: 209
+Waterfalls Lake                                                               Seed:  75   Index: 209
+Overworld (Kaipo)                                                             Seed:  75   Index: 210
+Overworld (Damcyan)                                                           Seed:  75   Index: 221
+Damcyan                                                                       Seed:  75   Index: 225
+  Optional Steps: 1
+  Extra Steps: 14
+Overworld (Damcyan)                                                           Seed:  75   Index: 247
+Antlion B1F                                                                   Seed:  75   Index: 247
+  Extra Steps: 4
+  Step  29: 13 / Imp x3 (6.649s)
+  Step  41: 14 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  92   Index:  33
+  Antlion B2F                                                                 Seed:  92   Index:  33
+    Step  17: 15 / Weeper x2 (7.114s)
+    Step  43: 16 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:  92   Index: 113
+Battle: Antlion                                                               Seed:  92   Index: 127
+Antlion's Nest                                                                Seed:  92   Index: 127
+Antlion B2F Outward Charm Room Steps                                          Seed:  92   Index: 142
+  Antlion B2F                                                                 Seed:  92   Index: 142
+  Antlion B2F Treasure Room                                                   Seed:  92   Index: 193
+    Extra Steps: 126
+  Antlion B2F                                                                 Seed: 109   Index:  63
+    Step  19: 17 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 109   Index:  97
+  Extra Steps: 2
+  Step  17: 18 / Imp x3 (6.648s)
+  Step  19: 19 / Basilisk x1, Imp x3 (6.783s)
+  Step  39: 20 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed: 109   Index: 137
+Overworld (Kaipo)                                                             Seed: 109   Index: 137
+Kaipo Revisited                                                               Seed: 109   Index: 137
+Overworld (Kaipo)                                                             Seed: 109   Index: 137
+Overworld (Damcyan)                                                           Seed: 109   Index: 137
+Mt.Hobs-West                                                                  Seed: 109   Index: 137
+Mt.Hobs Summit                                                                Seed: 109   Index: 176
+Battle: MomBomb                                                               Seed: 109   Index: 191
+Mt.Hobs Summit                                                                Seed: 109   Index: 191
+Mt.Hobs-East                                                                  Seed: 109   Index: 197
+  Step  38: 21 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 109   Index: 243
+  Step  36: 22 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 126   Index:  71
+  Optional Steps: 10
+  Extra Steps: 20
+Overworld (Fabul)                                                             Seed: 126   Index: 161
+Fabul Boat and Leviatan                                                       Seed: 126   Index: 168
+Overworld (Mysidia)                                                           Seed: 126   Index: 168
+Mysidia                                                                       Seed: 126   Index: 177
+Overworld (Mysidia)                                                           Seed: 126   Index: 177
+Overworld (Mt.Ordeals)                                                        Seed: 126   Index: 187
+  Step  22: 23 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  28: 24 / Raven x1, Cocktric x3 (9.100s)
+  Step  83: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 143   Index:  25
+Mt.Ordeals-3rd station                                                        Seed: 143   Index:  68
+  Step   3: 26 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed: 143   Index:  91
+Mt.Ordeals-3rd station                                                        Seed: 143   Index:  91
+Mt.Ordeals-7th station                                                        Seed: 143   Index:  96
+  Step  11: 27 / Revenant x1, Ghoul x3 (8.914s)
+  Step  14: 28 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 143   Index: 138
+  Optional Steps: 1
+  Step   4: 29 / Revenant x1, Ghoul x3 (8.914s)
+  Step  14: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed: 143   Index: 156
+Mt.Ordeals Summit                                                             Seed: 143   Index: 156
+Paladin                                                                       Seed: 143   Index: 160
+Mt.Ordeals Summit                                                             Seed: 143   Index: 160
+  Optional Steps: 1
+  Step  14: 31 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed: 143   Index: 183
+Mt.Ordeals-3rd station                                                        Seed: 143   Index: 225
+  Step  15: 32 / Spirit x2, Soul x2, Red Bone x2 (9.471s)
+Mt.Ordeals                                                                    Seed: 143   Index: 255
+  Step  17: 33 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 160   Index:  43
+Take Chocobo to Mysidia                                                       Seed: 160   Index:  56
+Overworld (Mysidia)                                                           Seed: 160   Index:  56
+Town of Baron Serpent Road                                                    Seed: 160   Index:  56
+  Extra Steps: 14
+Credit Warp Fight Search                                                      Seed: 160   Index:  74
+  Overworld (Baron)                                                           Seed: 160   Index:  74
+    Extra Steps: 34
+    Step   1: 34 / Imp x3 (7.174s)
+    Step  34: 35 / Imp x3, SwordRat x1 (7.227s)
+   (Step  64: 36 / FloatEye x1, Eagle x2)
+   (Step  80: 37 / Imp x3, SwordRat x1)
+   (Step 111: 38 / FloatEye x1, Eagle x2)
+   (Step 174: 39 / Imp x3, SwordRat x1)
+   (Step 186: 40 / Imp x3)
+   (Step 191: 41 / Eagle x3)
+
+Encounter Time:      264.409s
+Other Time:          552.590s
+Total Time:          816.999s
+
+Base Total Time:     859.107s
+Time Saved:          42.108s
+
+Optional Steps:      13
+Extra Steps:         218
+Encounters:          35
+
+Base Encounters:     47
+Encounters Saved:    12
+
+Number of Variables: 54

--- a/data/routes/cw/059.txt
+++ b/data/routes/cw/059.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	59
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49251828
+VARS	FFFFFFFF:12 E302500:3 E302600:1 E307701:6 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  59   Index:   0
+Overworld (Kaipo)                                                             Seed:  59   Index:   1
+  Step  14: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  23: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  59   Index:  37
+Overworld (Kaipo)                                                             Seed:  59   Index:  37
+  Step  16: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  59   Index:  69
+  Step  30: 4 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  59   Index: 101
+Watery Pass-South B1F                                                         Seed:  59   Index: 101
+Watery Pass-South B2F                                                         Seed:  59   Index: 121
+  Step   3: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  59   Index: 211
+Watery Pass-South B2F                                                         Seed:  59   Index: 215
+  Step  17: 6 / Pike x3 (7.152s)
+  Step  34: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  59   Index: 254
+  Step   3: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed:  76   Index:  32
+  Step  16: 9 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed:  76   Index:  53
+  Step  19: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  24: 11 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed:  76   Index: 113
+  Step   5: 12 / SandMoth x2, Larva x2 (7.163s)
+Waterfalls B1F                                                                Seed:  76   Index: 122
+Waterfalls B2F                                                                Seed:  76   Index: 123
+  Step   4: 13 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed:  76   Index: 168
+Battle: Octomamm                                                              Seed:  76   Index: 205
+Waterfalls Lake                                                               Seed:  76   Index: 205
+Overworld (Kaipo)                                                             Seed:  76   Index: 206
+Overworld (Damcyan)                                                           Seed:  76   Index: 217
+Damcyan                                                                       Seed:  76   Index: 221
+  Optional Steps: 1
+  Extra Steps: 2
+Overworld (Damcyan)                                                           Seed:  76   Index: 231
+Antlion B1F                                                                   Seed:  76   Index: 231
+  Step  16: 14 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  93   Index:  13
+  Antlion B2F                                                                 Seed:  93   Index:  13
+    Step   7: 15 / SandWorm x2 (6.841s)
+    Step  19: 16 / Basilisk x1, Imp x3 (6.775s)
+    Step  37: 17 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed:  93   Index:  93
+Battle: Antlion                                                               Seed:  93   Index: 107
+Antlion's Nest                                                                Seed:  93   Index: 107
+Antlion B2F Outward Direct                                                    Seed:  93   Index: 122
+  Antlion B2F                                                                 Seed:  93   Index: 122
+    Step  26: 18 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed:  93   Index: 202
+  Extra Steps: 6
+  Step   3: 19 / Basilisk x1, Imp x3 (6.783s)
+  Step  11: 20 / Basilisk x1, Imp x3 (6.783s)
+  Step  28: 21 / Imp x3 (6.648s)
+  Step  43: 22 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed:  93   Index: 246
+Overworld (Kaipo)                                                             Seed:  93   Index: 246
+Kaipo Revisited                                                               Seed:  93   Index: 246
+Overworld (Kaipo)                                                             Seed:  93   Index: 246
+Overworld (Damcyan)                                                           Seed:  93   Index: 246
+Mt.Hobs-West                                                                  Seed:  93   Index: 246
+  Step  22: 23 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 110   Index:  29
+  Step   4: 24 / Spirit x3, Skelton x2, Red Bone x1 (10.387s)
+Battle: MomBomb                                                               Seed: 110   Index:  44
+Mt.Hobs Summit                                                                Seed: 110   Index:  44
+Mt.Hobs-East                                                                  Seed: 110   Index:  50
+  Step  12: 25 / Gargoyle x2 (7.630s)
+  Step  32: 26 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 110   Index:  96
+  Step  18: 27 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  20: 28 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  40: 29 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  51: 30 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 110   Index: 180
+  Optional Steps: 1
+Overworld (Fabul)                                                             Seed: 110   Index: 241
+Fabul Boat and Leviatan                                                       Seed: 110   Index: 248
+Overworld (Mysidia)                                                           Seed: 110   Index: 248
+Mysidia                                                                       Seed: 127   Index:   1
+Overworld (Mysidia)                                                           Seed: 127   Index:   1
+Overworld (Mt.Ordeals)                                                        Seed: 127   Index:  11
+  Step  12: 31 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  69: 32 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  75: 33 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 127   Index: 105
+  Step   7: 34 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 127   Index: 148
+  Step   7: 35 / Ghoul x2, Soul x2 (9.357s)
+  Step  12: 36 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed: 127   Index: 171
+Mt.Ordeals-3rd station                                                        Seed: 127   Index: 171
+Mt.Ordeals-7th station                                                        Seed: 127   Index: 176
+  Step  32: 37 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  39: 38 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 127   Index: 218
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 127   Index: 236
+Mt.Ordeals Summit                                                             Seed: 127   Index: 236
+Paladin                                                                       Seed: 127   Index: 240
+Mt.Ordeals Summit                                                             Seed: 127   Index: 240
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 144   Index:   7
+  Step   7: 39 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 144   Index:  49
+Mt.Ordeals                                                                    Seed: 144   Index:  79
+  Step  28: 40 / Spirit x2, Skelton x2 (8.065s)
+  Step  31: 41 / Soul x2, Red Bone x2 (8.881s)
+Overworld (Mt.Ordeals)                                                        Seed: 144   Index: 123
+Take Chocobo to Mysidia                                                       Seed: 144   Index: 136
+Overworld (Mysidia)                                                           Seed: 144   Index: 136
+Town of Baron Serpent Road                                                    Seed: 144   Index: 136
+Credit Warp Fight Search                                                      Seed: 144   Index: 140
+  Overworld (Baron)                                                           Seed: 144   Index: 140
+    Extra Steps: 12
+    Step   2: 42 / Eagle x3 (7.417s)
+    Step  12: 43 / Imp x4 (7.223s)
+   (Step  34: 44 / FloatEye x2)
+   (Step  76: 45 / Imp x4)
+   (Step 100: 46 / Imp x4)
+   (Step 132: 47 / Imp x3, SwordRat x1)
+   (Step 191: 48 / FloatEye x2)
+   (Step 224: 49 / FloatEye x2)
+   (Step 254: 50 / Imp x3)
+
+Encounter Time:      330.087s
+Other Time:          489.427s
+Total Time:          819.514s
+
+Base Total Time:     844.128s
+Time Saved:          24.614s
+
+Optional Steps:      4
+Extra Steps:         20
+Encounters:          43
+
+Base Encounters:     45
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/060.txt
+++ b/data/routes/cw/060.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	60
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48945764
+VARS	FFFFFFFF:12 E302600:1 E307000:4 E307300:1 E307701:4 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  60   Index:   0
+Overworld (Kaipo)                                                             Seed:  60   Index:   1
+  Step  14: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  23: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  60   Index:  37
+Overworld (Kaipo)                                                             Seed:  60   Index:  37
+  Step  16: 3 / Sandpede x1, Sand Man x2 (7.096s)
+  Step  31: 4 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  60   Index:  69
+  Step  30: 5 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  60   Index: 101
+Watery Pass-South B1F                                                         Seed:  60   Index: 101
+Watery Pass-South B2F                                                         Seed:  60   Index: 121
+  Step   3: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  60   Index: 211
+Watery Pass-South B2F                                                         Seed:  60   Index: 215
+  Extra Steps: 4
+  Step  17: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  34: 8 / CaveToad x3 (7.014s)
+  Step  42: 9 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  77   Index:   2
+Watery Pass-North B2F                                                         Seed:  77   Index:  36
+  Step  12: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B1F                                                         Seed:  77   Index:  57
+  Extra Steps: 1
+  Step  15: 11 / Zombie x4 (7.148s)
+  Step  20: 12 / Aligator x1, Pike x2 (7.368s)
+  Step  61: 13 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed:  77   Index: 118
+  Step   9: 14 / Sandpede x1, Sand Man x2 (7.188s)
+Waterfalls B1F                                                                Seed:  77   Index: 127
+Waterfalls B2F                                                                Seed:  77   Index: 128
+Waterfalls Lake                                                               Seed:  77   Index: 173
+  Step  22: 15 / Mad Toad x4 (7.317s)
+Battle: Octomamm                                                              Seed:  77   Index: 210
+Waterfalls Lake                                                               Seed:  77   Index: 210
+Overworld (Kaipo)                                                             Seed:  77   Index: 211
+Overworld (Damcyan)                                                           Seed:  77   Index: 222
+Damcyan                                                                       Seed:  77   Index: 226
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  77   Index: 233
+Antlion B1F                                                                   Seed:  77   Index: 233
+  Step  14: 16 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Direct                                                     Seed:  94   Index:  15
+  Antlion B2F                                                                 Seed:  94   Index:  15
+    Step   5: 17 / Weeper x2 (7.114s)
+    Step  35: 18 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed:  94   Index:  95
+Battle: Antlion                                                               Seed:  94   Index: 109
+Antlion's Nest                                                                Seed:  94   Index: 109
+Antlion B2F Outward Direct                                                    Seed:  94   Index: 124
+  Antlion B2F                                                                 Seed:  94   Index: 124
+    Step  24: 19 / Basilisk x1, Turtle x1 (7.124s)
+    Step  57: 20 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed:  94   Index: 204
+  Extra Steps: 4
+  Step   1: 21 / Imp x3 (6.648s)
+  Step   9: 22 / Basilisk x1, Imp x3 (6.783s)
+  Step  26: 23 / Cream x4 (7.523s)
+  Step  41: 24 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  94   Index: 246
+Overworld (Kaipo)                                                             Seed:  94   Index: 246
+Kaipo Revisited                                                               Seed:  94   Index: 246
+Overworld (Kaipo)                                                             Seed:  94   Index: 246
+Overworld (Damcyan)                                                           Seed:  94   Index: 246
+Mt.Hobs-West                                                                  Seed:  94   Index: 246
+Mt.Hobs Summit                                                                Seed: 111   Index:  29
+  Step   4: 25 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed: 111   Index:  44
+Mt.Hobs Summit                                                                Seed: 111   Index:  44
+Mt.Hobs-East                                                                  Seed: 111   Index:  50
+  Step  12: 26 / Turtle x2 (7.432s)
+  Step  32: 27 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 111   Index:  96
+  Step  18: 28 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  20: 29 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  40: 30 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 111   Index: 180
+  Optional Steps: 1
+Overworld (Fabul)                                                             Seed: 111   Index: 241
+Fabul Boat and Leviatan                                                       Seed: 111   Index: 248
+Overworld (Mysidia)                                                           Seed: 111   Index: 248
+Mysidia                                                                       Seed: 128   Index:   1
+Overworld (Mysidia)                                                           Seed: 128   Index:   1
+Overworld (Mt.Ordeals)                                                        Seed: 128   Index:  11
+  Step  12: 31 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  35: 32 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  69: 33 / Raven x1 (8.356s)
+  Step  75: 34 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 128   Index: 105
+  Step   7: 35 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 128   Index: 148
+  Step   7: 36 / Zombie x2, Ghoul x2 (7.661s)
+  Step  12: 37 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 128   Index: 171
+Mt.Ordeals-3rd station                                                        Seed: 128   Index: 171
+Mt.Ordeals-7th station                                                        Seed: 128   Index: 176
+  Step  32: 38 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  39: 39 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 128   Index: 218
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 128   Index: 236
+Mt.Ordeals Summit                                                             Seed: 128   Index: 236
+Paladin                                                                       Seed: 128   Index: 240
+Mt.Ordeals Summit                                                             Seed: 128   Index: 240
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 145   Index:   7
+Mt.Ordeals-3rd station                                                        Seed: 145   Index:  49
+Mt.Ordeals                                                                    Seed: 145   Index:  79
+  Step  28: 40 / Spirit x2, Skelton x2 (8.065s)
+  Step  31: 41 / Soul x2, Red Bone x2 (8.881s)
+Overworld (Mt.Ordeals)                                                        Seed: 145   Index: 123
+Take Chocobo to Mysidia                                                       Seed: 145   Index: 136
+Overworld (Mysidia)                                                           Seed: 145   Index: 136
+Town of Baron Serpent Road                                                    Seed: 145   Index: 136
+Credit Warp Fight Search                                                      Seed: 145   Index: 140
+  Overworld (Baron)                                                           Seed: 145   Index: 140
+    Extra Steps: 12
+    Step   2: 42 / Eagle x3 (7.417s)
+    Step  12: 43 / Imp x4 (7.223s)
+   (Step  34: 44 / FloatEye x2)
+   (Step  76: 45 / Imp x4)
+   (Step 103: 46 / Imp x4)
+   (Step 127: 47 / Imp x3, SwordRat x1)
+   (Step 132: 48 / FloatEye x2)
+   (Step 191: 49 / FloatEye x2)
+   (Step 224: 50 / Imp x3)
+   (Step 254: 51 / Imp x3)
+
+Encounter Time:      324.462s
+Other Time:          489.960s
+Total Time:          814.421s
+
+Base Total Time:     851.980s
+Time Saved:          37.559s
+
+Optional Steps:      3
+Extra Steps:         21
+Encounters:          43
+
+Base Encounters:     45
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/061.txt
+++ b/data/routes/cw/061.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	61
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49994476
+VARS	FFFFFFFF:34 E000202:4 E302600:2 E307000:4 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  61   Index:   0
+Overworld (Kaipo)                                                             Seed:  61   Index:   1
+  Step  23: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed:  61   Index:  37
+Overworld (Kaipo)                                                             Seed:  61   Index:  37
+  Step  16: 2 / Sand Man x4 (7.242s)
+  Step  31: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  61   Index:  69
+  Step   9: 4 / Pike x2, EvilShel x2 (6.952s)
+  Step  30: 5 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  61   Index: 101
+Watery Pass-South B1F                                                         Seed:  61   Index: 101
+Watery Pass-South B2F                                                         Seed:  61   Index: 121
+  Step   3: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  61   Index: 211
+Watery Pass-South B2F                                                         Seed:  61   Index: 215
+  Extra Steps: 4
+  Step  17: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  34: 8 / CaveToad x3 (7.014s)
+  Step  42: 9 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  78   Index:   2
+  Step   8: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B2F                                                         Seed:  78   Index:  36
+  Step  12: 11 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed:  78   Index:  57
+  Step  20: 12 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  78   Index: 117
+  Step   1: 13 / SandMoth x2, Larva x2 (7.163s)
+Waterfalls B1F                                                                Seed:  78   Index: 126
+Waterfalls B2F                                                                Seed:  78   Index: 127
+Waterfalls Lake                                                               Seed:  78   Index: 172
+  Step  23: 14 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed:  78   Index: 209
+Waterfalls Lake                                                               Seed:  78   Index: 209
+Overworld (Kaipo)                                                             Seed:  78   Index: 210
+Overworld (Damcyan)                                                           Seed:  78   Index: 221
+Damcyan                                                                       Seed:  78   Index: 225
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  78   Index: 232
+Antlion B1F                                                                   Seed:  78   Index: 232
+  Step  15: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Direct                                                     Seed:  95   Index:  14
+  Antlion B2F                                                                 Seed:  95   Index:  14
+    Step   6: 16 / Basilisk x1, Imp x3 (6.775s)
+    Step  25: 17 / Weeper x2 (7.114s)
+    Step  36: 18 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed:  95   Index:  94
+Battle: Antlion                                                               Seed:  95   Index: 108
+Antlion's Nest                                                                Seed:  95   Index: 108
+Antlion B2F Outward Direct                                                    Seed:  95   Index: 123
+  Antlion B2F                                                                 Seed:  95   Index: 123
+    Step  25: 19 / Basilisk x1, Turtle x1 (7.124s)
+    Step  58: 20 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed:  95   Index: 203
+  Step   2: 21 / Imp x3 (6.648s)
+  Step  27: 22 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed:  95   Index: 241
+Overworld (Kaipo)                                                             Seed:  95   Index: 241
+  Extra Steps: 4
+  Step   4: 23 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed:  95   Index: 245
+Overworld (Kaipo)                                                             Seed:  95   Index: 245
+Overworld (Damcyan)                                                           Seed:  95   Index: 245
+Mt.Hobs-West                                                                  Seed:  95   Index: 245
+Mt.Hobs Summit                                                                Seed: 112   Index:  28
+  Step   5: 24 / Gargoyle x1, Cocktric x2 (9.399s)
+Battle: MomBomb                                                               Seed: 112   Index:  43
+Mt.Hobs Summit                                                                Seed: 112   Index:  43
+Mt.Hobs-East                                                                  Seed: 112   Index:  49
+  Step  33: 25 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 112   Index:  95
+  Step  19: 26 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  21: 27 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  41: 28 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  71: 29 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 112   Index: 179
+  Optional Steps: 2
+Overworld (Fabul)                                                             Seed: 112   Index: 241
+Fabul Boat and Leviatan                                                       Seed: 112   Index: 248
+Overworld (Mysidia)                                                           Seed: 112   Index: 248
+Mysidia                                                                       Seed: 129   Index:   1
+Overworld (Mysidia)                                                           Seed: 129   Index:   1
+Overworld (Mt.Ordeals)                                                        Seed: 129   Index:  11
+  Step  12: 30 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  35: 31 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  69: 32 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  75: 33 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 129   Index: 105
+  Step   7: 34 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 129   Index: 148
+  Step  12: 35 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 129   Index: 171
+Mt.Ordeals-3rd station                                                        Seed: 129   Index: 171
+Mt.Ordeals-7th station                                                        Seed: 129   Index: 176
+  Step  32: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  39: 37 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 129   Index: 218
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 129   Index: 236
+Mt.Ordeals Summit                                                             Seed: 129   Index: 236
+  Step   1: 38 / Zombie x3, Ghoul x2, Revenant x2 (7.808s)
+Paladin                                                                       Seed: 129   Index: 240
+Mt.Ordeals Summit                                                             Seed: 129   Index: 240
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 146   Index:   7
+  Step  38: 39 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 146   Index:  49
+Mt.Ordeals                                                                    Seed: 146   Index:  79
+  Step  28: 40 / Spirit x2, Skelton x2 (8.065s)
+  Step  31: 41 / Soul x2, Red Bone x2 (8.881s)
+Overworld (Mt.Ordeals)                                                        Seed: 146   Index: 123
+Take Chocobo to Mysidia                                                       Seed: 146   Index: 136
+Overworld (Mysidia)                                                           Seed: 146   Index: 136
+Town of Baron Serpent Road                                                    Seed: 146   Index: 136
+Credit Warp Fight Search                                                      Seed: 146   Index: 140
+  Overworld (Baron)                                                           Seed: 146   Index: 140
+    Extra Steps: 34
+    Step   2: 42 / Eagle x3 (7.417s)
+    Step  34: 43 / Imp x4 (7.223s)
+   (Step  76: 44 / FloatEye x2)
+   (Step 103: 45 / Imp x4)
+   (Step 127: 46 / Imp x4)
+   (Step 132: 47 / Imp x3, SwordRat x1)
+   (Step 191: 48 / FloatEye x2)
+   (Step 254: 49 / FloatEye x2)
+
+Encounter Time:      330.730s
+Other Time:          501.141s
+Total Time:          831.871s
+
+Base Total Time:     874.332s
+Time Saved:          42.461s
+
+Optional Steps:      4
+Extra Steps:         42
+Encounters:          43
+
+Base Encounters:     45
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/062.txt
+++ b/data/routes/cw/062.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	62
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48575480
+VARS	FFFFFFFF:6 C307801:1 E302500:26 E302600:12 E305400:52 E307900:24 E307B01:18 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  62   Index:   0
+Overworld (Kaipo)                                                             Seed:  62   Index:   1
+  Step  23: 1 / Imp x4 (6.882s)
+  Step  27: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  62   Index:  37
+Overworld (Kaipo)                                                             Seed:  62   Index:  37
+  Step  31: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  62   Index:  69
+  Step   9: 4 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  62   Index: 101
+Watery Pass-South B1F                                                         Seed:  62   Index: 101
+Watery Pass-South B2F                                                         Seed:  62   Index: 121
+  Step   3: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  62   Index: 211
+  Extra Steps: 52
+Watery Pass-South B2F                                                         Seed:  79   Index:  11
+  Step  37: 6 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  79   Index:  50
+Watery Pass-North B2F                                                         Seed:  79   Index:  84
+Watery Pass-North B1F                                                         Seed:  79   Index: 105
+  Step  13: 7 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  22: 8 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed:  79   Index: 165
+Waterfalls B1F                                                                Seed:  79   Index: 174
+Waterfalls B2F                                                                Seed:  79   Index: 175
+  Step  20: 9 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed:  79   Index: 220
+  Step   9: 10 / Aligator x2 (7.544s)
+  Step  27: 11 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed:  96   Index:   1
+Waterfalls Lake                                                               Seed:  96   Index:   1
+Overworld (Kaipo)                                                             Seed:  96   Index:   2
+Overworld (Damcyan)                                                           Seed:  96   Index:  13
+Damcyan                                                                       Seed:  96   Index:  17
+  Optional Steps: 0
+  Extra Steps: 26
+Overworld (Damcyan)                                                           Seed:  96   Index:  50
+Antlion B1F                                                                   Seed:  96   Index:  50
+Antlion B2F Inward Direct                                                     Seed:  96   Index:  88
+  Antlion B2F                                                                 Seed:  96   Index:  88
+    Step  14: 12 / Weeper x2 (7.114s)
+    Step  60: 13 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed:  96   Index: 168
+  Extra Steps: 24
+  Step  13: 14 / Turtle x2 (7.487s)
+  Step  37: 15 / SandWorm x2 (6.841s)
+Battle: Antlion                                                               Seed:  96   Index: 206
+Antlion's Nest                                                                Seed:  96   Index: 206
+Antlion B2F Outward Charm Room Steps                                          Seed:  96   Index: 221
+  Antlion B2F                                                                 Seed:  96   Index: 221
+    Step   9: 16 / Basilisk x1, Imp x3 (6.783s)
+  Antlion B2F Treasure Room                                                   Seed: 113   Index:  16
+    Extra Steps: 18
+  Antlion B2F                                                                 Seed: 113   Index:  34
+Antlion B1F                                                                   Seed: 113   Index:  68
+  Step  14: 17 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 113   Index: 106
+Overworld (Kaipo)                                                             Seed: 113   Index: 106
+Kaipo Revisited                                                               Seed: 113   Index: 106
+Overworld (Kaipo)                                                             Seed: 113   Index: 106
+Overworld (Damcyan)                                                           Seed: 113   Index: 106
+Mt.Hobs-West                                                                  Seed: 113   Index: 106
+  Step   8: 18 / Skelton x4 (8.683s)
+  Step  10: 19 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 113   Index: 145
+Battle: MomBomb                                                               Seed: 113   Index: 160
+Mt.Hobs Summit                                                                Seed: 113   Index: 160
+  Step   6: 20 / Cocktric x3 (7.853s)
+Mt.Hobs-East                                                                  Seed: 113   Index: 166
+Overworld (Fabul)                                                             Seed: 113   Index: 212
+  Step   6: 21 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  14: 22 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 130   Index:  40
+  Optional Steps: 10
+  Extra Steps: 2
+Overworld (Fabul)                                                             Seed: 130   Index: 112
+Fabul Boat and Leviatan                                                       Seed: 130   Index: 119
+Overworld (Mysidia)                                                           Seed: 130   Index: 119
+Mysidia                                                                       Seed: 130   Index: 128
+Overworld (Mysidia)                                                           Seed: 130   Index: 128
+Overworld (Mt.Ordeals)                                                        Seed: 130   Index: 138
+  Step  17: 23 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  22: 24 / Raven x1 (8.356s)
+  Step  70: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  77: 26 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed: 130   Index: 232
+  Step   5: 27 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 147   Index:  19
+Recruit Tellah                                                                Seed: 147   Index:  42
+Mt.Ordeals-3rd station                                                        Seed: 147   Index:  42
+  Step   3: 28 / Spirit x2, Soul x2, Red Bone x2 (9.695s)
+Mt.Ordeals-7th station                                                        Seed: 147   Index:  47
+Mt.Ordeals Summit                                                             Seed: 147   Index:  89
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 147   Index: 106
+Mt.Ordeals Summit                                                             Seed: 147   Index: 106
+  Step   1: 29 / Revenant x1, Ghoul x3 (8.611s)
+  Step   4: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.808s)
+Paladin                                                                       Seed: 147   Index: 110
+Mt.Ordeals Summit                                                             Seed: 147   Index: 110
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 147   Index: 133
+  Step   9: 31 / Revenant x1, Ghoul x3 (8.489s)
+  Step  16: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  41: 33 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 147   Index: 175
+Mt.Ordeals                                                                    Seed: 147   Index: 205
+  Step  11: 34 / Spirit x2, Skelton x2 (8.065s)
+  Step  38: 35 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 147   Index: 249
+Take Chocobo to Mysidia                                                       Seed: 164   Index:   6
+Overworld (Mysidia)                                                           Seed: 164   Index:   6
+Town of Baron Serpent Road                                                    Seed: 164   Index:   6
+Credit Warp Fight Search                                                      Seed: 164   Index:  10
+  Overworld (Baron)                                                           Seed: 164   Index:  10
+    Extra Steps: 6
+    Step   1: 36 / FloatEye x1, Eagle x2 (7.365s)
+    Step   6: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step  65: 38 / FloatEye x1, Eagle x2)
+   (Step 128: 39 / Eagle x3)
+   (Step 179: 40 / Imp x3)
+   (Step 186: 41 / Eagle x3)
+   (Step 194: 42 / Eagle x3)
+   (Step 255: 43 / Imp x4)
+
+Encounter Time:      287.085s
+Other Time:          521.175s
+Total Time:          808.260s
+
+Base Total Time:     851.645s
+Time Saved:          43.385s
+
+Optional Steps:      11
+Extra Steps:         128
+Encounters:          37
+
+Base Encounters:     45
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/063.txt
+++ b/data/routes/cw/063.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	63
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48630321
+VARS	FFFFFFFF:8 E302500:58 E305400:52 E307200:14 E307400:6 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  63   Index:   0
+Overworld (Kaipo)                                                             Seed:  63   Index:   1
+  Step  23: 1 / Imp x4 (6.882s)
+  Step  27: 2 / Sand Man x4 (7.172s)
+  Step  29: 3 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  63   Index:  37
+Overworld (Kaipo)                                                             Seed:  63   Index:  37
+  Step  31: 4 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  63   Index:  69
+  Step   9: 5 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  63   Index: 101
+Watery Pass-South B1F                                                         Seed:  63   Index: 101
+Watery Pass-South B2F                                                         Seed:  63   Index: 121
+  Step   3: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  63   Index: 211
+  Extra Steps: 52
+Watery Pass-South B2F                                                         Seed:  80   Index:  11
+  Step  37: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  80   Index:  50
+Watery Pass-North B2F                                                         Seed:  80   Index:  84
+  Extra Steps: 14
+  Step  34: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed:  80   Index: 119
+  Step   8: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  21: 10 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  80   Index: 179
+Waterfalls B1F                                                                Seed:  80   Index: 188
+  Extra Steps: 6
+Waterfalls B2F                                                                Seed:  80   Index: 195
+  Step  34: 11 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:  80   Index: 240
+Battle: Octomamm                                                              Seed:  97   Index:  21
+Waterfalls Lake                                                               Seed:  97   Index:  21
+Overworld (Kaipo)                                                             Seed:  97   Index:  22
+Overworld (Damcyan)                                                           Seed:  97   Index:  33
+Damcyan                                                                       Seed:  97   Index:  37
+  Optional Steps: 0
+  Extra Steps: 58
+Overworld (Damcyan)                                                           Seed:  97   Index: 102
+Antlion B1F                                                                   Seed:  97   Index: 102
+Antlion B2F Inward Direct                                                     Seed:  97   Index: 140
+  Antlion B2F                                                                 Seed:  97   Index: 140
+    Step   8: 12 / Weeper x2 (7.114s)
+    Step  41: 13 / Cream x4 (7.552s)
+    Step  65: 14 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  97   Index: 220
+  Step  10: 15 / SandWorm x2 (6.841s)
+Battle: Antlion                                                               Seed:  97   Index: 234
+Antlion's Nest                                                                Seed:  97   Index: 234
+Antlion B2F Outward Direct                                                    Seed:  97   Index: 249
+  Antlion B2F                                                                 Seed:  97   Index: 249
+    Step  24: 16 / Basilisk x1, Imp x3 (6.783s)
+    Step  40: 17 / Weeper x2 (7.132s)
+    Step  56: 18 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed: 114   Index:  73
+  Step   9: 19 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed: 114   Index: 111
+Overworld (Kaipo)                                                             Seed: 114   Index: 111
+Kaipo Revisited                                                               Seed: 114   Index: 111
+Overworld (Kaipo)                                                             Seed: 114   Index: 111
+Overworld (Damcyan)                                                           Seed: 114   Index: 111
+Mt.Hobs-West                                                                  Seed: 114   Index: 111
+  Step   3: 20 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 114   Index: 150
+Battle: MomBomb                                                               Seed: 114   Index: 165
+Mt.Hobs Summit                                                                Seed: 114   Index: 165
+  Step   1: 21 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed: 114   Index: 171
+Overworld (Fabul)                                                             Seed: 114   Index: 217
+  Step   1: 22 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step   9: 23 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 131   Index:  45
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 131   Index: 105
+  Step   7: 24 / Imp Cap. x3, Needler x1 (7.956s)
+Fabul Boat and Leviatan                                                       Seed: 131   Index: 112
+Overworld (Mysidia)                                                           Seed: 131   Index: 112
+Mysidia                                                                       Seed: 131   Index: 121
+Overworld (Mysidia)                                                           Seed: 131   Index: 121
+Overworld (Mt.Ordeals)                                                        Seed: 131   Index: 131
+  Step  29: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  77: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  84: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 131   Index: 225
+  Step  12: 28 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 148   Index:  12
+Recruit Tellah                                                                Seed: 148   Index:  35
+Mt.Ordeals-3rd station                                                        Seed: 148   Index:  35
+Mt.Ordeals-7th station                                                        Seed: 148   Index:  40
+  Step   4: 29 / Revenant x1, Ghoul x3 (8.914s)
+  Step   5: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 148   Index:  82
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 148   Index:  99
+Mt.Ordeals Summit                                                             Seed: 148   Index:  99
+Paladin                                                                       Seed: 148   Index: 103
+Mt.Ordeals Summit                                                             Seed: 148   Index: 103
+  Optional Steps: 1
+  Step   4: 31 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed: 148   Index: 126
+  Step  16: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  23: 33 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 148   Index: 168
+  Step   6: 34 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 148   Index: 198
+  Step  18: 35 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 148   Index: 242
+  Step   1: 36 / Imp Cap. x3, Needler x1 (7.897s)
+Take Chocobo to Mysidia                                                       Seed: 148   Index: 255
+Overworld (Mysidia)                                                           Seed: 148   Index: 255
+Town of Baron Serpent Road                                                    Seed: 148   Index: 255
+Credit Warp Fight Search                                                      Seed: 165   Index:   3
+  Overworld (Baron)                                                           Seed: 165   Index:   3
+    Extra Steps: 8
+    Step   2: 37 / Imp x3, SwordRat x1 (7.227s)
+    Step   8: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  13: 39 / Eagle x3)
+   (Step  72: 40 / Imp x3)
+   (Step 186: 41 / Eagle x3)
+   (Step 193: 42 / Imp x4)
+   (Step 201: 43 / Imp x4)
+
+Encounter Time:      289.395s
+Other Time:          519.777s
+Total Time:          809.173s
+
+Base Total Time:     860.574s
+Time Saved:          51.401s
+
+Optional Steps:      1
+Extra Steps:         138
+Encounters:          38
+
+Base Encounters:     46
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/064.txt
+++ b/data/routes/cw/064.txt
@@ -1,0 +1,147 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	64
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48216813
+VARS	FFFFFFFF:6 E302500:58 E302600:7 E305400:52 E307200:14 E307400:6 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  64   Index:   0
+Overworld (Kaipo)                                                             Seed:  64   Index:   1
+  Step  23: 1 / Imp x4 (6.882s)
+  Step  27: 2 / Sand Man x4 (7.172s)
+  Step  29: 3 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  64   Index:  37
+Overworld (Kaipo)                                                             Seed:  64   Index:  37
+  Step  31: 4 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  64   Index:  69
+  Step   9: 5 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  64   Index: 101
+Watery Pass-South B1F                                                         Seed:  64   Index: 101
+Watery Pass-South B2F                                                         Seed:  64   Index: 121
+  Step   3: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  64   Index: 211
+  Extra Steps: 52
+Watery Pass-South B2F                                                         Seed:  81   Index:  11
+  Step  37: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  81   Index:  50
+Watery Pass-North B2F                                                         Seed:  81   Index:  84
+  Extra Steps: 14
+  Step  34: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed:  81   Index: 119
+  Step  21: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  38: 10 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  81   Index: 179
+Waterfalls B1F                                                                Seed:  81   Index: 188
+  Extra Steps: 6
+Waterfalls B2F                                                                Seed:  81   Index: 195
+  Step  34: 11 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:  81   Index: 240
+Battle: Octomamm                                                              Seed:  98   Index:  21
+Waterfalls Lake                                                               Seed:  98   Index:  21
+Overworld (Kaipo)                                                             Seed:  98   Index:  22
+Overworld (Damcyan)                                                           Seed:  98   Index:  33
+Damcyan                                                                       Seed:  98   Index:  37
+  Optional Steps: 0
+  Extra Steps: 58
+Overworld (Damcyan)                                                           Seed:  98   Index: 102
+Antlion B1F                                                                   Seed:  98   Index: 102
+Antlion B2F Inward Direct                                                     Seed:  98   Index: 140
+  Antlion B2F                                                                 Seed:  98   Index: 140
+    Step   8: 12 / Weeper x2 (7.114s)
+    Step  41: 13 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed:  98   Index: 220
+  Step  10: 14 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed:  98   Index: 234
+Antlion's Nest                                                                Seed:  98   Index: 234
+Antlion B2F Outward Direct                                                    Seed:  98   Index: 249
+  Antlion B2F                                                                 Seed:  98   Index: 249
+    Step  24: 15 / SandWorm x2 (6.858s)
+    Step  40: 16 / Basilisk x1, Imp x3 (6.783s)
+    Step  56: 17 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 115   Index:  73
+  Step  15: 18 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 115   Index: 111
+Overworld (Kaipo)                                                             Seed: 115   Index: 111
+Kaipo Revisited                                                               Seed: 115   Index: 111
+Overworld (Kaipo)                                                             Seed: 115   Index: 111
+Overworld (Damcyan)                                                           Seed: 115   Index: 111
+Mt.Hobs-West                                                                  Seed: 115   Index: 111
+  Step   3: 19 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 115   Index: 150
+Battle: MomBomb                                                               Seed: 115   Index: 165
+Mt.Hobs Summit                                                                Seed: 115   Index: 165
+  Step   1: 20 / Cocktric x3 (7.853s)
+Mt.Hobs-East                                                                  Seed: 115   Index: 171
+Overworld (Fabul)                                                             Seed: 115   Index: 217
+  Step   1: 21 / Imp Cap. x3, Needler x1 (8.023s)
+  Step   9: 22 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 132   Index:  45
+  Optional Steps: 7
+Overworld (Fabul)                                                             Seed: 132   Index: 112
+Fabul Boat and Leviatan                                                       Seed: 132   Index: 119
+Overworld (Mysidia)                                                           Seed: 132   Index: 119
+Mysidia                                                                       Seed: 132   Index: 128
+Overworld (Mysidia)                                                           Seed: 132   Index: 128
+Overworld (Mt.Ordeals)                                                        Seed: 132   Index: 138
+  Step  22: 23 / Raven x1 (8.356s)
+  Step  70: 24 / Raven x1 (8.356s)
+  Step  77: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 132   Index: 232
+  Step   5: 26 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 149   Index:  19
+Recruit Tellah                                                                Seed: 149   Index:  42
+Mt.Ordeals-3rd station                                                        Seed: 149   Index:  42
+  Step   2: 27 / Zombie x2, Ghoul x2 (7.616s)
+  Step   3: 28 / Spirit x2, Soul x2, Red Bone x2 (9.695s)
+Mt.Ordeals-7th station                                                        Seed: 149   Index:  47
+  Step  36: 29 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 149   Index:  89
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 149   Index: 106
+Mt.Ordeals Summit                                                             Seed: 149   Index: 106
+  Step   1: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.808s)
+Paladin                                                                       Seed: 149   Index: 110
+Mt.Ordeals Summit                                                             Seed: 149   Index: 110
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 149   Index: 133
+  Step  16: 31 / Revenant x1, Ghoul x3 (8.489s)
+  Step  41: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 149   Index: 175
+Mt.Ordeals                                                                    Seed: 149   Index: 205
+  Step  11: 33 / Spirit x2, Skelton x2 (8.065s)
+  Step  38: 34 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 149   Index: 249
+  Step  12: 35 / Imp Cap. x4, Imp x2 (8.400s)
+Take Chocobo to Mysidia                                                       Seed: 166   Index:   6
+Overworld (Mysidia)                                                           Seed: 166   Index:   6
+Town of Baron Serpent Road                                                    Seed: 166   Index:   6
+Credit Warp Fight Search                                                      Seed: 166   Index:  10
+  Overworld (Baron)                                                           Seed: 166   Index:  10
+    Extra Steps: 6
+    Step   1: 36 / FloatEye x1, Eagle x2 (7.365s)
+    Step   6: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step 161: 38 / Imp x3, SwordRat x1)
+   (Step 179: 39 / Eagle x3)
+   (Step 186: 40 / Imp x3)
+   (Step 194: 41 / Eagle x3)
+   (Step 255: 42 / Imp x4)
+
+Encounter Time:      283.580s
+Other Time:          518.712s
+Total Time:          802.292s
+
+Base Total Time:     876.082s
+Time Saved:          73.790s
+
+Optional Steps:      8
+Extra Steps:         136
+Encounters:          37
+
+Base Encounters:     45
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/065.txt
+++ b/data/routes/cw/065.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	65
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48276023
+VARS	FFFFFFFF:8 C307801:1 E302500:7 E302600:7 E305400:52 E307400:20 E307700:2 E307B01:22 E308700:1 E308702:1 E309700:14
+
+Overworld (Kaipo)                                                             Seed:  65   Index:   0
+Overworld (Kaipo)                                                             Seed:  65   Index:   1
+  Step  27: 1 / Imp x4 (6.882s)
+  Step  29: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  65   Index:  37
+Overworld (Kaipo)                                                             Seed:  65   Index:  37
+  Step  31: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  65   Index:  69
+  Step   9: 4 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  65   Index: 101
+Watery Pass-South B1F                                                         Seed:  65   Index: 101
+Watery Pass-South B2F                                                         Seed:  65   Index: 121
+  Step   3: 5 / Pike x3 (7.152s)
+  Step  57: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  65   Index: 211
+  Extra Steps: 52
+Watery Pass-South B2F                                                         Seed:  82   Index:  11
+Watery Pass-South B3F                                                         Seed:  82   Index:  50
+Watery Pass-North B2F                                                         Seed:  82   Index:  84
+Watery Pass-North B1F                                                         Seed:  82   Index: 105
+  Step  13: 7 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  35: 8 / Jelly x4 (7.324s)
+  Step  52: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:  82   Index: 165
+Waterfalls B1F                                                                Seed:  82   Index: 174
+  Extra Steps: 20
+Waterfalls B2F                                                                Seed:  82   Index: 195
+  Step  34: 10 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed:  82   Index: 240
+Battle: Octomamm                                                              Seed:  99   Index:  21
+Waterfalls Lake                                                               Seed:  99   Index:  21
+Overworld (Kaipo)                                                             Seed:  99   Index:  22
+Overworld (Damcyan)                                                           Seed:  99   Index:  33
+Damcyan                                                                       Seed:  99   Index:  37
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed:  99   Index:  51
+Antlion B1F                                                                   Seed:  99   Index:  51
+  Extra Steps: 2
+  Step  40: 11 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Direct                                                     Seed:  99   Index:  91
+  Antlion B2F                                                                 Seed:  99   Index:  91
+    Step  11: 12 / Weeper x2 (7.114s)
+    Step  57: 13 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed:  99   Index: 171
+  Step  10: 14 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed:  99   Index: 185
+Antlion's Nest                                                                Seed:  99   Index: 185
+Antlion B2F Outward Charm Room Steps                                          Seed:  99   Index: 200
+  Antlion B2F                                                                 Seed:  99   Index: 200
+    Step  17: 15 / SandWorm x2 (6.858s)
+  Antlion B2F Treasure Room                                                   Seed:  99   Index: 251
+    Extra Steps: 22
+  Antlion B2F                                                                 Seed: 116   Index:  17
+    Step  16: 16 / Basilisk x1, Imp x3 (6.783s)
+    Step  32: 17 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 116   Index:  51
+  Step   8: 18 / Imp x3 (6.648s)
+  Step  37: 19 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed: 116   Index:  89
+Overworld (Kaipo)                                                             Seed: 116   Index:  89
+Kaipo Revisited                                                               Seed: 116   Index:  89
+Overworld (Kaipo)                                                             Seed: 116   Index:  89
+Overworld (Damcyan)                                                           Seed: 116   Index:  89
+Mt.Hobs-West                                                                  Seed: 116   Index:  89
+Mt.Hobs Summit                                                                Seed: 116   Index: 128
+Battle: MomBomb                                                               Seed: 116   Index: 143
+Mt.Hobs Summit                                                                Seed: 116   Index: 143
+Mt.Hobs-East                                                                  Seed: 116   Index: 149
+  Step  17: 20 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 116   Index: 195
+  Step  23: 21 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  31: 22 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 133   Index:  23
+  Optional Steps: 7
+Overworld (Fabul)                                                             Seed: 133   Index:  90
+Fabul Boat and Leviatan                                                       Seed: 133   Index:  97
+Overworld (Mysidia)                                                           Seed: 133   Index:  97
+Mysidia                                                                       Seed: 133   Index: 106
+Overworld (Mysidia)                                                           Seed: 133   Index: 106
+  Step   5: 23 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 133   Index: 116
+  Step  44: 24 / Raven x1 (8.356s)
+  Step  92: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 133   Index: 210
+  Step   5: 26 / Skelton x3, Red Bone x2 (8.244s)
+  Step  27: 27 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  28: 28 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 133   Index: 253
+Recruit Tellah                                                                Seed: 150   Index:  20
+Mt.Ordeals-3rd station                                                        Seed: 150   Index:  20
+Mt.Ordeals-7th station                                                        Seed: 150   Index:  25
+  Step  19: 29 / Revenant x1, Ghoul x3 (8.914s)
+  Step  20: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 150   Index:  67
+  Optional Steps: 1
+  Step  16: 31 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed: 150   Index:  85
+Mt.Ordeals Summit                                                             Seed: 150   Index:  85
+Paladin                                                                       Seed: 150   Index:  89
+Mt.Ordeals Summit                                                             Seed: 150   Index:  89
+  Optional Steps: 1
+  Step  18: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 150   Index: 112
+  Step  37: 33 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 150   Index: 154
+  Step  19: 34 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 150   Index: 184
+  Step  32: 35 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 150   Index: 228
+Take Chocobo to Mysidia                                                       Seed: 150   Index: 241
+Overworld (Mysidia)                                                           Seed: 150   Index: 241
+Town of Baron Serpent Road                                                    Seed: 150   Index: 241
+  Extra Steps: 14
+Credit Warp Fight Search                                                      Seed: 167   Index:   3
+  Overworld (Baron)                                                           Seed: 167   Index:   3
+    Extra Steps: 8
+    Step   2: 36 / FloatEye x1, Eagle x2 (7.365s)
+    Step   8: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step  92: 38 / Imp x3, SwordRat x1)
+   (Step 168: 39 / Eagle x3)
+   (Step 186: 40 / Imp x3)
+   (Step 193: 41 / Eagle x3)
+   (Step 201: 42 / Imp x4)
+
+Encounter Time:      282.635s
+Other Time:          520.643s
+Total Time:          803.277s
+
+Base Total Time:     876.252s
+Time Saved:          72.975s
+
+Optional Steps:      10
+Extra Steps:         124
+Encounters:          37
+
+Base Encounters:     45
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/066.txt
+++ b/data/routes/cw/066.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	66
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49759501
+VARS	FFFFFFFF:26 C307800:1 E302500:1 E302600:4 E307300:5 E307B00:2 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  66   Index:   0
+Overworld (Kaipo)                                                             Seed:  66   Index:   1
+  Step  27: 1 / Imp x4 (6.882s)
+  Step  29: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  66   Index:  37
+Overworld (Kaipo)                                                             Seed:  66   Index:  37
+  Step   6: 3 / Sandpede x1, Sand Man x2 (7.096s)
+  Step  31: 4 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  66   Index:  69
+  Step   9: 5 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  66   Index: 101
+Watery Pass-South B1F                                                         Seed:  66   Index: 101
+Watery Pass-South B2F                                                         Seed:  66   Index: 121
+  Step  57: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  66   Index: 211
+Watery Pass-South B2F                                                         Seed:  66   Index: 215
+  Step  35: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  66   Index: 254
+  Step  10: 8 / Pike x2, EvilShel x2 (7.149s)
+  Step  12: 9 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  83   Index:  32
+Watery Pass-North B1F                                                         Seed:  83   Index:  53
+  Extra Steps: 5
+  Step  32: 10 / Aligator x1, Pike x2 (7.368s)
+  Step  65: 11 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:  83   Index: 118
+Waterfalls B1F                                                                Seed:  83   Index: 127
+Waterfalls B2F                                                                Seed:  83   Index: 128
+  Step  12: 12 / Aligator x1, WaterBug x2 (7.292s)
+  Step  29: 13 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed:  83   Index: 173
+  Step  22: 14 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed:  83   Index: 210
+Waterfalls Lake                                                               Seed:  83   Index: 210
+Overworld (Kaipo)                                                             Seed:  83   Index: 211
+Overworld (Damcyan)                                                           Seed:  83   Index: 222
+Damcyan                                                                       Seed:  83   Index: 226
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  83   Index: 234
+Antlion B1F                                                                   Seed:  83   Index: 234
+Antlion B2F Inward Charm Room Steps                                           Seed: 100   Index:  16
+  Antlion B2F                                                                 Seed: 100   Index:  16
+    Step  23: 15 / SandWorm x2 (6.841s)
+  Antlion B2F Treasure Room                                                   Seed: 100   Index:  49
+    Extra Steps: 2
+  Antlion B2F                                                                 Seed: 100   Index:  51
+    Step  40: 16 / Basilisk x1, Imp x3 (6.775s)
+    Step  51: 17 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 100   Index: 103
+  Step  12: 18 / Cream x4 (7.552s)
+Battle: Antlion                                                               Seed: 100   Index: 117
+Antlion's Nest                                                                Seed: 100   Index: 117
+Antlion B2F Outward Direct                                                    Seed: 100   Index: 132
+  Antlion B2F                                                                 Seed: 100   Index: 132
+    Step  16: 19 / Basilisk x1, Turtle x1 (7.124s)
+    Step  49: 20 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed: 100   Index: 212
+  Step   5: 21 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 100   Index: 250
+Overworld (Kaipo)                                                             Seed: 100   Index: 250
+Kaipo Revisited                                                               Seed: 100   Index: 250
+Overworld (Kaipo)                                                             Seed: 100   Index: 250
+Overworld (Damcyan)                                                           Seed: 100   Index: 250
+Mt.Hobs-West                                                                  Seed: 100   Index: 250
+  Step  23: 22 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 117   Index:  33
+Battle: MomBomb                                                               Seed: 117   Index:  48
+Mt.Hobs Summit                                                                Seed: 117   Index:  48
+  Step   1: 23 / Cocktric x3 (7.853s)
+Mt.Hobs-East                                                                  Seed: 117   Index:  54
+  Step   5: 24 / Spirit x2, Skelton x2 (8.237s)
+  Step  34: 25 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 117   Index: 100
+  Step  14: 26 / SwordRat x3, Needler x3 (7.663s)
+  Step  66: 27 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  69: 28 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 117   Index: 184
+  Optional Steps: 4
+Overworld (Fabul)                                                             Seed: 117   Index: 248
+Fabul Boat and Leviatan                                                       Seed: 117   Index: 255
+Overworld (Mysidia)                                                           Seed: 117   Index: 255
+Mysidia                                                                       Seed: 134   Index:   8
+Overworld (Mysidia)                                                           Seed: 134   Index:   8
+Overworld (Mt.Ordeals)                                                        Seed: 134   Index:  18
+  Step  28: 29 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  61: 30 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  72: 31 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  93: 32 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 134   Index: 112
+Mt.Ordeals-3rd station                                                        Seed: 134   Index: 155
+  Step  13: 33 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed: 134   Index: 178
+Mt.Ordeals-3rd station                                                        Seed: 134   Index: 178
+Mt.Ordeals-7th station                                                        Seed: 134   Index: 183
+  Step  25: 34 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 134   Index: 225
+  Optional Steps: 1
+  Step  12: 35 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  13: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed: 134   Index: 243
+Mt.Ordeals Summit                                                             Seed: 134   Index: 243
+Paladin                                                                       Seed: 134   Index: 247
+Mt.Ordeals Summit                                                             Seed: 134   Index: 247
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 151   Index:  14
+  Step  30: 37 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  31: 38 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed: 151   Index:  56
+  Step  27: 39 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed: 151   Index:  86
+  Step  19: 40 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 151   Index: 130
+Take Chocobo to Mysidia                                                       Seed: 151   Index: 143
+Overworld (Mysidia)                                                           Seed: 151   Index: 143
+Town of Baron Serpent Road                                                    Seed: 151   Index: 143
+Credit Warp Fight Search                                                      Seed: 151   Index: 147
+  Overworld (Baron)                                                           Seed: 151   Index: 147
+    Extra Steps: 26
+    Step   2: 41 / Eagle x3 (7.417s)
+    Step  26: 42 / Imp x4 (7.223s)
+   (Step  96: 43 / Imp x4)
+   (Step 114: 44 / FloatEye x2)
+   (Step 120: 45 / Imp x3, SwordRat x1)
+   (Step 204: 46 / Imp x3, SwordRat x1)
+
+Encounter Time:      326.487s
+Other Time:          501.474s
+Total Time:          827.961s
+
+Base Total Time:     890.090s
+Time Saved:          62.128s
+
+Optional Steps:      7
+Extra Steps:         33
+Encounters:          42
+
+Base Encounters:     45
+Encounters Saved:    3
+
+Number of Variables: 54

--- a/data/routes/cw/067.txt
+++ b/data/routes/cw/067.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	67
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50550156
+VARS	FFFFFFFF:26 E302600:5 E308502:10 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed:  67   Index:   0
+Overworld (Kaipo)                                                             Seed:  67   Index:   1
+  Step  27: 1 / Imp x4 (6.882s)
+  Step  29: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  67   Index:  37
+Overworld (Kaipo)                                                             Seed:  67   Index:  37
+  Step   6: 3 / Sandpede x1, Sand Man x2 (7.096s)
+  Step  31: 4 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  67   Index:  69
+  Step   9: 5 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  67   Index: 101
+Watery Pass-South B1F                                                         Seed:  67   Index: 101
+Watery Pass-South B2F                                                         Seed:  67   Index: 121
+  Step  32: 6 / Pike x3 (7.152s)
+  Step  57: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  67   Index: 211
+Watery Pass-South B2F                                                         Seed:  67   Index: 215
+  Step  35: 8 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  67   Index: 254
+  Step  10: 9 / CaveToad x3 (7.014s)
+  Step  12: 10 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed:  84   Index:  32
+Watery Pass-North B1F                                                         Seed:  84   Index:  53
+  Step  32: 11 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:  84   Index: 113
+  Step   4: 12 / SandMoth x2, Larva x2 (7.163s)
+Waterfalls B1F                                                                Seed:  84   Index: 122
+Waterfalls B2F                                                                Seed:  84   Index: 123
+  Step  17: 13 / Jelly x4 (7.324s)
+  Step  34: 14 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed:  84   Index: 168
+  Step  27: 15 / TinyMage x4 (7.558s)
+Battle: Octomamm                                                              Seed:  84   Index: 205
+Waterfalls Lake                                                               Seed:  84   Index: 205
+Overworld (Kaipo)                                                             Seed:  84   Index: 206
+Overworld (Damcyan)                                                           Seed:  84   Index: 217
+Damcyan                                                                       Seed:  84   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  84   Index: 228
+Antlion B1F                                                                   Seed:  84   Index: 228
+  Step   1: 16 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Direct                                                     Seed: 101   Index:  10
+  Antlion B2F                                                                 Seed: 101   Index:  10
+    Step  29: 17 / Weeper x2 (7.114s)
+    Step  41: 18 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 101   Index:  90
+  Step   1: 19 / Basilisk x1, Turtle x1 (7.110s)
+  Step  12: 20 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 101   Index: 104
+Antlion's Nest                                                                Seed: 101   Index: 104
+  Step  11: 21 / Basilisk x1, Imp x3 (6.783s)
+Antlion B2F Outward Direct                                                    Seed: 101   Index: 119
+  Antlion B2F                                                                 Seed: 101   Index: 119
+    Step  28: 22 / Weeper x2 (7.132s)
+    Step  62: 23 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed: 101   Index: 199
+  Step  18: 24 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 101   Index: 237
+Overworld (Kaipo)                                                             Seed: 101   Index: 237
+Kaipo Revisited                                                               Seed: 101   Index: 237
+Overworld (Kaipo)                                                             Seed: 101   Index: 237
+Overworld (Damcyan)                                                           Seed: 101   Index: 237
+Mt.Hobs-West                                                                  Seed: 101   Index: 237
+  Step  36: 25 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 118   Index:  20
+Battle: MomBomb                                                               Seed: 118   Index:  35
+Mt.Hobs Summit                                                                Seed: 118   Index:  35
+Mt.Hobs-East                                                                  Seed: 118   Index:  41
+  Step   8: 26 / Gargoyle x2 (7.630s)
+  Step  18: 27 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 118   Index:  87
+  Step   1: 28 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  79: 29 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  82: 30 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 118   Index: 171
+  Optional Steps: 5
+Overworld (Fabul)                                                             Seed: 118   Index: 236
+Fabul Boat and Leviatan                                                       Seed: 118   Index: 243
+Overworld (Mysidia)                                                           Seed: 118   Index: 243
+Mysidia                                                                       Seed: 118   Index: 252
+Overworld (Mysidia)                                                           Seed: 118   Index: 252
+Overworld (Mt.Ordeals)                                                        Seed: 135   Index:   6
+  Step  40: 31 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  73: 32 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  84: 33 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 135   Index: 100
+  Step  11: 34 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 135   Index: 143
+Recruit Tellah                                                                Seed: 135   Index: 166
+Mt.Ordeals-3rd station                                                        Seed: 135   Index: 166
+  Step   2: 35 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 135   Index: 171
+  Step  27: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 135   Index: 213
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 135   Index: 231
+Mt.Ordeals Summit                                                             Seed: 135   Index: 231
+Paladin                                                                       Seed: 135   Index: 235
+Mt.Ordeals Summit                                                             Seed: 135   Index: 235
+  Optional Steps: 1
+  Step   2: 37 / Lilith x1, Red Bone x2 (8.437s)
+  Step   3: 38 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed: 152   Index:   2
+  Step  23: 39 / Lilith x1, Red Bone x2 (8.437s)
+  Step  42: 40 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 152   Index:  44
+  Extra Steps: 10
+  Step   1: 41 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  39: 42 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 152   Index:  84
+  Step  21: 43 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 152   Index: 128
+Take Chocobo to Mysidia                                                       Seed: 152   Index: 141
+Overworld (Mysidia)                                                           Seed: 152   Index: 141
+Town of Baron Serpent Road                                                    Seed: 152   Index: 141
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 152   Index: 147
+  Overworld (Baron)                                                           Seed: 152   Index: 147
+    Extra Steps: 26
+    Step   2: 44 / FloatEye x2 (7.230s)
+    Step  26: 45 / Imp x3, SwordRat x1 (7.227s)
+   (Step 114: 46 / Imp x3, SwordRat x1)
+   (Step 204: 47 / Imp x3)
+
+Encounter Time:      343.171s
+Other Time:          497.947s
+Total Time:          841.117s
+
+Base Total Time:     849.394s
+Time Saved:          8.277s
+
+Optional Steps:      7
+Extra Steps:         38
+Encounters:          45
+
+Base Encounters:     45
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/068.txt
+++ b/data/routes/cw/068.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	68
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49804416
+VARS	FFFFFFFF:26 E000600:2 E302500:1 E302600:10 E307300:4 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  68   Index:   0
+Overworld (Kaipo)                                                             Seed:  68   Index:   1
+  Step  27: 1 / Imp x4 (6.882s)
+  Step  29: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  68   Index:  37
+Overworld (Kaipo)                                                             Seed:  68   Index:  37
+  Step   6: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  68   Index:  69
+Recruit Tellah                                                                Seed:  68   Index: 101
+Watery Pass-South B1F                                                         Seed:  68   Index: 101
+  Step  18: 4 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F                                                         Seed:  68   Index: 121
+  Step  32: 5 / Pike x3 (7.152s)
+  Step  57: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  68   Index: 211
+Watery Pass-South B2F                                                         Seed:  68   Index: 215
+  Step  35: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  68   Index: 254
+  Step  10: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed:  85   Index:  32
+Watery Pass-North B1F                                                         Seed:  85   Index:  53
+  Extra Steps: 4
+  Step  23: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  32: 10 / Aligator x1, Pike x2 (7.368s)
+  Step  64: 11 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:  85   Index: 117
+Waterfalls B1F                                                                Seed:  85   Index: 126
+Waterfalls B2F                                                                Seed:  85   Index: 127
+  Step  13: 12 / Aligator x1, WaterBug x2 (7.292s)
+  Step  30: 13 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed:  85   Index: 172
+Battle: Octomamm                                                              Seed:  85   Index: 209
+Waterfalls Lake                                                               Seed:  85   Index: 209
+Overworld (Kaipo)                                                             Seed:  85   Index: 210
+Overworld (Damcyan)                                                           Seed:  85   Index: 221
+Damcyan                                                                       Seed:  85   Index: 225
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  85   Index: 233
+Antlion B1F                                                                   Seed:  85   Index: 233
+Antlion B2F Inward Direct                                                     Seed: 102   Index:  15
+  Antlion B2F                                                                 Seed: 102   Index:  15
+    Step  24: 14 / Turtle x2 (7.487s)
+    Step  36: 15 / SandWorm x1, Sandpede x1 (6.829s)
+    Step  76: 16 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 102   Index:  95
+  Step   7: 17 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed: 102   Index: 109
+Antlion's Nest                                                                Seed: 102   Index: 109
+  Step   6: 18 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed: 102   Index: 124
+  Antlion B2F                                                                 Seed: 102   Index: 124
+    Step  23: 19 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed: 102   Index: 204
+  Step  13: 20 / Basilisk x1, Imp x3 (6.783s)
+  Step  31: 21 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 102   Index: 242
+Overworld (Kaipo)                                                             Seed: 102   Index: 242
+Kaipo Revisited                                                               Seed: 102   Index: 242
+Overworld (Kaipo)                                                             Seed: 102   Index: 242
+Overworld (Damcyan)                                                           Seed: 102   Index: 242
+Mt.Hobs-West                                                                  Seed: 102   Index: 242
+  Step  31: 22 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 119   Index:  25
+Battle: MomBomb                                                               Seed: 119   Index:  40
+Mt.Hobs Summit                                                                Seed: 119   Index:  40
+Mt.Hobs-East                                                                  Seed: 119   Index:  46
+  Step   3: 23 / Red Bone x1, Skelton x3 (8.007s)
+  Step  13: 24 / Spirit x2, Skelton x2 (8.237s)
+  Step  42: 25 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 119   Index:  92
+  Step  74: 26 / SwordRat x3, Needler x3 (7.663s)
+  Step  77: 27 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 119   Index: 176
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 119   Index: 246
+Fabul Boat and Leviatan                                                       Seed: 119   Index: 253
+Overworld (Mysidia)                                                           Seed: 119   Index: 253
+Mysidia                                                                       Seed: 136   Index:   6
+Overworld (Mysidia)                                                           Seed: 136   Index:   6
+Overworld (Mt.Ordeals)                                                        Seed: 136   Index:  16
+  Extra Steps: 2
+  Step  30: 28 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  55: 29 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  63: 30 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  74: 31 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  95: 32 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 136   Index: 112
+Mt.Ordeals-3rd station                                                        Seed: 136   Index: 155
+  Step  13: 33 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed: 136   Index: 178
+Mt.Ordeals-3rd station                                                        Seed: 136   Index: 178
+Mt.Ordeals-7th station                                                        Seed: 136   Index: 183
+  Step  15: 34 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 136   Index: 225
+  Optional Steps: 1
+  Step  12: 35 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  13: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed: 136   Index: 243
+Mt.Ordeals Summit                                                             Seed: 136   Index: 243
+Paladin                                                                       Seed: 136   Index: 247
+Mt.Ordeals Summit                                                             Seed: 136   Index: 247
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 153   Index:  14
+  Step  11: 37 / Lilith x1, Red Bone x2 (8.437s)
+  Step  30: 38 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  31: 39 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 153   Index:  56
+  Step  27: 40 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 153   Index:  86
+  Step  19: 41 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 153   Index: 130
+Take Chocobo to Mysidia                                                       Seed: 153   Index: 143
+Overworld (Mysidia)                                                           Seed: 153   Index: 143
+Town of Baron Serpent Road                                                    Seed: 153   Index: 143
+Credit Warp Fight Search                                                      Seed: 153   Index: 147
+  Overworld (Baron)                                                           Seed: 153   Index: 147
+    Extra Steps: 26
+    Step   2: 42 / Imp x4 (7.223s)
+    Step  26: 43 / Imp x4 (7.223s)
+   (Step  64: 44 / FloatEye x2)
+   (Step 114: 45 / Imp x3, SwordRat x1)
+   (Step 151: 46 / Imp x3, SwordRat x1)
+   (Step 204: 47 / Imp x3)
+
+Encounter Time:      332.360s
+Other Time:          496.349s
+Total Time:          828.709s
+
+Base Total Time:     871.686s
+Time Saved:          42.977s
+
+Optional Steps:      13
+Extra Steps:         32
+Encounters:          43
+
+Base Encounters:     45
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/069.txt
+++ b/data/routes/cw/069.txt
@@ -1,0 +1,157 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	69
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49985005
+VARS	FFFFFFFF:2 C307800:1 E000202:2 E302600:24 E305400:16 E307400:18 E307700:8 E307B00:30 E308000:12 E308700:1 E308702:1 E309700:14
+
+Overworld (Kaipo)                                                             Seed:  69   Index:   0
+Overworld (Kaipo)                                                             Seed:  69   Index:   1
+  Step  27: 1 / Imp x4 (6.882s)
+  Step  29: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  69   Index:  37
+Overworld (Kaipo)                                                             Seed:  69   Index:  37
+  Step   6: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  69   Index:  69
+Recruit Tellah                                                                Seed:  69   Index: 101
+Watery Pass-South B1F                                                         Seed:  69   Index: 101
+  Step  18: 4 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F                                                         Seed:  69   Index: 121
+  Step  32: 5 / Pike x3 (7.152s)
+  Step  57: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  69   Index: 211
+  Extra Steps: 16
+Watery Pass-South B2F                                                         Seed:  69   Index: 231
+  Step  19: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  33: 8 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  86   Index:  14
+  Step  18: 9 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  86   Index:  48
+Watery Pass-North B1F                                                         Seed:  86   Index:  69
+  Step   7: 10 / Aligator x1, Pike x2 (7.368s)
+  Step  16: 11 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  48: 12 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  86   Index: 129
+Waterfalls B1F                                                                Seed:  86   Index: 138
+  Extra Steps: 18
+Waterfalls B2F                                                                Seed:  86   Index: 157
+Waterfalls Lake                                                               Seed:  86   Index: 202
+  Step  27: 13 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed:  86   Index: 239
+Waterfalls Lake                                                               Seed:  86   Index: 239
+Overworld (Kaipo)                                                             Seed:  86   Index: 240
+Overworld (Damcyan)                                                           Seed:  86   Index: 251
+Damcyan                                                                       Seed:  86   Index: 255
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 103   Index:   6
+Antlion B1F                                                                   Seed: 103   Index:   6
+  Extra Steps: 8
+  Step   6: 14 / Turtle x1, Imp x2 (7.044s)
+  Step  45: 15 / Imp x3 (6.649s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 103   Index:  52
+  Antlion B2F                                                                 Seed: 103   Index:  52
+  Antlion B2F Treasure Room                                                   Seed: 103   Index:  85
+    Extra Steps: 30
+  Antlion B2F                                                                 Seed: 103   Index: 115
+    Step  32: 16 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 103   Index: 167
+Battle: Antlion                                                               Seed: 103   Index: 181
+Antlion's Nest                                                                Seed: 103   Index: 181
+Antlion B2F Outward Direct                                                    Seed: 103   Index: 196
+  Antlion B2F                                                                 Seed: 103   Index: 196
+    Step  21: 17 / Weeper x2 (7.132s)
+    Step  39: 18 / Cream x4 (7.523s)
+    Step  77: 19 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 120   Index:  20
+  Step   3: 20 / Basilisk x1, Imp x3 (6.783s)
+  Step  29: 21 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 120   Index:  58
+Overworld (Kaipo)                                                             Seed: 120   Index:  58
+  Extra Steps: 2
+  Step   1: 22 / SandMoth x2, Larva x2 (7.135s)
+Kaipo Revisited                                                               Seed: 120   Index:  60
+Overworld (Kaipo)                                                             Seed: 120   Index:  60
+Overworld (Damcyan)                                                           Seed: 120   Index:  60
+Mt.Hobs-West                                                                  Seed: 120   Index:  60
+  Step  28: 23 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 120   Index:  99
+Battle: MomBomb                                                               Seed: 120   Index: 114
+Mt.Hobs Summit                                                                Seed: 120   Index: 114
+Mt.Hobs-East                                                                  Seed: 120   Index: 120
+  Extra Steps: 12
+  Step  49: 24 / Spirit x2, Skelton x2 (8.237s)
+  Step  57: 25 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 120   Index: 178
+  Step  31: 26 / SwordRat x3, Needler x3 (7.663s)
+  Step  48: 27 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 137   Index:   6
+  Optional Steps: 10
+  Extra Steps: 14
+Overworld (Fabul)                                                             Seed: 137   Index:  90
+Fabul Boat and Leviatan                                                       Seed: 137   Index:  97
+Overworld (Mysidia)                                                           Seed: 137   Index:  97
+Mysidia                                                                       Seed: 137   Index: 106
+Overworld (Mysidia)                                                           Seed: 137   Index: 106
+  Step   5: 28 / Imp Cap. x3, Needler x1 (7.932s)
+Overworld (Mt.Ordeals)                                                        Seed: 137   Index: 116
+  Step  52: 29 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  82: 30 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 137   Index: 210
+  Step  28: 31 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 137   Index: 253
+Recruit Tellah                                                                Seed: 154   Index:  20
+Mt.Ordeals-3rd station                                                        Seed: 154   Index:  20
+  Step   5: 32 / Zombie x2, Ghoul x2 (7.616s)
+Mt.Ordeals-7th station                                                        Seed: 154   Index:  25
+  Step  19: 33 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 154   Index:  67
+  Optional Steps: 1
+  Step  16: 34 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed: 154   Index:  85
+Mt.Ordeals Summit                                                             Seed: 154   Index:  85
+Paladin                                                                       Seed: 154   Index:  89
+Mt.Ordeals Summit                                                             Seed: 154   Index:  89
+  Optional Steps: 1
+  Step  16: 35 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed: 154   Index: 112
+  Step  37: 36 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  42: 37 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 154   Index: 154
+  Step  19: 38 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed: 154   Index: 184
+  Step  27: 39 / Soul x2, Red Bone x2 (8.881s)
+Overworld (Mt.Ordeals)                                                        Seed: 154   Index: 228
+Take Chocobo to Mysidia                                                       Seed: 154   Index: 241
+Overworld (Mysidia)                                                           Seed: 154   Index: 241
+Town of Baron Serpent Road                                                    Seed: 154   Index: 241
+  Extra Steps: 14
+Credit Warp Fight Search                                                      Seed: 171   Index:   3
+  Overworld (Baron)                                                           Seed: 171   Index:   3
+    Extra Steps: 2
+    Step   1: 40 / FloatEye x2 (7.230s)
+    Step   2: 41 / Imp x4 (7.223s)
+   (Step  39: 42 / Imp x4)
+   (Step  92: 43 / Imp x4)
+   (Step 168: 44 / FloatEye x2)
+   (Step 173: 45 / Imp x3, SwordRat x1)
+   (Step 216: 46 / Imp x3, SwordRat x1)
+
+Encounter Time:      314.798s
+Other Time:          516.915s
+Total Time:          831.714s
+
+Base Total Time:     860.435s
+Time Saved:          28.721s
+
+Optional Steps:      12
+Extra Steps:         116
+Encounters:          41
+
+Base Encounters:     46
+Encounters Saved:    5
+
+Number of Variables: 54

--- a/data/routes/cw/070.txt
+++ b/data/routes/cw/070.txt
@@ -1,0 +1,156 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	70
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50764256
+VARS	FFFFFFFF:14 E302500:1 E302600:10 E305400:16 E307400:2 E307E00:10 E308401:2 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  70   Index:   0
+Overworld (Kaipo)                                                             Seed:  70   Index:   1
+  Step  29: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed:  70   Index:  37
+Overworld (Kaipo)                                                             Seed:  70   Index:  37
+  Step   6: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  70   Index:  69
+  Step   3: 3 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed:  70   Index: 101
+Watery Pass-South B1F                                                         Seed:  70   Index: 101
+  Step  18: 4 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F                                                         Seed:  70   Index: 121
+  Step  32: 5 / Pike x3 (7.152s)
+  Step  57: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  70   Index: 211
+  Extra Steps: 16
+Watery Pass-South B2F                                                         Seed:  70   Index: 231
+  Step  19: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  33: 8 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  87   Index:  14
+  Step  18: 9 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  87   Index:  48
+Watery Pass-North B1F                                                         Seed:  87   Index:  69
+  Step   7: 10 / Aligator x1, Pike x2 (7.368s)
+  Step  16: 11 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  48: 12 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  87   Index: 129
+Waterfalls B1F                                                                Seed:  87   Index: 138
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed:  87   Index: 141
+  Step  16: 13 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed:  87   Index: 186
+  Step  27: 14 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed:  87   Index: 223
+Waterfalls Lake                                                               Seed:  87   Index: 223
+Overworld (Kaipo)                                                             Seed:  87   Index: 224
+Overworld (Damcyan)                                                           Seed:  87   Index: 235
+Damcyan                                                                       Seed:  87   Index: 239
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  87   Index: 247
+Antlion B1F                                                                   Seed:  87   Index: 247
+  Step  21: 15 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 104   Index:  29
+  Antlion B2F                                                                 Seed: 104   Index:  29
+    Step  22: 16 / Turtle x2 (7.487s)
+    Step  33: 17 / SandWorm x2 (6.841s)
+    Step  62: 18 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 104   Index: 109
+  Step   6: 19 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed: 104   Index: 123
+Antlion's Nest                                                                Seed: 104   Index: 123
+Antlion B2F Outward Direct                                                    Seed: 104   Index: 138
+  Antlion B2F                                                                 Seed: 104   Index: 138
+    Step   9: 20 / Basilisk x1, Turtle x1 (7.124s)
+    Step  79: 21 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 104   Index: 218
+  Step  17: 22 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 121   Index:   0
+Overworld (Kaipo)                                                             Seed: 121   Index:   0
+Kaipo Revisited                                                               Seed: 121   Index:   0
+Overworld (Kaipo)                                                             Seed: 121   Index:   0
+Overworld (Damcyan)                                                           Seed: 121   Index:   0
+Mt.Hobs-West                                                                  Seed: 121   Index:   0
+  Extra Steps: 10
+  Step  23: 23 / Cocktric x3 (9.055s)
+  Step  49: 24 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 121   Index:  49
+  Step  10: 25 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed: 121   Index:  64
+Mt.Hobs Summit                                                                Seed: 121   Index:  64
+Mt.Hobs-East                                                                  Seed: 121   Index:  70
+  Step  18: 26 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 121   Index: 116
+  Step  39: 27 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  50: 28 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  53: 29 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  61: 30 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 121   Index: 200
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 138   Index:  14
+Fabul Boat and Leviatan                                                       Seed: 138   Index:  21
+Overworld (Mysidia)                                                           Seed: 138   Index:  21
+Mysidia                                                                       Seed: 138   Index:  30
+Overworld (Mysidia)                                                           Seed: 138   Index:  30
+Overworld (Mt.Ordeals)                                                        Seed: 138   Index:  40
+  Step  31: 31 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  39: 32 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  50: 33 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  71: 34 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 138   Index: 134
+  Step  34: 35 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 138   Index: 177
+  Step  21: 36 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 138   Index: 200
+Mt.Ordeals-3rd station                                                        Seed: 138   Index: 200
+Mt.Ordeals-7th station                                                        Seed: 138   Index: 205
+  Step  33: 37 / Lilith x1, Red Bone x2 (8.912s)
+  Step  35: 38 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 138   Index: 247
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 155   Index:   9
+Mt.Ordeals Summit                                                             Seed: 155   Index:   9
+Paladin                                                                       Seed: 155   Index:  13
+Mt.Ordeals Summit                                                             Seed: 155   Index:  13
+  Optional Steps: 1
+  Step  12: 39 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed: 155   Index:  36
+  Step   8: 40 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 155   Index:  78
+  Step   5: 41 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  27: 42 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 155   Index: 108
+  Extra Steps: 2
+  Step  46: 43 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 155   Index: 154
+Take Chocobo to Mysidia                                                       Seed: 155   Index: 167
+Overworld (Mysidia)                                                           Seed: 155   Index: 167
+Town of Baron Serpent Road                                                    Seed: 155   Index: 167
+Credit Warp Fight Search                                                      Seed: 155   Index: 171
+  Overworld (Baron)                                                           Seed: 155   Index: 171
+    Extra Steps: 14
+    Step   2: 44 / FloatEye x2 (7.230s)
+    Step  14: 45 / Imp x3, SwordRat x1 (7.227s)
+   (Step  40: 46 / Imp x3, SwordRat x1)
+   (Step  89: 47 / Imp x3)
+   (Step 127: 48 / FloatEye x1, Eagle x2)
+   (Step 180: 49 / FloatEye x2)
+   (Step 207: 50 / Imp x3)
+   (Step 256: 51 / FloatEye x2)
+
+Encounter Time:      348.331s
+Other Time:          496.349s
+Total Time:          844.680s
+
+Base Total Time:     857.869s
+Time Saved:          13.189s
+
+Optional Steps:      13
+Extra Steps:         44
+Encounters:          45
+
+Base Encounters:     46
+Encounters Saved:    1
+
+Number of Variables: 54

--- a/data/routes/cw/071.txt
+++ b/data/routes/cw/071.txt
@@ -1,0 +1,156 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	71
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50286708
+VARS	FFFFFFFF:14 C307800:1 E302500:1 E302600:15 E305400:16 E307B00:2 E308401:4
+
+Overworld (Kaipo)                                                             Seed:  71   Index:   0
+Overworld (Kaipo)                                                             Seed:  71   Index:   1
+Kaipo                                                                         Seed:  71   Index:  37
+Overworld (Kaipo)                                                             Seed:  71   Index:  37
+  Step   6: 1 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  71   Index:  69
+  Step   3: 2 / Pike x3 (6.935s)
+  Step   8: 3 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed:  71   Index: 101
+Watery Pass-South B1F                                                         Seed:  71   Index: 101
+  Step  18: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  71   Index: 121
+  Step  32: 5 / Pike x3 (7.152s)
+  Step  57: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  71   Index: 211
+  Extra Steps: 16
+Watery Pass-South B2F                                                         Seed:  71   Index: 231
+  Step  33: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  88   Index:  14
+  Step  18: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed:  88   Index:  48
+Watery Pass-North B1F                                                         Seed:  88   Index:  69
+  Step   7: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  16: 10 / Aligator x1, Pike x2 (7.368s)
+  Step  48: 11 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:  88   Index: 129
+Waterfalls B1F                                                                Seed:  88   Index: 138
+Waterfalls B2F                                                                Seed:  88   Index: 139
+  Step  18: 12 / Mad Toad x4 (7.317s)
+Waterfalls Lake                                                               Seed:  88   Index: 184
+  Step  29: 13 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed:  88   Index: 221
+Waterfalls Lake                                                               Seed:  88   Index: 221
+Overworld (Kaipo)                                                             Seed:  88   Index: 222
+Overworld (Damcyan)                                                           Seed:  88   Index: 233
+Damcyan                                                                       Seed:  88   Index: 237
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  88   Index: 245
+Antlion B1F                                                                   Seed:  88   Index: 245
+  Step  23: 14 / Cream x4 (7.552s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 105   Index:  27
+  Antlion B2F                                                                 Seed: 105   Index:  27
+    Step  24: 15 / Cream x4 (7.552s)
+  Antlion B2F Treasure Room                                                   Seed: 105   Index:  60
+    Extra Steps: 2
+  Antlion B2F                                                                 Seed: 105   Index:  62
+Antlion's Nest                                                                Seed: 105   Index: 114
+  Step   1: 16 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed: 105   Index: 128
+Antlion's Nest                                                                Seed: 105   Index: 128
+  Step   8: 17 / SandWorm x2 (6.858s)
+Antlion B2F Outward Direct                                                    Seed: 105   Index: 143
+  Antlion B2F                                                                 Seed: 105   Index: 143
+    Step   4: 18 / Cream x4 (7.523s)
+    Step  74: 19 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 105   Index: 223
+  Step  12: 20 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 122   Index:   5
+Overworld (Kaipo)                                                             Seed: 122   Index:   5
+Kaipo Revisited                                                               Seed: 122   Index:   5
+Overworld (Kaipo)                                                             Seed: 122   Index:   5
+Overworld (Damcyan)                                                           Seed: 122   Index:   5
+Mt.Hobs-West                                                                  Seed: 122   Index:   5
+  Step  18: 21 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 122   Index:  44
+  Step  15: 22 / Spirit x2, Skelton x2 (9.087s)
+Battle: MomBomb                                                               Seed: 122   Index:  59
+Mt.Hobs Summit                                                                Seed: 122   Index:  59
+Mt.Hobs-East                                                                  Seed: 122   Index:  65
+  Step  21: 23 / Red Bone x1, Skelton x3 (8.007s)
+  Step  23: 24 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 122   Index: 111
+  Step  44: 25 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  58: 26 / SwordRat x3, Needler x3 (7.663s)
+  Step  66: 27 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 122   Index: 195
+  Optional Steps: 9
+  Extra Steps: 6
+Overworld (Fabul)                                                             Seed: 139   Index:  14
+Fabul Boat and Leviatan                                                       Seed: 139   Index:  21
+Overworld (Mysidia)                                                           Seed: 139   Index:  21
+Mysidia                                                                       Seed: 139   Index:  30
+Overworld (Mysidia)                                                           Seed: 139   Index:  30
+Overworld (Mt.Ordeals)                                                        Seed: 139   Index:  40
+  Step  31: 28 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  39: 29 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  50: 30 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  71: 31 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 139   Index: 134
+  Step  18: 32 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  34: 33 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 139   Index: 177
+  Step  21: 34 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed: 139   Index: 200
+Mt.Ordeals-3rd station                                                        Seed: 139   Index: 200
+Mt.Ordeals-7th station                                                        Seed: 139   Index: 205
+  Step  33: 35 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  35: 36 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 139   Index: 247
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 156   Index:   8
+Mt.Ordeals Summit                                                             Seed: 156   Index:   8
+Paladin                                                                       Seed: 156   Index:  12
+Mt.Ordeals Summit                                                             Seed: 156   Index:  12
+  Optional Steps: 0
+  Step  13: 37 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed: 156   Index:  34
+Mt.Ordeals-3rd station                                                        Seed: 156   Index:  76
+  Step   7: 38 / Ghoul x2, Soul x2 (8.971s)
+  Step  29: 39 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed: 156   Index: 106
+  Extra Steps: 4
+  Step   2: 40 / Red Bone x1, Skelton x3 (7.844s)
+  Step  48: 41 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 156   Index: 154
+Take Chocobo to Mysidia                                                       Seed: 156   Index: 167
+Overworld (Mysidia)                                                           Seed: 156   Index: 167
+Town of Baron Serpent Road                                                    Seed: 156   Index: 167
+Credit Warp Fight Search                                                      Seed: 156   Index: 171
+  Overworld (Baron)                                                           Seed: 156   Index: 171
+    Extra Steps: 14
+    Step   2: 42 / Imp x4 (7.223s)
+    Step  14: 43 / Imp x4 (7.223s)
+   (Step  40: 44 / FloatEye x2)
+   (Step  89: 45 / Imp x3, SwordRat x1)
+   (Step 127: 46 / Imp x6)
+   (Step 180: 47 / Imp x3)
+   (Step 207: 48 / FloatEye x1, Eagle x2)
+   (Step 250: 49 / FloatEye x2)
+
+Encounter Time:      336.325s
+Other Time:          500.409s
+Total Time:          836.734s
+
+Base Total Time:     851.935s
+Time Saved:          15.201s
+
+Optional Steps:      10
+Extra Steps:         42
+Encounters:          43
+
+Base Encounters:     45
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/072.txt
+++ b/data/routes/cw/072.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	72
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48876890
+VARS	FFFFFFFF:14 C307800:1 E302600:10 E305400:74 E307000:14 E307400:2 E307B00:14
+
+Overworld (Kaipo)                                                             Seed:  72   Index:   0
+Overworld (Kaipo)                                                             Seed:  72   Index:   1
+Kaipo                                                                         Seed:  72   Index:  37
+Overworld (Kaipo)                                                             Seed:  72   Index:  37
+  Step   6: 1 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  72   Index:  69
+  Step   3: 2 / Pike x3 (6.935s)
+  Step   8: 3 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed:  72   Index: 101
+Watery Pass-South B1F                                                         Seed:  72   Index: 101
+  Step  18: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  72   Index: 121
+  Step  32: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  72   Index: 211
+  Extra Steps: 74
+Watery Pass-South B2F                                                         Seed:  89   Index:  33
+  Extra Steps: 14
+  Step  43: 6 / Pike x3 (7.152s)
+  Step  52: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  89   Index:  86
+  Step  31: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed:  89   Index: 120
+Watery Pass-North B1F                                                         Seed:  89   Index: 141
+Overworld (Kaipo)                                                             Seed:  89   Index: 201
+Waterfalls B1F                                                                Seed:  89   Index: 210
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed:  89   Index: 213
+  Step  32: 9 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 106   Index:   2
+  Step  10: 10 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 106   Index:  39
+Waterfalls Lake                                                               Seed: 106   Index:  39
+Overworld (Kaipo)                                                             Seed: 106   Index:  40
+Overworld (Damcyan)                                                           Seed: 106   Index:  51
+Damcyan                                                                       Seed: 106   Index:  55
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 106   Index:  62
+Antlion B1F                                                                   Seed: 106   Index:  62
+Antlion B2F Inward Charm Room Steps                                           Seed: 106   Index: 100
+  Antlion B2F                                                                 Seed: 106   Index: 100
+    Step  15: 11 / Basilisk x1, Imp x3 (6.775s)
+    Step  16: 12 / SandWorm x2 (6.841s)
+  Antlion B2F Treasure Room                                                   Seed: 106   Index: 133
+    Extra Steps: 14
+  Antlion B2F                                                                 Seed: 106   Index: 147
+Antlion's Nest                                                                Seed: 106   Index: 199
+Battle: Antlion                                                               Seed: 106   Index: 213
+Antlion's Nest                                                                Seed: 106   Index: 213
+  Step   4: 13 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed: 106   Index: 228
+  Antlion B2F                                                                 Seed: 106   Index: 228
+    Step   7: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  51: 15 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed: 123   Index:  52
+  Step   7: 16 / Turtle x1, Imp x2 (7.009s)
+  Step  28: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Step  34: 18 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 123   Index:  90
+Overworld (Kaipo)                                                             Seed: 123   Index:  90
+Kaipo Revisited                                                               Seed: 123   Index:  90
+Overworld (Kaipo)                                                             Seed: 123   Index:  90
+Overworld (Damcyan)                                                           Seed: 123   Index:  90
+Mt.Hobs-West                                                                  Seed: 123   Index:  90
+Mt.Hobs Summit                                                                Seed: 123   Index: 129
+Battle: MomBomb                                                               Seed: 123   Index: 144
+Mt.Hobs Summit                                                                Seed: 123   Index: 144
+Mt.Hobs-East                                                                  Seed: 123   Index: 150
+  Step   5: 19 / Turtle x2 (7.432s)
+  Step  19: 20 / Turtle x2 (7.432s)
+  Step  27: 21 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 123   Index: 196
+  Step  13: 22 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  74: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 140   Index:  24
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 140   Index:  94
+Fabul Boat and Leviatan                                                       Seed: 140   Index: 101
+Overworld (Mysidia)                                                           Seed: 140   Index: 101
+  Step   9: 24 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 140   Index: 110
+Overworld (Mysidia)                                                           Seed: 140   Index: 110
+Overworld (Mt.Ordeals)                                                        Seed: 140   Index: 120
+  Step  32: 25 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  48: 26 / Raven x1, Cocktric x3 (9.100s)
+  Step  78: 27 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 140   Index: 214
+  Step  24: 28 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  26: 29 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 157   Index:   1
+Recruit Tellah                                                                Seed: 157   Index:  24
+Mt.Ordeals-3rd station                                                        Seed: 157   Index:  24
+  Step   1: 30 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 157   Index:  29
+Mt.Ordeals Summit                                                             Seed: 157   Index:  71
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 157   Index:  88
+Mt.Ordeals Summit                                                             Seed: 157   Index:  88
+Paladin                                                                       Seed: 157   Index:  92
+Mt.Ordeals Summit                                                             Seed: 157   Index:  92
+  Optional Steps: 0
+  Step  13: 31 / Revenant x1, Ghoul x3 (8.489s)
+  Step  16: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 157   Index: 114
+  Step  40: 33 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 157   Index: 156
+  Step  17: 34 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+  Step  29: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed: 157   Index: 186
+  Step  25: 36 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 157   Index: 230
+Take Chocobo to Mysidia                                                       Seed: 157   Index: 243
+Overworld (Mysidia)                                                           Seed: 157   Index: 243
+Town of Baron Serpent Road                                                    Seed: 157   Index: 243
+Credit Warp Fight Search                                                      Seed: 157   Index: 247
+  Overworld (Baron)                                                           Seed: 157   Index: 247
+    Extra Steps: 14
+    Step   1: 37 / Eagle x3 (7.417s)
+    Step  13: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  51: 39 / Eagle x3)
+   (Step 131: 40 / FloatEye x2)
+   (Step 174: 41 / Imp x4)
+   (Step 179: 42 / Imp x4)
+   (Step 185: 43 / Imp x4)
+   (Step 228: 44 / FloatEye x2)
+
+Encounter Time:      292.633s
+Other Time:          520.643s
+Total Time:          813.275s
+
+Base Total Time:     847.171s
+Time Saved:          33.895s
+
+Optional Steps:      10
+Extra Steps:         118
+Encounters:          38
+
+Base Encounters:     43
+Encounters Saved:    5
+
+Number of Variables: 54

--- a/data/routes/cw/073.txt
+++ b/data/routes/cw/073.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	73
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48894433
+VARS	FFFFFFFF:14 C307800:1 E302600:6 E305400:74 E307000:4 E307400:12 E307B00:14 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed:  73   Index:   0
+Overworld (Kaipo)                                                             Seed:  73   Index:   1
+Kaipo                                                                         Seed:  73   Index:  37
+Overworld (Kaipo)                                                             Seed:  73   Index:  37
+  Step   6: 1 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  73   Index:  69
+  Step   3: 2 / Pike x3 (6.935s)
+  Step   8: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  73   Index: 101
+Watery Pass-South B1F                                                         Seed:  73   Index: 101
+  Step  18: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  73   Index: 121
+  Step   6: 5 / Pike x3 (7.152s)
+  Step  32: 6 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed:  73   Index: 211
+  Extra Steps: 74
+Watery Pass-South B2F                                                         Seed:  90   Index:  33
+  Extra Steps: 4
+  Step  43: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  90   Index:  76
+Watery Pass-North B2F                                                         Seed:  90   Index: 110
+  Step   7: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed:  90   Index: 131
+Overworld (Kaipo)                                                             Seed:  90   Index: 191
+Waterfalls B1F                                                                Seed:  90   Index: 200
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed:  90   Index: 213
+  Step  32: 9 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 107   Index:   2
+  Step  10: 10 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 107   Index:  39
+Waterfalls Lake                                                               Seed: 107   Index:  39
+Overworld (Kaipo)                                                             Seed: 107   Index:  40
+Overworld (Damcyan)                                                           Seed: 107   Index:  51
+Damcyan                                                                       Seed: 107   Index:  55
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 107   Index:  62
+Antlion B1F                                                                   Seed: 107   Index:  62
+  Step  20: 11 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 107   Index: 100
+  Antlion B2F                                                                 Seed: 107   Index: 100
+    Step  15: 12 / SandWorm x2 (6.841s)
+    Step  16: 13 / Basilisk x1, Imp x3 (6.775s)
+  Antlion B2F Treasure Room                                                   Seed: 107   Index: 133
+    Extra Steps: 14
+  Antlion B2F                                                                 Seed: 107   Index: 147
+Antlion's Nest                                                                Seed: 107   Index: 199
+Battle: Antlion                                                               Seed: 107   Index: 213
+Antlion's Nest                                                                Seed: 107   Index: 213
+Antlion B2F Outward Direct                                                    Seed: 107   Index: 228
+  Antlion B2F                                                                 Seed: 107   Index: 228
+    Step   7: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  51: 15 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed: 124   Index:  52
+  Step  28: 16 / Turtle x1, Imp x2 (7.009s)
+  Step  34: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed: 124   Index:  90
+Overworld (Kaipo)                                                             Seed: 124   Index:  90
+Kaipo Revisited                                                               Seed: 124   Index:  90
+Overworld (Kaipo)                                                             Seed: 124   Index:  90
+Overworld (Damcyan)                                                           Seed: 124   Index:  90
+Mt.Hobs-West                                                                  Seed: 124   Index:  90
+  Step  22: 18 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 124   Index: 129
+Battle: MomBomb                                                               Seed: 124   Index: 144
+Mt.Hobs Summit                                                                Seed: 124   Index: 144
+Mt.Hobs-East                                                                  Seed: 124   Index: 150
+  Step   5: 19 / Turtle x2 (7.432s)
+  Step  19: 20 / Turtle x2 (7.432s)
+  Step  27: 21 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 124   Index: 196
+  Step  13: 22 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  74: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 141   Index:  24
+  Optional Steps: 6
+Overworld (Fabul)                                                             Seed: 141   Index:  90
+Fabul Boat and Leviatan                                                       Seed: 141   Index:  97
+Overworld (Mysidia)                                                           Seed: 141   Index:  97
+Mysidia                                                                       Seed: 141   Index: 106
+Overworld (Mysidia)                                                           Seed: 141   Index: 106
+  Step   4: 24 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 141   Index: 116
+  Step  26: 25 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  36: 26 / Raven x1, Cocktric x3 (9.100s)
+  Step  52: 27 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  82: 28 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 141   Index: 210
+  Step  30: 29 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 141   Index: 253
+Recruit Tellah                                                                Seed: 158   Index:  20
+Mt.Ordeals-3rd station                                                        Seed: 158   Index:  20
+  Step   5: 30 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 158   Index:  25
+Mt.Ordeals Summit                                                             Seed: 158   Index:  67
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 158   Index:  84
+Mt.Ordeals Summit                                                             Seed: 158   Index:  84
+Paladin                                                                       Seed: 158   Index:  88
+Mt.Ordeals Summit                                                             Seed: 158   Index:  88
+  Optional Steps: 1
+  Step  17: 31 / Revenant x1, Ghoul x3 (8.489s)
+  Step  20: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 158   Index: 111
+  Step  27: 33 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 158   Index: 153
+  Step   1: 34 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 158   Index: 183
+  Step   2: 35 / Spirit x3, Soul x1 (8.429s)
+  Step  28: 36 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 158   Index: 227
+Take Chocobo to Mysidia                                                       Seed: 158   Index: 240
+Overworld (Mysidia)                                                           Seed: 158   Index: 240
+Town of Baron Serpent Road                                                    Seed: 158   Index: 240
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 158   Index: 246
+  Overworld (Baron)                                                           Seed: 158   Index: 246
+    Extra Steps: 14
+    Step   2: 37 / Eagle x3 (7.417s)
+    Step  14: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  52: 39 / Eagle x3)
+   (Step 132: 40 / FloatEye x2)
+   (Step 175: 41 / Imp x4)
+   (Step 180: 42 / Imp x4)
+   (Step 212: 43 / Imp x4)
+   (Step 229: 44 / FloatEye x2)
+
+Encounter Time:      292.392s
+Other Time:          521.175s
+Total Time:          813.567s
+
+Base Total Time:     860.068s
+Time Saved:          46.501s
+
+Optional Steps:      7
+Extra Steps:         120
+Encounters:          38
+
+Base Encounters:     45
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/074.txt
+++ b/data/routes/cw/074.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	74
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49159196
+VARS	FFFFFFFF:18 E302500:2 E302600:6
+
+Overworld (Kaipo)                                                             Seed:  74   Index:   0
+  Step   1: 1 / Imp x4 (6.962s)
+Overworld (Kaipo)                                                             Seed:  74   Index:   1
+Kaipo                                                                         Seed:  74   Index:  37
+Overworld (Kaipo)                                                             Seed:  74   Index:  37
+Watery Pass-South B1F                                                         Seed:  74   Index:  69
+  Step   3: 2 / Pike x3 (6.935s)
+  Step   8: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  74   Index: 101
+Watery Pass-South B1F                                                         Seed:  74   Index: 101
+  Step  18: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  74   Index: 121
+  Step   6: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  74   Index: 211
+Watery Pass-South B2F                                                         Seed:  74   Index: 215
+  Step  16: 6 / Zombie x4 (7.148s)
+  Step  32: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  74   Index: 254
+  Step  22: 8 / Pike x2, EvilShel x2 (7.149s)
+  Step  34: 9 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  91   Index:  32
+Watery Pass-North B1F                                                         Seed:  91   Index:  53
+  Step  23: 10 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  91   Index: 113
+  Step   4: 11 / Sand Man x4 (7.310s)
+Waterfalls B1F                                                                Seed:  91   Index: 122
+Waterfalls B2F                                                                Seed:  91   Index: 123
+Waterfalls Lake                                                               Seed:  91   Index: 168
+  Step  37: 12 / Mad Toad x4 (7.317s)
+Battle: Octomamm                                                              Seed:  91   Index: 205
+Waterfalls Lake                                                               Seed:  91   Index: 205
+Overworld (Kaipo)                                                             Seed:  91   Index: 206
+  Step   7: 13 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed:  91   Index: 217
+Damcyan                                                                       Seed:  91   Index: 221
+  Optional Steps: 0
+  Extra Steps: 2
+Overworld (Damcyan)                                                           Seed:  91   Index: 230
+Antlion B1F                                                                   Seed:  91   Index: 230
+  Step  15: 14 / Cream x4 (7.552s)
+  Step  38: 15 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 108   Index:  12
+  Antlion B2F                                                                 Seed: 108   Index:  12
+    Step  50: 16 / Turtle x2 (7.487s)
+    Step  70: 17 / SandWorm x2 (6.841s)
+Antlion's Nest                                                                Seed: 108   Index:  92
+Battle: Antlion                                                               Seed: 108   Index: 106
+Antlion's Nest                                                                Seed: 108   Index: 106
+  Step   8: 18 / Cream x4 (7.523s)
+  Step  10: 19 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed: 108   Index: 121
+  Antlion B2F                                                                 Seed: 108   Index: 121
+    Step  15: 20 / Weeper x2 (7.132s)
+    Step  26: 21 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 108   Index: 201
+  Step  34: 22 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 108   Index: 239
+Overworld (Kaipo)                                                             Seed: 108   Index: 239
+Kaipo Revisited                                                               Seed: 108   Index: 239
+Overworld (Kaipo)                                                             Seed: 108   Index: 239
+Overworld (Damcyan)                                                           Seed: 108   Index: 239
+Mt.Hobs-West                                                                  Seed: 108   Index: 239
+Mt.Hobs Summit                                                                Seed: 125   Index:  22
+  Step   1: 23 / Cocktric x3 (9.055s)
+Battle: MomBomb                                                               Seed: 125   Index:  37
+Mt.Hobs Summit                                                                Seed: 125   Index:  37
+Mt.Hobs-East                                                                  Seed: 125   Index:  43
+  Step  37: 24 / Spirit x2, Skelton x2 (8.237s)
+  Step  43: 25 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 125   Index:  89
+  Step  23: 26 / SwordRat x3, Needler x3 (7.663s)
+  Step  66: 27 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  71: 28 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  80: 29 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 125   Index: 173
+  Optional Steps: 6
+Overworld (Fabul)                                                             Seed: 125   Index: 239
+Fabul Boat and Leviatan                                                       Seed: 125   Index: 246
+Overworld (Mysidia)                                                           Seed: 125   Index: 246
+Mysidia                                                                       Seed: 125   Index: 255
+Overworld (Mysidia)                                                           Seed: 125   Index: 255
+Overworld (Mt.Ordeals)                                                        Seed: 142   Index:   9
+  Step   5: 30 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  62: 31 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 142   Index: 103
+  Step   7: 32 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  39: 33 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 142   Index: 146
+  Step   6: 34 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed: 142   Index: 169
+Mt.Ordeals-3rd station                                                        Seed: 142   Index: 169
+  Step   5: 35 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 142   Index: 174
+  Step  24: 36 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 142   Index: 216
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 142   Index: 233
+Mt.Ordeals Summit                                                             Seed: 142   Index: 233
+Paladin                                                                       Seed: 142   Index: 237
+Mt.Ordeals Summit                                                             Seed: 142   Index: 237
+  Optional Steps: 0
+  Step   3: 37 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed: 159   Index:   3
+  Step  22: 38 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed: 159   Index:  45
+  Step  30: 39 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed: 159   Index:  75
+  Step  33: 40 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 159   Index: 119
+Take Chocobo to Mysidia                                                       Seed: 159   Index: 132
+Overworld (Mysidia)                                                           Seed: 159   Index: 132
+Town of Baron Serpent Road                                                    Seed: 159   Index: 132
+Credit Warp Fight Search                                                      Seed: 159   Index: 136
+  Overworld (Baron)                                                           Seed: 159   Index: 136
+    Extra Steps: 18
+    Step   2: 41 / Imp x4 (7.223s)
+    Step  18: 42 / Imp x4 (7.223s)
+   (Step  49: 43 / Imp x4)
+   (Step  75: 44 / FloatEye x2)
+   (Step 112: 45 / Imp x3)
+   (Step 124: 46 / Imp x3)
+   (Step 162: 47 / Imp x3)
+   (Step 242: 48 / FloatEye x1, Eagle x2)
+
+Encounter Time:      326.948s
+Other Time:          491.025s
+Total Time:          817.973s
+
+Base Total Time:     829.250s
+Time Saved:          11.277s
+
+Optional Steps:      6
+Extra Steps:         20
+Encounters:          42
+
+Base Encounters:     43
+Encounters Saved:    1
+
+Number of Variables: 54

--- a/data/routes/cw/075.txt
+++ b/data/routes/cw/075.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	75
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49028594
+VARS	FFFFFFFF:18 E302500:2 E302600:6
+
+Overworld (Kaipo)                                                             Seed:  75   Index:   0
+  Step   1: 1 / Imp x4 (6.962s)
+Overworld (Kaipo)                                                             Seed:  75   Index:   1
+Kaipo                                                                         Seed:  75   Index:  37
+Overworld (Kaipo)                                                             Seed:  75   Index:  37
+  Step  11: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  75   Index:  69
+  Step   3: 3 / Pike x2, EvilShel x2 (6.952s)
+  Step   8: 4 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:  75   Index: 101
+Watery Pass-South B1F                                                         Seed:  75   Index: 101
+Watery Pass-South B2F                                                         Seed:  75   Index: 121
+  Step   6: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  75   Index: 211
+Watery Pass-South B2F                                                         Seed:  75   Index: 215
+  Step  16: 6 / Zombie x4 (7.148s)
+  Step  32: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  75   Index: 254
+  Step  22: 8 / Pike x2, EvilShel x2 (7.149s)
+  Step  34: 9 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  92   Index:  32
+  Step  18: 10 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed:  92   Index:  53
+  Step  23: 11 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:  92   Index: 113
+Waterfalls B1F                                                                Seed:  92   Index: 122
+Waterfalls B2F                                                                Seed:  92   Index: 123
+Waterfalls Lake                                                               Seed:  92   Index: 168
+  Step  37: 12 / Mad Toad x4 (7.317s)
+Battle: Octomamm                                                              Seed:  92   Index: 205
+Waterfalls Lake                                                               Seed:  92   Index: 205
+Overworld (Kaipo)                                                             Seed:  92   Index: 206
+  Step   7: 13 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed:  92   Index: 217
+Damcyan                                                                       Seed:  92   Index: 221
+  Optional Steps: 0
+  Extra Steps: 2
+Overworld (Damcyan)                                                           Seed:  92   Index: 230
+Antlion B1F                                                                   Seed:  92   Index: 230
+  Step  15: 14 / Cream x4 (7.552s)
+  Step  38: 15 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 109   Index:  12
+  Antlion B2F                                                                 Seed: 109   Index:  12
+    Step  21: 16 / Turtle x2 (7.487s)
+    Step  50: 17 / SandWorm x2 (6.841s)
+    Step  70: 18 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 109   Index:  92
+Battle: Antlion                                                               Seed: 109   Index: 106
+Antlion's Nest                                                                Seed: 109   Index: 106
+  Step   8: 19 / Weeper x2 (7.132s)
+  Step  10: 20 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed: 109   Index: 121
+  Antlion B2F                                                                 Seed: 109   Index: 121
+    Step  15: 21 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 109   Index: 201
+  Step  34: 22 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 109   Index: 239
+Overworld (Kaipo)                                                             Seed: 109   Index: 239
+Kaipo Revisited                                                               Seed: 109   Index: 239
+Overworld (Kaipo)                                                             Seed: 109   Index: 239
+Overworld (Damcyan)                                                           Seed: 109   Index: 239
+Mt.Hobs-West                                                                  Seed: 109   Index: 239
+Mt.Hobs Summit                                                                Seed: 126   Index:  22
+  Step   1: 23 / Cocktric x3 (9.055s)
+Battle: MomBomb                                                               Seed: 126   Index:  37
+Mt.Hobs Summit                                                                Seed: 126   Index:  37
+Mt.Hobs-East                                                                  Seed: 126   Index:  43
+  Step  37: 24 / Spirit x2, Skelton x2 (8.237s)
+  Step  43: 25 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 126   Index:  89
+  Step  23: 26 / SwordRat x3, Needler x3 (7.663s)
+  Step  66: 27 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  71: 28 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  80: 29 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 126   Index: 173
+  Optional Steps: 6
+Overworld (Fabul)                                                             Seed: 126   Index: 239
+Fabul Boat and Leviatan                                                       Seed: 126   Index: 246
+Overworld (Mysidia)                                                           Seed: 126   Index: 246
+Mysidia                                                                       Seed: 126   Index: 255
+Overworld (Mysidia)                                                           Seed: 126   Index: 255
+Overworld (Mt.Ordeals)                                                        Seed: 143   Index:   9
+  Step   5: 30 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  62: 31 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 143   Index: 103
+  Step   4: 32 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step   7: 33 / Red Bone x1, Skelton x3 (8.067s)
+  Step  39: 34 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 143   Index: 146
+  Step   6: 35 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed: 143   Index: 169
+Mt.Ordeals-3rd station                                                        Seed: 143   Index: 169
+  Step   5: 36 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 143   Index: 174
+Mt.Ordeals Summit                                                             Seed: 143   Index: 216
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 143   Index: 233
+Mt.Ordeals Summit                                                             Seed: 143   Index: 233
+Paladin                                                                       Seed: 143   Index: 237
+Mt.Ordeals Summit                                                             Seed: 143   Index: 237
+  Optional Steps: 0
+  Step   3: 37 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed: 160   Index:   3
+  Step  13: 38 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed: 160   Index:  45
+  Step  30: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 160   Index:  75
+  Step  33: 40 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 160   Index: 119
+Take Chocobo to Mysidia                                                       Seed: 160   Index: 132
+Overworld (Mysidia)                                                           Seed: 160   Index: 132
+Town of Baron Serpent Road                                                    Seed: 160   Index: 132
+Credit Warp Fight Search                                                      Seed: 160   Index: 136
+  Overworld (Baron)                                                           Seed: 160   Index: 136
+    Extra Steps: 18
+    Step   2: 41 / Imp x4 (7.223s)
+    Step  18: 42 / Imp x4 (7.223s)
+   (Step  49: 43 / Imp x3, SwordRat x1)
+   (Step 112: 44 / FloatEye x2)
+   (Step 124: 45 / Imp x3)
+   (Step 129: 46 / Imp x3)
+   (Step 242: 47 / Imp x3)
+
+Encounter Time:      324.775s
+Other Time:          491.025s
+Total Time:          815.800s
+
+Base Total Time:     827.727s
+Time Saved:          11.927s
+
+Optional Steps:      6
+Extra Steps:         20
+Encounters:          42
+
+Base Encounters:     43
+Encounters Saved:    1
+
+Number of Variables: 54

--- a/data/routes/cw/076.txt
+++ b/data/routes/cw/076.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	76
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49302919
+VARS	FFFFFFFF:12 E302500:3 E308702:1 E309700:52
+
+Overworld (Kaipo)                                                             Seed:  76   Index:   0
+  Step   1: 1 / Imp x4 (6.962s)
+Overworld (Kaipo)                                                             Seed:  76   Index:   1
+Kaipo                                                                         Seed:  76   Index:  37
+Overworld (Kaipo)                                                             Seed:  76   Index:  37
+  Step  11: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  76   Index:  69
+  Step   3: 3 / Pike x2, EvilShel x2 (6.952s)
+  Step   8: 4 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:  76   Index: 101
+Watery Pass-South B1F                                                         Seed:  76   Index: 101
+  Step  17: 5 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed:  76   Index: 121
+  Step   6: 6 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed:  76   Index: 211
+Watery Pass-South B2F                                                         Seed:  76   Index: 215
+  Step  32: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  76   Index: 254
+  Step  22: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed:  93   Index:  32
+  Step  18: 9 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed:  93   Index:  53
+Overworld (Kaipo)                                                             Seed:  93   Index: 113
+Waterfalls B1F                                                                Seed:  93   Index: 122
+Waterfalls B2F                                                                Seed:  93   Index: 123
+  Step  25: 10 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed:  93   Index: 168
+  Step  37: 11 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed:  93   Index: 205
+Waterfalls Lake                                                               Seed:  93   Index: 205
+Overworld (Kaipo)                                                             Seed:  93   Index: 206
+  Step   7: 12 / SandWorm x1 (7.264s)
+Overworld (Damcyan)                                                           Seed:  93   Index: 217
+Damcyan                                                                       Seed:  93   Index: 221
+  Optional Steps: 1
+  Extra Steps: 2
+Overworld (Damcyan)                                                           Seed:  93   Index: 231
+Antlion B1F                                                                   Seed:  93   Index: 231
+  Step  14: 13 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  37: 14 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed: 110   Index:  13
+  Antlion B2F                                                                 Seed: 110   Index:  13
+    Step  20: 15 / Cream x4 (7.552s)
+    Step  49: 16 / Turtle x2 (7.487s)
+    Step  69: 17 / SandWorm x2 (6.841s)
+Antlion's Nest                                                                Seed: 110   Index:  93
+Battle: Antlion                                                               Seed: 110   Index: 107
+Antlion's Nest                                                                Seed: 110   Index: 107
+  Step   7: 18 / Cream x4 (7.523s)
+  Step   9: 19 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed: 110   Index: 122
+  Antlion B2F                                                                 Seed: 110   Index: 122
+    Step  14: 20 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 110   Index: 202
+  Step  16: 21 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 110   Index: 240
+Overworld (Kaipo)                                                             Seed: 110   Index: 240
+Kaipo Revisited                                                               Seed: 110   Index: 240
+Overworld (Kaipo)                                                             Seed: 110   Index: 240
+Overworld (Damcyan)                                                           Seed: 110   Index: 240
+Mt.Hobs-West                                                                  Seed: 110   Index: 240
+  Step  39: 22 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 127   Index:  23
+Battle: MomBomb                                                               Seed: 127   Index:  38
+Mt.Hobs Summit                                                                Seed: 127   Index:  38
+Mt.Hobs-East                                                                  Seed: 127   Index:  44
+  Step  36: 23 / Red Bone x1, Skelton x3 (8.007s)
+  Step  42: 24 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 127   Index:  90
+  Step  22: 25 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  65: 26 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  70: 27 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 127   Index: 174
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 127   Index: 234
+Fabul Boat and Leviatan                                                       Seed: 127   Index: 241
+Overworld (Mysidia)                                                           Seed: 127   Index: 241
+Mysidia                                                                       Seed: 127   Index: 250
+Overworld (Mysidia)                                                           Seed: 127   Index: 250
+Overworld (Mt.Ordeals)                                                        Seed: 144   Index:   4
+  Step  10: 28 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  67: 29 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 144   Index:  98
+  Step   9: 30 / Spirit x3, Soul x1 (8.687s)
+  Step  12: 31 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed: 144   Index: 141
+  Step   1: 32 / Zombie x2, Ghoul x2 (7.661s)
+  Step  11: 33 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed: 144   Index: 164
+Mt.Ordeals-3rd station                                                        Seed: 144   Index: 164
+Mt.Ordeals-7th station                                                        Seed: 144   Index: 169
+  Step   5: 34 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 144   Index: 211
+  Optional Steps: 0
+  Step   5: 35 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed: 144   Index: 228
+Mt.Ordeals Summit                                                             Seed: 144   Index: 228
+Paladin                                                                       Seed: 144   Index: 232
+Mt.Ordeals Summit                                                             Seed: 144   Index: 232
+  Optional Steps: 1
+  Step   8: 36 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed: 144   Index: 255
+  Step  17: 37 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 161   Index:  41
+Mt.Ordeals                                                                    Seed: 161   Index:  71
+  Step   4: 38 / Spirit x3, Soul x1 (8.429s)
+  Step  37: 39 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 161   Index: 115
+Take Chocobo to Mysidia                                                       Seed: 161   Index: 128
+Overworld (Mysidia)                                                           Seed: 161   Index: 128
+Town of Baron Serpent Road                                                    Seed: 161   Index: 128
+  Extra Steps: 52
+Credit Warp Fight Search                                                      Seed: 161   Index: 184
+  Overworld (Baron)                                                           Seed: 161   Index: 184
+    Extra Steps: 12
+    Step   1: 40 / FloatEye x2 (7.230s)
+    Step  12: 41 / Imp x4 (7.223s)
+   (Step  64: 42 / Imp x4)
+   (Step  81: 43 / Imp x3, SwordRat x1)
+   (Step 113: 44 / FloatEye x1, Eagle x2)
+   (Step 194: 45 / Imp x3)
+   (Step 237: 46 / Imp x3)
+   (Step 242: 47 / Imp x3)
+
+Encounter Time:      318.690s
+Other Time:          501.674s
+Total Time:          820.364s
+
+Base Total Time:     842.684s
+Time Saved:          22.320s
+
+Optional Steps:      2
+Extra Steps:         66
+Encounters:          41
+
+Base Encounters:     42
+Encounters Saved:    1
+
+Number of Variables: 54

--- a/data/routes/cw/077.txt
+++ b/data/routes/cw/077.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	77
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49908233
+VARS	FFFFFFFF:6 E000202:14 E000401:16 E302500:57 E302600:86 E307000:22 E307400:86 E308000:4 E308501:2 E308700:1 E308701:4
+
+Overworld (Kaipo)                                                             Seed:  77   Index:   0
+  Step   1: 1 / Imp x4 (6.962s)
+Overworld (Kaipo)                                                             Seed:  77   Index:   1
+Kaipo                                                                         Seed:  77   Index:  37
+Overworld (Kaipo)                                                             Seed:  77   Index:  37
+  Step  11: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  77   Index:  69
+  Step   8: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  77   Index: 101
+Watery Pass-South B1F                                                         Seed:  77   Index: 101
+  Step  17: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  77   Index: 121
+  Step   6: 5 / Zombie x4 (7.148s)
+  Step  74: 6 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed:  77   Index: 211
+Watery Pass-South B2F                                                         Seed:  77   Index: 215
+  Extra Steps: 22
+  Step  32: 7 / Pike x3 (7.152s)
+  Step  61: 8 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  94   Index:  20
+  Step  30: 9 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  94   Index:  54
+Watery Pass-North B1F                                                         Seed:  94   Index:  75
+Overworld (Kaipo)                                                             Seed:  94   Index: 135
+Waterfalls B1F                                                                Seed:  94   Index: 144
+  Extra Steps: 86
+Waterfalls B2F                                                                Seed:  94   Index: 231
+  Step  14: 10 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed: 111   Index:  20
+  Step  13: 11 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 111   Index:  57
+Waterfalls Lake                                                               Seed: 111   Index:  57
+Overworld (Kaipo)                                                             Seed: 111   Index:  58
+  Step   4: 12 / SandWorm x1 (7.264s)
+Overworld (Damcyan)                                                           Seed: 111   Index:  69
+Damcyan                                                                       Seed: 111   Index:  73
+  Optional Steps: 1
+  Extra Steps: 56
+Overworld (Damcyan)                                                           Seed: 111   Index: 137
+Antlion B1F                                                                   Seed: 111   Index: 137
+Antlion B2F Inward Direct                                                     Seed: 111   Index: 175
+  Antlion B2F                                                                 Seed: 111   Index: 175
+    Step  43: 13 / Basilisk x1, Imp x3 (6.775s)
+    Step  51: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 111   Index: 255
+Battle: Antlion                                                               Seed: 128   Index:  13
+Antlion's Nest                                                                Seed: 128   Index:  13
+Antlion B2F Outward Direct                                                    Seed: 128   Index:  28
+  Antlion B2F                                                                 Seed: 128   Index:  28
+    Step  18: 15 / Cream x4 (7.523s)
+    Step  52: 16 / Turtle x2 (7.464s)
+    Step  58: 17 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 128   Index: 108
+  Step   4: 18 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 128   Index: 146
+Overworld (Kaipo)                                                             Seed: 128   Index: 146
+  Extra Steps: 14
+  Step   9: 19 / SandMoth x2, Larva x2 (7.135s)
+  Step  14: 20 / SandMoth x2, Larva x2 (7.135s)
+Kaipo Revisited                                                               Seed: 128   Index: 160
+Overworld (Kaipo)                                                             Seed: 128   Index: 160
+Overworld (Damcyan)                                                           Seed: 128   Index: 160
+Mt.Hobs-West                                                                  Seed: 128   Index: 160
+Mt.Hobs Summit                                                                Seed: 128   Index: 199
+  Step   9: 21 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed: 128   Index: 214
+Mt.Hobs Summit                                                                Seed: 128   Index: 214
+  Step   1: 22 / Spirit x2, Skelton x2 (8.237s)
+Mt.Hobs-East                                                                  Seed: 128   Index: 220
+  Extra Steps: 4
+Overworld (Fabul)                                                             Seed: 145   Index:  14
+  Step  57: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 145   Index:  98
+  Optional Steps: 10
+  Extra Steps: 76
+Overworld (Fabul)                                                             Seed: 145   Index: 244
+  Extra Steps: 16
+  Step  23: 24 / Imp Cap. x3, Needler x1 (7.956s)
+Fabul Boat and Leviatan                                                       Seed: 162   Index:  11
+Overworld (Mysidia)                                                           Seed: 162   Index:  11
+  Step   5: 25 / Imp Cap. x3, Needler x1 (7.821s)
+Mysidia                                                                       Seed: 162   Index:  20
+Overworld (Mysidia)                                                           Seed: 162   Index:  20
+Overworld (Mt.Ordeals)                                                        Seed: 162   Index:  30
+  Step  45: 26 / Raven x1 (8.356s)
+  Step  78: 27 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 162   Index: 124
+  Step  14: 28 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed: 162   Index: 167
+  Step  18: 29 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed: 162   Index: 190
+Mt.Ordeals-3rd station                                                        Seed: 162   Index: 190
+  Extra Steps: 2
+  Step   6: 30 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 162   Index: 197
+Mt.Ordeals Summit                                                             Seed: 162   Index: 239
+  Optional Steps: 1
+  Step   9: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed: 179   Index:   1
+Mt.Ordeals Summit                                                             Seed: 179   Index:   1
+  Extra Steps: 4
+  Step   8: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.808s)
+Paladin                                                                       Seed: 179   Index:   9
+Mt.Ordeals Summit                                                             Seed: 179   Index:   9
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 179   Index:  31
+  Step  10: 33 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 179   Index:  73
+Mt.Ordeals                                                                    Seed: 179   Index: 103
+  Step  19: 34 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 179   Index: 147
+Take Chocobo to Mysidia                                                       Seed: 179   Index: 160
+Overworld (Mysidia)                                                           Seed: 179   Index: 160
+Town of Baron Serpent Road                                                    Seed: 179   Index: 160
+Credit Warp Fight Search                                                      Seed: 179   Index: 164
+  Overworld (Baron)                                                           Seed: 179   Index: 164
+    Extra Steps: 6
+    Step   1: 35 / Eagle x3 (7.417s)
+    Step   6: 36 / Imp x3, SwordRat x1 (7.227s)
+   (Step  23: 37 / Eagle x3)
+   (Step  38: 38 / Imp x3, SwordRat x1)
+   (Step  70: 39 / Imp x4)
+   (Step 111: 40 / FloatEye x2)
+   (Step 195: 41 / Imp x4)
+   (Step 198: 42 / Imp x4)
+   (Step 248: 43 / Imp x3, SwordRat x1)
+
+Encounter Time:      271.790s
+Other Time:          558.647s
+Total Time:          830.436s
+
+Base Total Time:     1084.492s
+Time Saved:          254.055s
+
+Optional Steps:      12
+Extra Steps:         286
+Encounters:          36
+
+Base Encounters:     53
+Encounters Saved:    17
+
+Number of Variables: 54

--- a/data/routes/cw/078.txt
+++ b/data/routes/cw/078.txt
@@ -1,0 +1,156 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	78
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49709269
+VARS	FFFFFFFF:10 E000500:14 E000600:4 E302500:17 E302600:14 E307802:2 E307E00:7 E308700:1 E308702:1 E309700:6
+
+Overworld (Kaipo)                                                             Seed:  78   Index:   0
+  Step   1: 1 / Imp x4 (6.962s)
+Overworld (Kaipo)                                                             Seed:  78   Index:   1
+  Step   9: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  78   Index:  37
+Overworld (Kaipo)                                                             Seed:  78   Index:  37
+  Step  11: 3 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  78   Index:  69
+Recruit Tellah                                                                Seed:  78   Index: 101
+Watery Pass-South B1F                                                         Seed:  78   Index: 101
+  Step  17: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  78   Index: 121
+  Step   6: 5 / Zombie x4 (7.148s)
+  Step  74: 6 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed:  78   Index: 211
+Watery Pass-South B2F                                                         Seed:  78   Index: 215
+  Step  32: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  78   Index: 254
+  Step  22: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed:  95   Index:  32
+  Step   7: 9 / CaveToad x3 (7.014s)
+  Step  18: 10 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed:  95   Index:  53
+Overworld (Kaipo)                                                             Seed:  95   Index: 113
+Waterfalls B1F                                                                Seed:  95   Index: 122
+Waterfalls B2F                                                                Seed:  95   Index: 123
+  Step  25: 11 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:  95   Index: 168
+  Step  13: 12 / Mad Toad x4 (7.317s)
+  Step  37: 13 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed:  95   Index: 205
+Waterfalls Lake                                                               Seed:  95   Index: 205
+Overworld (Kaipo)                                                             Seed:  95   Index: 206
+Overworld (Damcyan)                                                           Seed:  95   Index: 217
+Damcyan                                                                       Seed:  95   Index: 221
+  Optional Steps: 1
+  Extra Steps: 16
+Overworld (Damcyan)                                                           Seed:  95   Index: 245
+Antlion B1F                                                                   Seed:  95   Index: 245
+Antlion B2F Inward Direct                                                     Seed: 112   Index:  27
+  Antlion B2F                                                                 Seed: 112   Index:  27
+    Step   6: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  55: 15 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 112   Index: 107
+  Step   7: 16 / Turtle x2 (7.487s)
+  Step   9: 17 / SandWorm x1, Sandpede x1 (6.829s)
+Battle: Antlion                                                               Seed: 112   Index: 121
+Antlion's Nest                                                                Seed: 112   Index: 121
+  Step  15: 18 / Basilisk x1, Imp x3 (6.783s)
+Antlion B2F Outward Direct                                                    Seed: 112   Index: 136
+  Antlion B2F                                                                 Seed: 112   Index: 136
+    Extra Steps: 2
+    Step  30: 19 / Weeper x2 (7.132s)
+    Step  82: 20 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 112   Index: 218
+  Step   8: 21 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 129   Index:   0
+Overworld (Kaipo)                                                             Seed: 129   Index:   0
+Kaipo Revisited                                                               Seed: 129   Index:   0
+Overworld (Kaipo)                                                             Seed: 129   Index:   0
+Overworld (Damcyan)                                                           Seed: 129   Index:   0
+Mt.Hobs-West                                                                  Seed: 129   Index:   0
+  Extra Steps: 7
+  Step  46: 22 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 129   Index:  46
+Battle: MomBomb                                                               Seed: 129   Index:  61
+Mt.Hobs Summit                                                                Seed: 129   Index:  61
+Mt.Hobs-East                                                                  Seed: 129   Index:  67
+  Step  13: 23 / Red Bone x1, Skelton x3 (8.007s)
+  Step  19: 24 / Spirit x2, Skelton x2 (8.237s)
+  Step  45: 25 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 129   Index: 113
+  Step  42: 26 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  47: 27 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 129   Index: 197
+  Optional Steps: 10
+  Extra Steps: 4
+Overworld (Fabul)                                                             Seed: 146   Index:  15
+Fabul Boat and Leviatan                                                       Seed: 146   Index:  22
+Overworld (Mysidia)                                                           Seed: 146   Index:  22
+  Extra Steps: 14
+  Step  23: 28 / Imp Cap. x3, Needler x1 (7.821s)
+Mysidia                                                                       Seed: 146   Index:  45
+Overworld (Mysidia)                                                           Seed: 146   Index:  45
+Overworld (Mt.Ordeals)                                                        Seed: 146   Index:  55
+  Extra Steps: 4
+  Step  52: 29 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  55: 30 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  87: 31 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  97: 32 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 146   Index: 153
+  Step  21: 33 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 146   Index: 196
+  Step  20: 34 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed: 146   Index: 219
+Mt.Ordeals-3rd station                                                        Seed: 146   Index: 219
+Mt.Ordeals-7th station                                                        Seed: 146   Index: 224
+  Step  19: 35 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 163   Index:  10
+  Optional Steps: 1
+  Step   1: 36 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step   6: 37 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed: 163   Index:  28
+Mt.Ordeals Summit                                                             Seed: 163   Index:  28
+Paladin                                                                       Seed: 163   Index:  32
+Mt.Ordeals Summit                                                             Seed: 163   Index:  32
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 163   Index:  55
+  Step  20: 38 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed: 163   Index:  97
+  Step  11: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 163   Index: 127
+  Step  11: 40 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 163   Index: 171
+Take Chocobo to Mysidia                                                       Seed: 163   Index: 184
+Overworld (Mysidia)                                                           Seed: 163   Index: 184
+Town of Baron Serpent Road                                                    Seed: 163   Index: 184
+  Extra Steps: 6
+Credit Warp Fight Search                                                      Seed: 163   Index: 194
+  Overworld (Baron)                                                           Seed: 163   Index: 194
+    Extra Steps: 10
+    Step   2: 41 / Imp x4 (7.223s)
+    Step  10: 42 / Imp x4 (7.223s)
+   (Step  54: 43 / Imp x3, SwordRat x1)
+   (Step  71: 44 / FloatEye x1, Eagle x2)
+   (Step  83: 45 / Imp x3)
+   (Step 103: 46 / Imp x3)
+   (Step 232: 47 / Imp x3)
+   (Step 249: 48 / FloatEye x1, Eagle x2)
+
+Encounter Time:      326.517s
+Other Time:          500.609s
+Total Time:          827.126s
+
+Base Total Time:     1062.817s
+Time Saved:          235.691s
+
+Optional Steps:      13
+Extra Steps:         63
+Encounters:          42
+
+Base Encounters:     53
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/079.txt
+++ b/data/routes/cw/079.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	79
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49057776
+VARS	FFFFFFFF:8 E000200:12 E000500:18 E302600:10 E305400:14 E308700:1 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed:  79   Index:   0
+  Step   1: 1 / Imp x4 (6.962s)
+Overworld (Kaipo)                                                             Seed:  79   Index:   1
+  Step   9: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  79   Index:  37
+Overworld (Kaipo)                                                             Seed:  79   Index:  37
+  Step  11: 3 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  79   Index:  69
+Recruit Tellah                                                                Seed:  79   Index: 101
+Watery Pass-South B1F                                                         Seed:  79   Index: 101
+  Step  17: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  79   Index: 121
+  Step   6: 5 / Zombie x4 (7.148s)
+  Step  74: 6 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed:  79   Index: 211
+  Extra Steps: 14
+Watery Pass-South B2F                                                         Seed:  79   Index: 229
+Watery Pass-South B3F                                                         Seed:  96   Index:  12
+  Step  27: 7 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed:  96   Index:  46
+  Step   4: 8 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:  96   Index:  67
+  Step  35: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:  96   Index: 127
+  Extra Steps: 12
+  Step  21: 10 / SandWorm x1 (7.231s)
+Waterfalls B1F                                                                Seed:  96   Index: 148
+Waterfalls B2F                                                                Seed:  96   Index: 149
+  Step  32: 11 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:  96   Index: 194
+  Step  11: 12 / TinyMage x4 (7.558s)
+  Step  36: 13 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed:  96   Index: 231
+Waterfalls Lake                                                               Seed:  96   Index: 231
+Overworld (Kaipo)                                                             Seed:  96   Index: 232
+Overworld (Damcyan)                                                           Seed:  96   Index: 243
+Damcyan                                                                       Seed:  96   Index: 247
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  96   Index: 254
+Antlion B1F                                                                   Seed:  96   Index: 254
+  Step  19: 14 / Cream x4 (7.552s)
+  Step  35: 15 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 113   Index:  36
+  Antlion B2F                                                                 Seed: 113   Index:  36
+    Step  46: 16 / Turtle x2 (7.487s)
+    Step  78: 17 / SandWorm x1, Sandpede x1 (6.829s)
+    Step  80: 18 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 113   Index: 116
+Battle: Antlion                                                               Seed: 113   Index: 130
+Antlion's Nest                                                                Seed: 113   Index: 130
+Antlion B2F Outward Direct                                                    Seed: 113   Index: 145
+  Antlion B2F                                                                 Seed: 113   Index: 145
+    Step  21: 19 / Weeper x2 (7.132s)
+    Step  73: 20 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 113   Index: 225
+  Step   1: 21 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 130   Index:   7
+Overworld (Kaipo)                                                             Seed: 130   Index:   7
+Kaipo Revisited                                                               Seed: 130   Index:   7
+Overworld (Kaipo)                                                             Seed: 130   Index:   7
+Overworld (Damcyan)                                                           Seed: 130   Index:   7
+Mt.Hobs-West                                                                  Seed: 130   Index:   7
+  Step  39: 22 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 130   Index:  46
+Battle: MomBomb                                                               Seed: 130   Index:  61
+Mt.Hobs Summit                                                                Seed: 130   Index:  61
+Mt.Hobs-East                                                                  Seed: 130   Index:  67
+  Step  13: 23 / Red Bone x1, Skelton x3 (8.007s)
+  Step  23: 24 / Spirit x2, Skelton x2 (8.237s)
+  Step  45: 25 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 130   Index: 113
+  Step  42: 26 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  47: 27 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 130   Index: 197
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 147   Index:  11
+Fabul Boat and Leviatan                                                       Seed: 147   Index:  18
+Overworld (Mysidia)                                                           Seed: 147   Index:  18
+  Extra Steps: 18
+  Step  27: 28 / Imp Cap. x3, Needler x1 (7.821s)
+Mysidia                                                                       Seed: 147   Index:  45
+Overworld (Mysidia)                                                           Seed: 147   Index:  45
+Overworld (Mt.Ordeals)                                                        Seed: 147   Index:  55
+  Step  52: 29 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  55: 30 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  87: 31 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  94: 32 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 147   Index: 149
+  Step  25: 33 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 147   Index: 192
+Recruit Tellah                                                                Seed: 147   Index: 215
+Mt.Ordeals-3rd station                                                        Seed: 147   Index: 215
+  Step   1: 34 / Spirit x2, Soul x2, Red Bone x2 (9.695s)
+Mt.Ordeals-7th station                                                        Seed: 147   Index: 220
+  Step  23: 35 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 164   Index:   6
+  Optional Steps: 1
+  Step   5: 36 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  10: 37 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed: 164   Index:  24
+Mt.Ordeals Summit                                                             Seed: 164   Index:  24
+Paladin                                                                       Seed: 164   Index:  28
+Mt.Ordeals Summit                                                             Seed: 164   Index:  28
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 164   Index:  51
+  Step  24: 38 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed: 164   Index:  93
+Mt.Ordeals                                                                    Seed: 164   Index: 123
+  Step  15: 39 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 164   Index: 167
+Take Chocobo to Mysidia                                                       Seed: 164   Index: 180
+Overworld (Mysidia)                                                           Seed: 164   Index: 180
+Town of Baron Serpent Road                                                    Seed: 164   Index: 180
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed: 164   Index: 188
+  Overworld (Baron)                                                           Seed: 164   Index: 188
+    Extra Steps: 8
+    Step   1: 40 / FloatEye x2 (7.230s)
+    Step   8: 41 / Imp x4 (7.223s)
+   (Step  16: 42 / Imp x3, SwordRat x1)
+   (Step  77: 43 / Imp x3, SwordRat x1)
+   (Step  89: 44 / FloatEye x1, Eagle x2)
+   (Step 109: 45 / Imp x3)
+   (Step 255: 46 / Imp x3)
+
+Encounter Time:      318.339s
+Other Time:          497.947s
+Total Time:          816.285s
+
+Base Total Time:     845.898s
+Time Saved:          29.613s
+
+Optional Steps:      12
+Extra Steps:         56
+Encounters:          41
+
+Base Encounters:     42
+Encounters Saved:    1
+
+Number of Variables: 54

--- a/data/routes/cw/080.txt
+++ b/data/routes/cw/080.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	80
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49124802
+VARS	FFFFFFFF:8 E302500:3 E302600:7 E308700:1 E308702:1 E309700:48
+
+Overworld (Kaipo)                                                             Seed:  80   Index:   0
+  Step   1: 1 / Imp x4 (6.962s)
+Overworld (Kaipo)                                                             Seed:  80   Index:   1
+  Step   9: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  80   Index:  37
+Overworld (Kaipo)                                                             Seed:  80   Index:  37
+  Step  11: 3 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  80   Index:  69
+Recruit Tellah                                                                Seed:  80   Index: 101
+Watery Pass-South B1F                                                         Seed:  80   Index: 101
+  Step  17: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  80   Index: 121
+  Step  19: 5 / Zombie x4 (7.148s)
+  Step  74: 6 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed:  80   Index: 211
+Watery Pass-South B2F                                                         Seed:  80   Index: 215
+  Step  14: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  80   Index: 254
+Watery Pass-North B2F                                                         Seed:  97   Index:  32
+  Step   7: 8 / Zombie x4 (7.148s)
+  Step  18: 9 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed:  97   Index:  53
+  Step  38: 10 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  49: 11 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:  97   Index: 113
+Waterfalls B1F                                                                Seed:  97   Index: 122
+Waterfalls B2F                                                                Seed:  97   Index: 123
+  Step  25: 12 / TinyMage x4 (7.558s)
+Waterfalls Lake                                                               Seed:  97   Index: 168
+  Step  13: 13 / Aligator x1, Pike x2 (7.368s)
+  Step  37: 14 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed:  97   Index: 205
+Waterfalls Lake                                                               Seed:  97   Index: 205
+Overworld (Kaipo)                                                             Seed:  97   Index: 206
+Overworld (Damcyan)                                                           Seed:  97   Index: 217
+Damcyan                                                                       Seed:  97   Index: 221
+  Optional Steps: 1
+  Extra Steps: 2
+Overworld (Damcyan)                                                           Seed:  97   Index: 231
+Antlion B1F                                                                   Seed:  97   Index: 231
+Antlion B2F Inward Direct                                                     Seed: 114   Index:  13
+  Antlion B2F                                                                 Seed: 114   Index:  13
+    Step   4: 15 / Cream x4 (7.552s)
+    Step  20: 16 / Turtle x2 (7.487s)
+    Step  36: 17 / Cream x4 (7.552s)
+    Step  69: 18 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 114   Index:  93
+Battle: Antlion                                                               Seed: 114   Index: 107
+Antlion's Nest                                                                Seed: 114   Index: 107
+  Step   7: 19 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed: 114   Index: 122
+  Antlion B2F                                                                 Seed: 114   Index: 122
+    Step  44: 20 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 114   Index: 202
+  Step  16: 21 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  24: 22 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed: 114   Index: 240
+Overworld (Kaipo)                                                             Seed: 114   Index: 240
+Kaipo Revisited                                                               Seed: 114   Index: 240
+Overworld (Kaipo)                                                             Seed: 114   Index: 240
+Overworld (Damcyan)                                                           Seed: 114   Index: 240
+Mt.Hobs-West                                                                  Seed: 114   Index: 240
+Mt.Hobs Summit                                                                Seed: 131   Index:  23
+Battle: MomBomb                                                               Seed: 131   Index:  38
+Mt.Hobs Summit                                                                Seed: 131   Index:  38
+Mt.Hobs-East                                                                  Seed: 131   Index:  44
+  Step   2: 23 / Turtle x2 (7.432s)
+  Step  35: 24 / Spirit x2, Skelton x2 (8.237s)
+  Step  46: 25 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 131   Index:  90
+  Step  22: 26 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  70: 27 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 131   Index: 174
+  Optional Steps: 7
+Overworld (Fabul)                                                             Seed: 131   Index: 241
+Fabul Boat and Leviatan                                                       Seed: 131   Index: 248
+Overworld (Mysidia)                                                           Seed: 131   Index: 248
+Mysidia                                                                       Seed: 148   Index:   1
+Overworld (Mysidia)                                                           Seed: 148   Index:   1
+Overworld (Mt.Ordeals)                                                        Seed: 148   Index:  11
+  Step  33: 28 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  34: 29 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 148   Index: 105
+  Step   2: 30 / Spirit x3, Soul x1 (8.687s)
+  Step  37: 31 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed: 148   Index: 148
+  Step   1: 32 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed: 148   Index: 171
+Mt.Ordeals-3rd station                                                        Seed: 148   Index: 171
+  Step   3: 33 / Spirit x2, Soul x2, Red Bone x2 (9.695s)
+Mt.Ordeals-7th station                                                        Seed: 148   Index: 176
+  Step  40: 34 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 148   Index: 218
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 148   Index: 236
+Mt.Ordeals Summit                                                             Seed: 148   Index: 236
+Paladin                                                                       Seed: 148   Index: 240
+Mt.Ordeals Summit                                                             Seed: 148   Index: 240
+  Optional Steps: 1
+  Step   3: 35 / Lilith x1, Red Bone x2 (8.437s)
+  Step  21: 36 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed: 165   Index:   7
+  Step   4: 37 / Lilith x1, Red Bone x2 (8.437s)
+  Step   9: 38 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed: 165   Index:  49
+  Step  26: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 165   Index:  79
+Overworld (Mt.Ordeals)                                                        Seed: 165   Index: 123
+Take Chocobo to Mysidia                                                       Seed: 165   Index: 136
+Overworld (Mysidia)                                                           Seed: 165   Index: 136
+Town of Baron Serpent Road                                                    Seed: 165   Index: 136
+  Extra Steps: 48
+Credit Warp Fight Search                                                      Seed: 165   Index: 188
+  Overworld (Baron)                                                           Seed: 165   Index: 188
+    Extra Steps: 8
+    Step   1: 40 / FloatEye x2 (7.230s)
+    Step   8: 41 / Imp x4 (7.223s)
+   (Step  16: 42 / Imp x3, SwordRat x1)
+   (Step  77: 43 / Imp x3, SwordRat x1)
+   (Step  89: 44 / FloatEye x1, Eagle x2)
+   (Step 109: 45 / Imp x3)
+   (Step 213: 46 / Imp x3)
+   (Step 255: 47 / Imp x3)
+
+Encounter Time:      318.921s
+Other Time:          498.479s
+Total Time:          817.401s
+
+Base Total Time:     855.350s
+Time Saved:          37.950s
+
+Optional Steps:      10
+Extra Steps:         58
+Encounters:          41
+
+Base Encounters:     43
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/081.txt
+++ b/data/routes/cw/081.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	81
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49456603
+VARS	FFFFFFFF:8 E302500:1 E302600:9 E305400:14 E307400:12 E308700:1 E308702:1 E309700:22
+
+Overworld (Kaipo)                                                             Seed:  81   Index:   0
+  Step   1: 1 / Imp x4 (6.962s)
+Overworld (Kaipo)                                                             Seed:  81   Index:   1
+  Step   9: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  81   Index:  37
+Overworld (Kaipo)                                                             Seed:  81   Index:  37
+  Step  11: 3 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  81   Index:  69
+Recruit Tellah                                                                Seed:  81   Index: 101
+Watery Pass-South B1F                                                         Seed:  81   Index: 101
+  Step  17: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  81   Index: 121
+  Step  19: 5 / Zombie x4 (7.148s)
+  Step  36: 6 / Zombie x4 (7.148s)
+  Step  74: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  81   Index: 211
+  Extra Steps: 14
+Watery Pass-South B2F                                                         Seed:  81   Index: 229
+Watery Pass-South B3F                                                         Seed:  98   Index:  12
+  Step  27: 8 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed:  98   Index:  46
+  Step   4: 9 / CaveToad x3 (7.014s)
+  Step   5: 10 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B1F                                                         Seed:  98   Index:  67
+  Step  24: 11 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  35: 12 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed:  98   Index: 127
+Waterfalls B1F                                                                Seed:  98   Index: 136
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed:  98   Index: 149
+  Step  32: 13 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:  98   Index: 194
+  Step  36: 14 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed:  98   Index: 231
+Waterfalls Lake                                                               Seed:  98   Index: 231
+Overworld (Kaipo)                                                             Seed:  98   Index: 232
+Overworld (Damcyan)                                                           Seed:  98   Index: 243
+Damcyan                                                                       Seed:  98   Index: 247
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  98   Index: 255
+Antlion B1F                                                                   Seed:  98   Index: 255
+  Step  18: 15 / Imp x3 (6.649s)
+  Step  34: 16 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 115   Index:  37
+  Antlion B2F                                                                 Seed: 115   Index:  37
+    Step  12: 17 / Cream x4 (7.552s)
+    Step  51: 18 / Basilisk x1, Imp x3 (6.775s)
+    Step  77: 19 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 115   Index: 117
+Battle: Antlion                                                               Seed: 115   Index: 131
+Antlion's Nest                                                                Seed: 115   Index: 131
+Antlion B2F Outward Direct                                                    Seed: 115   Index: 146
+  Antlion B2F                                                                 Seed: 115   Index: 146
+    Step  20: 20 / Weeper x2 (7.132s)
+    Step  72: 21 / Basilisk x1, Imp x3 (6.783s)
+    Step  80: 22 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 115   Index: 226
+Overworld (Damcyan)                                                           Seed: 132   Index:   8
+Overworld (Kaipo)                                                             Seed: 132   Index:   8
+Kaipo Revisited                                                               Seed: 132   Index:   8
+Overworld (Kaipo)                                                             Seed: 132   Index:   8
+Overworld (Damcyan)                                                           Seed: 132   Index:   8
+Mt.Hobs-West                                                                  Seed: 132   Index:   8
+  Step  38: 23 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 132   Index:  47
+Battle: MomBomb                                                               Seed: 132   Index:  62
+Mt.Hobs Summit                                                                Seed: 132   Index:  62
+Mt.Hobs-East                                                                  Seed: 132   Index:  68
+  Step  11: 24 / Spirit x2, Skelton x2 (8.237s)
+  Step  22: 25 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  43: 26 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 132   Index: 114
+  Step  46: 27 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 132   Index: 198
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed: 149   Index:  11
+Fabul Boat and Leviatan                                                       Seed: 149   Index:  18
+Overworld (Mysidia)                                                           Seed: 149   Index:  18
+Mysidia                                                                       Seed: 149   Index:  27
+Overworld (Mysidia)                                                           Seed: 149   Index:  27
+Overworld (Mt.Ordeals)                                                        Seed: 149   Index:  37
+  Step   7: 28 / Imp Cap. x3, Needler x1 (7.932s)
+  Step   8: 29 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  46: 30 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  70: 31 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  73: 32 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 149   Index: 131
+  Step  18: 33 / Red Bone x1, Skelton x3 (8.067s)
+  Step  43: 34 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 149   Index: 174
+Recruit Tellah                                                                Seed: 149   Index: 197
+Mt.Ordeals-3rd station                                                        Seed: 149   Index: 197
+Mt.Ordeals-7th station                                                        Seed: 149   Index: 202
+  Step  14: 35 / Lilith x1, Red Bone x2 (8.912s)
+  Step  41: 36 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 149   Index: 244
+  Optional Steps: 1
+  Step  17: 37 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed: 166   Index:   6
+Mt.Ordeals Summit                                                             Seed: 166   Index:   6
+Paladin                                                                       Seed: 166   Index:  10
+Mt.Ordeals Summit                                                             Seed: 166   Index:  10
+  Optional Steps: 1
+  Step   1: 38 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step   6: 39 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed: 166   Index:  33
+  Step  42: 40 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 166   Index:  75
+Mt.Ordeals                                                                    Seed: 166   Index: 105
+Overworld (Mt.Ordeals)                                                        Seed: 166   Index: 149
+Take Chocobo to Mysidia                                                       Seed: 166   Index: 162
+Overworld (Mysidia)                                                           Seed: 166   Index: 162
+Town of Baron Serpent Road                                                    Seed: 166   Index: 162
+  Extra Steps: 22
+Credit Warp Fight Search                                                      Seed: 166   Index: 188
+  Overworld (Baron)                                                           Seed: 166   Index: 188
+    Extra Steps: 8
+    Step   1: 41 / Imp x4 (7.223s)
+    Step   8: 42 / Imp x3, SwordRat x1 (7.227s)
+   (Step  16: 43 / Imp x3, SwordRat x1)
+   (Step  77: 44 / FloatEye x1, Eagle x2)
+   (Step  89: 45 / Imp x3)
+   (Step 109: 46 / Imp x3)
+   (Step 213: 47 / Imp x3)
+   (Step 240: 48 / FloatEye x1, Eagle x2)
+   (Step 255: 49 / FloatEye x1, Eagle x2)
+
+Encounter Time:      324.975s
+Other Time:          497.947s
+Total Time:          822.921s
+
+Base Total Time:     1056.365s
+Time Saved:          233.443s
+
+Optional Steps:      12
+Extra Steps:         56
+Encounters:          42
+
+Base Encounters:     53
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/082.txt
+++ b/data/routes/cw/082.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	82
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48938092
+VARS	FFFFFFFF:8 E302500:1 E302600:9 E305400:14 E307400:12 E308700:1 E308702:1 E309700:22
+
+Overworld (Kaipo)                                                             Seed:  82   Index:   0
+Overworld (Kaipo)                                                             Seed:  82   Index:   1
+  Step   7: 1 / Imp x4 (6.882s)
+  Step   9: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  82   Index:  37
+Overworld (Kaipo)                                                             Seed:  82   Index:  37
+  Step  11: 3 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  82   Index:  69
+Recruit Tellah                                                                Seed:  82   Index: 101
+Watery Pass-South B1F                                                         Seed:  82   Index: 101
+  Step  17: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  82   Index: 121
+  Step  19: 5 / Zombie x4 (7.148s)
+  Step  36: 6 / Zombie x4 (7.148s)
+  Step  74: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  82   Index: 211
+  Extra Steps: 14
+Watery Pass-South B2F                                                         Seed:  82   Index: 229
+Watery Pass-South B3F                                                         Seed:  99   Index:  12
+  Step  27: 8 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed:  99   Index:  46
+  Step   4: 9 / CaveToad x3 (7.014s)
+  Step   5: 10 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B1F                                                         Seed:  99   Index:  67
+  Step  24: 11 / Jelly x4 (7.324s)
+  Step  35: 12 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed:  99   Index: 127
+Waterfalls B1F                                                                Seed:  99   Index: 136
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed:  99   Index: 149
+  Step  32: 13 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:  99   Index: 194
+  Step  23: 14 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed:  99   Index: 231
+Waterfalls Lake                                                               Seed:  99   Index: 231
+Overworld (Kaipo)                                                             Seed:  99   Index: 232
+Overworld (Damcyan)                                                           Seed:  99   Index: 243
+Damcyan                                                                       Seed:  99   Index: 247
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  99   Index: 255
+Antlion B1F                                                                   Seed:  99   Index: 255
+  Step  18: 15 / Imp x3 (6.649s)
+  Step  34: 16 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 116   Index:  37
+  Antlion B2F                                                                 Seed: 116   Index:  37
+    Step  12: 17 / Cream x4 (7.552s)
+    Step  22: 18 / Basilisk x1, Imp x3 (6.775s)
+    Step  51: 19 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 116   Index: 117
+Battle: Antlion                                                               Seed: 116   Index: 131
+Antlion's Nest                                                                Seed: 116   Index: 131
+Antlion B2F Outward Direct                                                    Seed: 116   Index: 146
+  Antlion B2F                                                                 Seed: 116   Index: 146
+    Step  20: 20 / Weeper x2 (7.132s)
+    Step  72: 21 / Basilisk x1, Imp x3 (6.783s)
+    Step  80: 22 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 116   Index: 226
+Overworld (Damcyan)                                                           Seed: 133   Index:   8
+Overworld (Kaipo)                                                             Seed: 133   Index:   8
+Kaipo Revisited                                                               Seed: 133   Index:   8
+Overworld (Kaipo)                                                             Seed: 133   Index:   8
+Overworld (Damcyan)                                                           Seed: 133   Index:   8
+Mt.Hobs-West                                                                  Seed: 133   Index:   8
+  Step  38: 23 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 133   Index:  47
+Battle: MomBomb                                                               Seed: 133   Index:  62
+Mt.Hobs Summit                                                                Seed: 133   Index:  62
+Mt.Hobs-East                                                                  Seed: 133   Index:  68
+  Step  11: 24 / Gargoyle x2 (7.630s)
+  Step  22: 25 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  43: 26 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 133   Index: 114
+  Step  46: 27 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 133   Index: 198
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed: 150   Index:  11
+Fabul Boat and Leviatan                                                       Seed: 150   Index:  18
+Overworld (Mysidia)                                                           Seed: 150   Index:  18
+Mysidia                                                                       Seed: 150   Index:  27
+Overworld (Mysidia)                                                           Seed: 150   Index:  27
+Overworld (Mt.Ordeals)                                                        Seed: 150   Index:  37
+  Step   7: 28 / Imp Cap. x3, Needler x1 (7.932s)
+  Step   8: 29 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  46: 30 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  70: 31 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 150   Index: 131
+  Step  18: 32 / Spirit x3, Soul x1 (8.687s)
+  Step  42: 33 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 150   Index: 174
+Recruit Tellah                                                                Seed: 150   Index: 197
+Mt.Ordeals-3rd station                                                        Seed: 150   Index: 197
+Mt.Ordeals-7th station                                                        Seed: 150   Index: 202
+  Step  14: 34 / Revenant x1, Ghoul x3 (8.914s)
+  Step  41: 35 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 150   Index: 244
+  Optional Steps: 1
+  Step  17: 36 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 167   Index:   6
+Mt.Ordeals Summit                                                             Seed: 167   Index:   6
+Paladin                                                                       Seed: 167   Index:  10
+Mt.Ordeals Summit                                                             Seed: 167   Index:  10
+  Optional Steps: 1
+  Step   1: 37 / Lilith x1, Red Bone x2 (8.437s)
+  Step   6: 38 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed: 167   Index:  33
+Mt.Ordeals-3rd station                                                        Seed: 167   Index:  75
+  Step  20: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 167   Index: 105
+Overworld (Mt.Ordeals)                                                        Seed: 167   Index: 149
+Take Chocobo to Mysidia                                                       Seed: 167   Index: 162
+Overworld (Mysidia)                                                           Seed: 167   Index: 162
+Town of Baron Serpent Road                                                    Seed: 167   Index: 162
+  Extra Steps: 22
+Credit Warp Fight Search                                                      Seed: 167   Index: 188
+  Overworld (Baron)                                                           Seed: 167   Index: 188
+    Extra Steps: 8
+    Step   1: 40 / FloatEye x2 (7.230s)
+    Step   8: 41 / Imp x4 (7.223s)
+   (Step  16: 42 / Imp x3, SwordRat x1)
+   (Step  89: 43 / Imp x3, SwordRat x1)
+   (Step 109: 44 / FloatEye x1, Eagle x2)
+   (Step 213: 45 / Imp x3)
+   (Step 240: 46 / Imp x3)
+   (Step 255: 47 / Imp x3)
+
+Encounter Time:      316.347s
+Other Time:          497.947s
+Total Time:          814.294s
+
+Base Total Time:     1057.843s
+Time Saved:          243.549s
+
+Optional Steps:      12
+Extra Steps:         56
+Encounters:          41
+
+Base Encounters:     53
+Encounters Saved:    12
+
+Number of Variables: 54

--- a/data/routes/cw/083.txt
+++ b/data/routes/cw/083.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	83
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48710665
+VARS	FFFFFFFF:6 E302600:10 E305400:14 E307300:1 E307400:10 E308702:1 E309700:6
+
+Overworld (Kaipo)                                                             Seed:  83   Index:   0
+Overworld (Kaipo)                                                             Seed:  83   Index:   1
+  Step   7: 1 / Sand Man x4 (7.172s)
+  Step   9: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  83   Index:  37
+Overworld (Kaipo)                                                             Seed:  83   Index:  37
+Watery Pass-South B1F                                                         Seed:  83   Index:  69
+  Step  16: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  83   Index: 101
+Watery Pass-South B1F                                                         Seed:  83   Index: 101
+Watery Pass-South B2F                                                         Seed:  83   Index: 121
+  Step  19: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  36: 5 / Zombie x4 (7.148s)
+  Step  74: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  83   Index: 211
+  Extra Steps: 14
+Watery Pass-South B2F                                                         Seed:  83   Index: 229
+Watery Pass-South B3F                                                         Seed: 100   Index:  12
+  Step  27: 7 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed: 100   Index:  46
+  Step   5: 8 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 100   Index:  67
+  Extra Steps: 1
+  Step  24: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  35: 10 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  48: 11 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 100   Index: 128
+Waterfalls B1F                                                                Seed: 100   Index: 137
+  Extra Steps: 10
+Waterfalls B2F                                                                Seed: 100   Index: 148
+  Step  33: 12 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 100   Index: 193
+  Step  24: 13 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 100   Index: 230
+Waterfalls Lake                                                               Seed: 100   Index: 230
+Overworld (Kaipo)                                                             Seed: 100   Index: 231
+Overworld (Damcyan)                                                           Seed: 100   Index: 242
+Damcyan                                                                       Seed: 100   Index: 246
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 100   Index: 253
+Antlion B1F                                                                   Seed: 100   Index: 253
+  Step  20: 14 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed: 117   Index:  35
+  Antlion B2F                                                                 Seed: 117   Index:  35
+    Step  14: 15 / Cream x4 (7.552s)
+    Step  24: 16 / Turtle x2 (7.487s)
+    Step  53: 17 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 117   Index: 115
+Battle: Antlion                                                               Seed: 117   Index: 129
+Antlion's Nest                                                                Seed: 117   Index: 129
+Antlion B2F Outward Direct                                                    Seed: 117   Index: 144
+  Antlion B2F                                                                 Seed: 117   Index: 144
+    Step  22: 18 / Basilisk x1, Imp x3 (6.783s)
+    Step  25: 19 / Weeper x2 (7.132s)
+    Step  74: 20 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 117   Index: 224
+  Step   2: 21 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 134   Index:   6
+Overworld (Kaipo)                                                             Seed: 134   Index:   6
+Kaipo Revisited                                                               Seed: 134   Index:   6
+Overworld (Kaipo)                                                             Seed: 134   Index:   6
+Overworld (Damcyan)                                                           Seed: 134   Index:   6
+Mt.Hobs-West                                                                  Seed: 134   Index:   6
+Mt.Hobs Summit                                                                Seed: 134   Index:  45
+  Step   1: 22 / Gargoyle x2 (8.791s)
+Battle: MomBomb                                                               Seed: 134   Index:  60
+Mt.Hobs Summit                                                                Seed: 134   Index:  60
+Mt.Hobs-East                                                                  Seed: 134   Index:  66
+  Step  13: 23 / Turtle x2 (7.432s)
+  Step  24: 24 / Gargoyle x2 (7.630s)
+  Step  45: 25 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 134   Index: 112
+  Step  48: 26 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  56: 27 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 134   Index: 196
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 151   Index:  10
+Fabul Boat and Leviatan                                                       Seed: 151   Index:  17
+Overworld (Mysidia)                                                           Seed: 151   Index:  17
+Mysidia                                                                       Seed: 151   Index:  26
+Overworld (Mysidia)                                                           Seed: 151   Index:  26
+Overworld (Mt.Ordeals)                                                        Seed: 151   Index:  36
+  Step   8: 28 / Imp Cap. x3, Needler x1 (7.932s)
+  Step   9: 29 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  47: 30 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  69: 31 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  71: 32 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 151   Index: 130
+  Step  19: 33 / Red Bone x1, Skelton x3 (8.067s)
+  Step  43: 34 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 151   Index: 173
+Recruit Tellah                                                                Seed: 151   Index: 196
+Mt.Ordeals-3rd station                                                        Seed: 151   Index: 196
+Mt.Ordeals-7th station                                                        Seed: 151   Index: 201
+  Step  15: 35 / Lilith x1, Red Bone x2 (8.912s)
+  Step  42: 36 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 151   Index: 243
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 168   Index:   4
+Mt.Ordeals Summit                                                             Seed: 168   Index:   4
+  Step   1: 37 / Lilith x1 (8.568s)
+Paladin                                                                       Seed: 168   Index:   8
+Mt.Ordeals Summit                                                             Seed: 168   Index:   8
+  Optional Steps: 1
+  Step   3: 38 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed: 168   Index:  31
+Mt.Ordeals-3rd station                                                        Seed: 168   Index:  73
+  Step  22: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 168   Index: 103
+Overworld (Mt.Ordeals)                                                        Seed: 168   Index: 147
+Take Chocobo to Mysidia                                                       Seed: 168   Index: 160
+Overworld (Mysidia)                                                           Seed: 168   Index: 160
+Town of Baron Serpent Road                                                    Seed: 168   Index: 160
+  Extra Steps: 6
+Credit Warp Fight Search                                                      Seed: 168   Index: 170
+  Overworld (Baron)                                                           Seed: 168   Index: 170
+    Extra Steps: 6
+    Step   1: 40 / FloatEye x2 (7.230s)
+    Step   6: 41 / Imp x3, SwordRat x1 (7.227s)
+   (Step  19: 42 / Imp x3, SwordRat x1)
+   (Step  34: 43 / Imp x6)
+   (Step 107: 44 / FloatEye x1, Eagle x2)
+   (Step 149: 45 / Imp x3)
+   (Step 231: 46 / Imp x3)
+
+Encounter Time:      317.888s
+Other Time:          492.622s
+Total Time:          810.510s
+
+Base Total Time:     1091.343s
+Time Saved:          280.833s
+
+Optional Steps:      11
+Extra Steps:         37
+Encounters:          41
+
+Base Encounters:     53
+Encounters Saved:    12
+
+Number of Variables: 54

--- a/data/routes/cw/084.txt
+++ b/data/routes/cw/084.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	84
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48387705
+VARS	FFFFFFFF:6 E302600:10 E308400:2 E308502:14 E308700:1 E308702:1 E309700:14
+
+Overworld (Kaipo)                                                             Seed:  84   Index:   0
+Overworld (Kaipo)                                                             Seed:  84   Index:   1
+  Step   7: 1 / Sand Man x4 (7.172s)
+  Step   9: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  84   Index:  37
+Overworld (Kaipo)                                                             Seed:  84   Index:  37
+Watery Pass-South B1F                                                         Seed:  84   Index:  69
+  Step  16: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  84   Index: 101
+Watery Pass-South B1F                                                         Seed:  84   Index: 101
+  Step  16: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  84   Index: 121
+  Step  19: 5 / Zombie x4 (7.148s)
+  Step  36: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  84   Index: 211
+Watery Pass-South B2F                                                         Seed:  84   Index: 215
+  Step  14: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  84   Index: 254
+Watery Pass-North B2F                                                         Seed: 101   Index:  32
+  Step   7: 8 / Zombie x4 (7.148s)
+  Step  19: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 101   Index:  53
+  Step  38: 10 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  49: 11 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 101   Index: 113
+  Step   2: 12 / SandMoth x2, Larva x2 (7.163s)
+Waterfalls B1F                                                                Seed: 101   Index: 122
+Waterfalls B2F                                                                Seed: 101   Index: 123
+  Step  24: 13 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 101   Index: 168
+  Step  13: 14 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed: 101   Index: 205
+Waterfalls Lake                                                               Seed: 101   Index: 205
+Overworld (Kaipo)                                                             Seed: 101   Index: 206
+  Step  11: 15 / SandMoth x2, Larva x2 (7.188s)
+Overworld (Damcyan)                                                           Seed: 101   Index: 217
+Damcyan                                                                       Seed: 101   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 101   Index: 228
+Antlion B1F                                                                   Seed: 101   Index: 228
+Antlion B2F Inward Direct                                                     Seed: 118   Index:  10
+  Antlion B2F                                                                 Seed: 118   Index:  10
+    Step   7: 16 / Turtle x2 (7.487s)
+    Step  39: 17 / Cream x4 (7.552s)
+    Step  49: 18 / Basilisk x1, Imp x3 (6.775s)
+    Step  78: 19 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 118   Index:  90
+Battle: Antlion                                                               Seed: 118   Index: 104
+Antlion's Nest                                                                Seed: 118   Index: 104
+Antlion B2F Outward Direct                                                    Seed: 118   Index: 119
+  Antlion B2F                                                                 Seed: 118   Index: 119
+    Step  47: 20 / Weeper x2 (7.132s)
+    Step  50: 21 / Basilisk x1, Imp x3 (6.783s)
+    Step  58: 22 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 118   Index: 199
+  Step  27: 23 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 118   Index: 237
+Overworld (Kaipo)                                                             Seed: 118   Index: 237
+Kaipo Revisited                                                               Seed: 118   Index: 237
+Overworld (Kaipo)                                                             Seed: 118   Index: 237
+Overworld (Damcyan)                                                           Seed: 118   Index: 237
+Mt.Hobs-West                                                                  Seed: 118   Index: 237
+Mt.Hobs Summit                                                                Seed: 135   Index:  20
+Battle: MomBomb                                                               Seed: 135   Index:  35
+Mt.Hobs Summit                                                                Seed: 135   Index:  35
+Mt.Hobs-East                                                                  Seed: 135   Index:  41
+  Step   5: 24 / Gargoyle x2 (7.630s)
+  Step  38: 25 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 135   Index:  87
+  Step   3: 26 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  24: 27 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  81: 28 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 135   Index: 171
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 135   Index: 241
+Fabul Boat and Leviatan                                                       Seed: 135   Index: 248
+Overworld (Mysidia)                                                           Seed: 135   Index: 248
+Mysidia                                                                       Seed: 152   Index:   1
+Overworld (Mysidia)                                                           Seed: 152   Index:   1
+Overworld (Mt.Ordeals)                                                        Seed: 152   Index:  11
+  Step  14: 29 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  33: 30 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  34: 31 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  72: 32 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  94: 33 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 152   Index: 105
+  Extra Steps: 2
+  Step  44: 34 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 152   Index: 150
+  Step  23: 35 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed: 152   Index: 173
+Mt.Ordeals-3rd station                                                        Seed: 152   Index: 173
+Mt.Ordeals-7th station                                                        Seed: 152   Index: 178
+Mt.Ordeals Summit                                                             Seed: 152   Index: 220
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 152   Index: 238
+Mt.Ordeals Summit                                                             Seed: 152   Index: 238
+Paladin                                                                       Seed: 152   Index: 242
+Mt.Ordeals Summit                                                             Seed: 152   Index: 242
+  Optional Steps: 1
+  Step   1: 36 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  19: 37 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed: 169   Index:   9
+  Step   2: 38 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 169   Index:  51
+  Extra Steps: 14
+  Step  44: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 169   Index:  95
+Overworld (Mt.Ordeals)                                                        Seed: 169   Index: 139
+Take Chocobo to Mysidia                                                       Seed: 169   Index: 152
+Overworld (Mysidia)                                                           Seed: 169   Index: 152
+Town of Baron Serpent Road                                                    Seed: 169   Index: 152
+  Extra Steps: 14
+Credit Warp Fight Search                                                      Seed: 169   Index: 170
+  Overworld (Baron)                                                           Seed: 169   Index: 170
+    Extra Steps: 6
+    Step   1: 40 / FloatEye x2 (7.230s)
+    Step   6: 41 / Imp x3, SwordRat x1 (7.227s)
+   (Step  19: 42 / Imp x3, SwordRat x1)
+   (Step  34: 43 / Imp x6)
+   (Step  49: 44 / FloatEye x1, Eagle x2)
+   (Step 107: 45 / Imp x3)
+   (Step 126: 46 / Imp x3)
+   (Step 149: 47 / Imp x3)
+   (Step 231: 48 / FloatEye x1, Eagle x2)
+
+Encounter Time:      313.046s
+Other Time:          492.090s
+Total Time:          805.136s
+
+Base Total Time:     836.831s
+Time Saved:          31.695s
+
+Optional Steps:      12
+Extra Steps:         36
+Encounters:          41
+
+Base Encounters:     43
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/085.txt
+++ b/data/routes/cw/085.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	85
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47497233
+VARS	FFFFFFFF:6 E302500:1 E302600:10 E305400:14 E307400:10 E308702:1 E309700:6
+
+Overworld (Kaipo)                                                             Seed:  85   Index:   0
+Overworld (Kaipo)                                                             Seed:  85   Index:   1
+  Step   7: 1 / Sand Man x4 (7.172s)
+  Step   9: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  85   Index:  37
+Overworld (Kaipo)                                                             Seed:  85   Index:  37
+Watery Pass-South B1F                                                         Seed:  85   Index:  69
+  Step   7: 3 / Pike x2, EvilShel x2 (6.952s)
+  Step  16: 4 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:  85   Index: 101
+Watery Pass-South B1F                                                         Seed:  85   Index: 101
+  Step  16: 5 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed:  85   Index: 121
+  Step  19: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  36: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  85   Index: 211
+  Extra Steps: 14
+Watery Pass-South B2F                                                         Seed:  85   Index: 229
+Watery Pass-South B3F                                                         Seed: 102   Index:  12
+Watery Pass-North B2F                                                         Seed: 102   Index:  46
+  Step   5: 8 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 102   Index:  67
+  Step  24: 9 / Jelly x4 (7.324s)
+  Step  35: 10 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  48: 11 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 102   Index: 127
+Waterfalls B1F                                                                Seed: 102   Index: 136
+  Extra Steps: 10
+Waterfalls B2F                                                                Seed: 102   Index: 147
+Waterfalls Lake                                                               Seed: 102   Index: 192
+  Step  25: 12 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 102   Index: 229
+Waterfalls Lake                                                               Seed: 102   Index: 229
+Overworld (Kaipo)                                                             Seed: 102   Index: 230
+  Step   5: 13 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 102   Index: 241
+Damcyan                                                                       Seed: 102   Index: 245
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 102   Index: 253
+Antlion B1F                                                                   Seed: 102   Index: 253
+  Step  20: 14 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed: 119   Index:  35
+  Antlion B2F                                                                 Seed: 119   Index:  35
+    Step  14: 15 / Cream x4 (7.552s)
+    Step  24: 16 / Turtle x2 (7.487s)
+    Step  53: 17 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 119   Index: 115
+Battle: Antlion                                                               Seed: 119   Index: 129
+Antlion's Nest                                                                Seed: 119   Index: 129
+Antlion B2F Outward Direct                                                    Seed: 119   Index: 144
+  Antlion B2F                                                                 Seed: 119   Index: 144
+    Step  22: 18 / Basilisk x1, Imp x3 (6.783s)
+    Step  25: 19 / SandWorm x2 (6.858s)
+    Step  33: 20 / Weeper x2 (7.132s)
+    Step  65: 21 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 119   Index: 224
+Overworld (Damcyan)                                                           Seed: 136   Index:   6
+Overworld (Kaipo)                                                             Seed: 136   Index:   6
+Kaipo Revisited                                                               Seed: 136   Index:   6
+Overworld (Kaipo)                                                             Seed: 136   Index:   6
+Overworld (Damcyan)                                                           Seed: 136   Index:   6
+Mt.Hobs-West                                                                  Seed: 136   Index:   6
+Mt.Hobs Summit                                                                Seed: 136   Index:  45
+Battle: MomBomb                                                               Seed: 136   Index:  60
+Mt.Hobs Summit                                                                Seed: 136   Index:  60
+Mt.Hobs-East                                                                  Seed: 136   Index:  66
+  Step   5: 22 / Gargoyle x2 (7.630s)
+  Step  13: 23 / Turtle x2 (7.432s)
+  Step  24: 24 / Gargoyle x2 (7.630s)
+  Step  45: 25 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 136   Index: 112
+  Step  56: 26 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 136   Index: 196
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 153   Index:  10
+Fabul Boat and Leviatan                                                       Seed: 153   Index:  17
+Overworld (Mysidia)                                                           Seed: 153   Index:  17
+  Step   8: 27 / Imp Cap. x4, Imp x2 (8.293s)
+Mysidia                                                                       Seed: 153   Index:  26
+Overworld (Mysidia)                                                           Seed: 153   Index:  26
+Overworld (Mt.Ordeals)                                                        Seed: 153   Index:  36
+  Step   8: 28 / Imp Cap. x3, Needler x1 (7.932s)
+  Step   9: 29 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  47: 30 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  69: 31 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 153   Index: 130
+  Step  19: 32 / Spirit x3, Soul x1 (8.687s)
+  Step  43: 33 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 153   Index: 173
+Recruit Tellah                                                                Seed: 153   Index: 196
+Mt.Ordeals-3rd station                                                        Seed: 153   Index: 196
+Mt.Ordeals-7th station                                                        Seed: 153   Index: 201
+  Step  10: 34 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 153   Index: 243
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 170   Index:   4
+Mt.Ordeals Summit                                                             Seed: 170   Index:   4
+  Step   1: 35 / Lilith x1, Red Bone x2 (8.744s)
+Paladin                                                                       Seed: 170   Index:   8
+Mt.Ordeals Summit                                                             Seed: 170   Index:   8
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 170   Index:  31
+  Step  11: 36 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed: 170   Index:  73
+  Step  22: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 170   Index: 103
+Overworld (Mt.Ordeals)                                                        Seed: 170   Index: 147
+Take Chocobo to Mysidia                                                       Seed: 170   Index: 160
+Overworld (Mysidia)                                                           Seed: 170   Index: 160
+Town of Baron Serpent Road                                                    Seed: 170   Index: 160
+  Extra Steps: 6
+Credit Warp Fight Search                                                      Seed: 170   Index: 170
+  Overworld (Baron)                                                           Seed: 170   Index: 170
+    Extra Steps: 6
+    Step   1: 38 / Eagle x3 (7.417s)
+    Step   6: 39 / Imp x4 (7.223s)
+   (Step  19: 40 / FloatEye x2)
+   (Step  49: 41 / Imp x3, SwordRat x1)
+   (Step 126: 42 / Imp x3, SwordRat x1)
+   (Step 149: 43 / Imp x3)
+   (Step 231: 44 / FloatEye x1, Eagle x2)
+
+Encounter Time:      298.229s
+Other Time:          492.090s
+Total Time:          790.319s
+
+Base Total Time:     1083.744s
+Time Saved:          293.425s
+
+Optional Steps:      12
+Extra Steps:         36
+Encounters:          39
+
+Base Encounters:     53
+Encounters Saved:    14
+
+Number of Variables: 54

--- a/data/routes/cw/086.txt
+++ b/data/routes/cw/086.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	86
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49401954
+VARS	FFFFFFFF:6 C307800:1 E302500:5 E302600:10 E307300:2 E307700:6 E307B00:4 E308700:1 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed:  86   Index:   0
+Overworld (Kaipo)                                                             Seed:  86   Index:   1
+  Step   7: 1 / Sand Man x4 (7.172s)
+  Step  31: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  86   Index:  37
+Overworld (Kaipo)                                                             Seed:  86   Index:  37
+Watery Pass-South B1F                                                         Seed:  86   Index:  69
+  Step   7: 3 / Pike x2, EvilShel x2 (6.952s)
+  Step  16: 4 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:  86   Index: 101
+Watery Pass-South B1F                                                         Seed:  86   Index: 101
+  Step  16: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  86   Index: 121
+  Step  19: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  36: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  86   Index: 211
+Watery Pass-South B2F                                                         Seed:  86   Index: 215
+Watery Pass-South B3F                                                         Seed:  86   Index: 254
+  Step  14: 8 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 103   Index:  32
+  Step  19: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 103   Index:  53
+  Extra Steps: 2
+  Step  38: 10 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  49: 11 / Jelly x4 (7.324s)
+  Step  62: 12 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 103   Index: 115
+Waterfalls B1F                                                                Seed: 103   Index: 124
+Waterfalls B2F                                                                Seed: 103   Index: 125
+  Step  22: 13 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 103   Index: 170
+Battle: Octomamm                                                              Seed: 103   Index: 207
+Waterfalls Lake                                                               Seed: 103   Index: 207
+Overworld (Kaipo)                                                             Seed: 103   Index: 208
+  Step   9: 14 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed: 103   Index: 219
+Damcyan                                                                       Seed: 103   Index: 223
+  Optional Steps: 1
+  Extra Steps: 4
+Overworld (Damcyan)                                                           Seed: 103   Index: 235
+Antlion B1F                                                                   Seed: 103   Index: 235
+  Extra Steps: 6
+  Step  38: 15 / Imp x3 (6.649s)
+  Step  44: 16 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 120   Index:  23
+  Antlion B2F                                                                 Seed: 120   Index:  23
+    Step  26: 17 / Cream x4 (7.552s)
+  Antlion B2F Treasure Room                                                   Seed: 120   Index:  56
+    Extra Steps: 4
+  Antlion B2F                                                                 Seed: 120   Index:  60
+    Step  28: 18 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 120   Index: 112
+Battle: Antlion                                                               Seed: 120   Index: 126
+Antlion's Nest                                                                Seed: 120   Index: 126
+Antlion B2F Outward Direct                                                    Seed: 120   Index: 141
+  Antlion B2F                                                                 Seed: 120   Index: 141
+    Step  28: 19 / SandWorm x2 (6.858s)
+    Step  36: 20 / Weeper x2 (7.132s)
+    Step  68: 21 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 120   Index: 221
+Overworld (Damcyan)                                                           Seed: 137   Index:   3
+Overworld (Kaipo)                                                             Seed: 137   Index:   3
+Kaipo Revisited                                                               Seed: 137   Index:   3
+Overworld (Kaipo)                                                             Seed: 137   Index:   3
+Overworld (Damcyan)                                                           Seed: 137   Index:   3
+Mt.Hobs-West                                                                  Seed: 137   Index:   3
+  Step  11: 22 / GrayBomb x2, Bomb x2 (10.938s)
+Mt.Hobs Summit                                                                Seed: 137   Index:  42
+Battle: MomBomb                                                               Seed: 137   Index:  57
+Mt.Hobs Summit                                                                Seed: 137   Index:  57
+Mt.Hobs-East                                                                  Seed: 137   Index:  63
+  Step   8: 23 / Turtle x2 (7.432s)
+  Step  16: 24 / Gargoyle x2 (7.630s)
+  Step  27: 25 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 137   Index: 109
+  Step   2: 26 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  59: 27 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 137   Index: 193
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 154   Index:   7
+Fabul Boat and Leviatan                                                       Seed: 154   Index:  14
+Overworld (Mysidia)                                                           Seed: 154   Index:  14
+Mysidia                                                                       Seed: 154   Index:  23
+Overworld (Mysidia)                                                           Seed: 154   Index:  23
+  Step   2: 28 / Imp Cap. x3, Needler x1 (7.932s)
+Overworld (Mt.Ordeals)                                                        Seed: 154   Index:  33
+  Step  11: 29 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  12: 30 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  50: 31 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  72: 32 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 154   Index: 127
+  Step  22: 33 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  27: 34 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 154   Index: 170
+  Step   3: 35 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed: 154   Index: 193
+Mt.Ordeals-3rd station                                                        Seed: 154   Index: 193
+Mt.Ordeals-7th station                                                        Seed: 154   Index: 198
+  Step  13: 36 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 154   Index: 240
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 171   Index:   2
+Mt.Ordeals Summit                                                             Seed: 171   Index:   2
+  Step   2: 37 / Lilith x1 (8.568s)
+  Step   3: 38 / Lilith x1, Red Bone x2 (8.744s)
+Paladin                                                                       Seed: 171   Index:   6
+Mt.Ordeals Summit                                                             Seed: 171   Index:   6
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 171   Index:  29
+  Step  13: 39 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed: 171   Index:  71
+  Step  24: 40 / Spirit x2, Soul x2, Red Bone x2 (9.471s)
+Mt.Ordeals                                                                    Seed: 171   Index: 101
+Overworld (Mt.Ordeals)                                                        Seed: 171   Index: 145
+Take Chocobo to Mysidia                                                       Seed: 171   Index: 158
+Overworld (Mysidia)                                                           Seed: 171   Index: 158
+Town of Baron Serpent Road                                                    Seed: 171   Index: 158
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed: 171   Index: 170
+  Overworld (Baron)                                                           Seed: 171   Index: 170
+    Extra Steps: 6
+    Step   1: 41 / Imp x3, SwordRat x1 (7.227s)
+    Step   6: 42 / Imp x3, SwordRat x1 (7.227s)
+   (Step  49: 43 / Imp x3)
+   (Step 126: 44 / FloatEye x1, Eagle x2)
+   (Step 149: 45 / Imp x3)
+   (Step 190: 46 / Imp x3)
+   (Step 231: 47 / FloatEye x2)
+
+Encounter Time:      326.927s
+Other Time:          495.085s
+Total Time:          822.012s
+
+Base Total Time:     941.710s
+Time Saved:          119.698s
+
+Optional Steps:      13
+Extra Steps:         30
+Encounters:          42
+
+Base Encounters:     48
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/087.txt
+++ b/data/routes/cw/087.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	87
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48840906
+VARS	FFFFFFFF:6 C307800:1 E302500:1 E302600:10 E307200:10 E307B00:6 E308000:2 E308400:2 E308700:1 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed:  87   Index:   0
+Overworld (Kaipo)                                                             Seed:  87   Index:   1
+  Step   7: 1 / Sand Man x4 (7.172s)
+  Step  31: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  87   Index:  37
+Overworld (Kaipo)                                                             Seed:  87   Index:  37
+Watery Pass-South B1F                                                         Seed:  87   Index:  69
+  Step   7: 3 / Pike x2, EvilShel x2 (6.952s)
+  Step  16: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  87   Index: 101
+Watery Pass-South B1F                                                         Seed:  87   Index: 101
+  Step  16: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  87   Index: 121
+  Step  36: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  87   Index: 211
+Watery Pass-South B2F                                                         Seed:  87   Index: 215
+Watery Pass-South B3F                                                         Seed:  87   Index: 254
+  Step  14: 7 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed: 104   Index:  32
+  Extra Steps: 10
+  Step  19: 8 / Zombie x4 (7.148s)
+  Step  30: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 104   Index:  63
+  Step  28: 10 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  52: 11 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 104   Index: 123
+Waterfalls B1F                                                                Seed: 104   Index: 132
+Waterfalls B2F                                                                Seed: 104   Index: 133
+  Step  14: 12 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 104   Index: 178
+Battle: Octomamm                                                              Seed: 104   Index: 215
+Waterfalls Lake                                                               Seed: 104   Index: 215
+Overworld (Kaipo)                                                             Seed: 104   Index: 216
+  Step   1: 13 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 104   Index: 227
+Damcyan                                                                       Seed: 104   Index: 231
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 104   Index: 239
+Antlion B1F                                                                   Seed: 104   Index: 239
+Antlion B2F Inward Charm Room Steps                                           Seed: 121   Index:  21
+  Antlion B2F                                                                 Seed: 121   Index:  21
+    Step   2: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  28: 15 / Cream x4 (7.552s)
+  Antlion B2F Treasure Room                                                   Seed: 121   Index:  54
+    Extra Steps: 6
+  Antlion B2F                                                                 Seed: 121   Index:  60
+    Step  28: 16 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 121   Index: 112
+Battle: Antlion                                                               Seed: 121   Index: 126
+Antlion's Nest                                                                Seed: 121   Index: 126
+Antlion B2F Outward Direct                                                    Seed: 121   Index: 141
+  Antlion B2F                                                                 Seed: 121   Index: 141
+    Step  14: 17 / Cream x4 (7.523s)
+    Step  28: 18 / Basilisk x1, Imp x3 (6.783s)
+    Step  36: 19 / SandWorm x2 (6.858s)
+    Step  68: 20 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 121   Index: 221
+Overworld (Damcyan)                                                           Seed: 138   Index:   3
+Overworld (Kaipo)                                                             Seed: 138   Index:   3
+Kaipo Revisited                                                               Seed: 138   Index:   3
+Overworld (Kaipo)                                                             Seed: 138   Index:   3
+Overworld (Damcyan)                                                           Seed: 138   Index:   3
+Mt.Hobs-West                                                                  Seed: 138   Index:   3
+  Step  11: 21 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 138   Index:  42
+Battle: MomBomb                                                               Seed: 138   Index:  57
+Mt.Hobs Summit                                                                Seed: 138   Index:  57
+Mt.Hobs-East                                                                  Seed: 138   Index:  63
+  Extra Steps: 2
+  Step   8: 22 / Gargoyle x2 (7.630s)
+  Step  16: 23 / Turtle x2 (7.432s)
+  Step  48: 24 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 138   Index: 111
+  Step  57: 25 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 138   Index: 195
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 155   Index:   9
+Fabul Boat and Leviatan                                                       Seed: 155   Index:  16
+Overworld (Mysidia)                                                           Seed: 155   Index:  16
+  Step   9: 26 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 155   Index:  25
+Overworld (Mysidia)                                                           Seed: 155   Index:  25
+Overworld (Mt.Ordeals)                                                        Seed: 155   Index:  35
+  Step   9: 27 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  10: 28 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  48: 29 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  70: 30 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 155   Index: 129
+  Extra Steps: 2
+  Step  25: 31 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  44: 32 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 155   Index: 174
+  Step  11: 33 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed: 155   Index: 197
+Mt.Ordeals-3rd station                                                        Seed: 155   Index: 197
+Mt.Ordeals-7th station                                                        Seed: 155   Index: 202
+  Step   9: 34 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 155   Index: 244
+  Optional Steps: 1
+  Step  16: 35 / Lilith x1, Red Bone x2 (8.912s)
+  Step  17: 36 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 172   Index:   6
+Mt.Ordeals Summit                                                             Seed: 172   Index:   6
+Paladin                                                                       Seed: 172   Index:  10
+Mt.Ordeals Summit                                                             Seed: 172   Index:  10
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 172   Index:  33
+  Step   9: 37 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed: 172   Index:  75
+  Step  20: 38 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed: 172   Index: 105
+  Step  17: 39 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 172   Index: 149
+Take Chocobo to Mysidia                                                       Seed: 172   Index: 162
+Overworld (Mysidia)                                                           Seed: 172   Index: 162
+Town of Baron Serpent Road                                                    Seed: 172   Index: 162
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed: 172   Index: 170
+  Overworld (Baron)                                                           Seed: 172   Index: 170
+    Extra Steps: 6
+    Step   1: 40 / FloatEye x2 (7.230s)
+    Step   6: 41 / Imp x3, SwordRat x1 (7.227s)
+   (Step  49: 42 / Imp x6)
+   (Step 104: 43 / Imp x3)
+   (Step 126: 44 / FloatEye x1, Eagle x2)
+   (Step 149: 45 / Imp x3)
+   (Step 190: 46 / Imp x3)
+
+Encounter Time:      317.592s
+Other Time:          495.085s
+Total Time:          812.677s
+
+Base Total Time:     903.779s
+Time Saved:          91.102s
+
+Optional Steps:      13
+Extra Steps:         30
+Encounters:          41
+
+Base Encounters:     48
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/088.txt
+++ b/data/routes/cw/088.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	88
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48186365
+VARS	FFFFFFFF:12 C307800:1 E302600:10 E307300:1 E307400:12 E307B00:4 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed:  88   Index:   0
+Overworld (Kaipo)                                                             Seed:  88   Index:   1
+  Step   7: 1 / Sand Man x4 (7.172s)
+  Step  31: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  88   Index:  37
+Overworld (Kaipo)                                                             Seed:  88   Index:  37
+Watery Pass-South B1F                                                         Seed:  88   Index:  69
+  Step   7: 3 / Pike x2, EvilShel x2 (6.952s)
+  Step  16: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  88   Index: 101
+Watery Pass-South B1F                                                         Seed:  88   Index: 101
+  Step  16: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  88   Index: 121
+Watery Pass-South B2F Save Room                                               Seed:  88   Index: 211
+Watery Pass-South B2F                                                         Seed:  88   Index: 215
+  Step  30: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  88   Index: 254
+  Step  14: 7 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed: 105   Index:  32
+  Step  19: 8 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 105   Index:  53
+  Extra Steps: 1
+  Step   9: 9 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 105   Index: 114
+  Step   1: 10 / SandWorm x1 (7.231s)
+Waterfalls B1F                                                                Seed: 105   Index: 123
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed: 105   Index: 136
+  Step  11: 11 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 105   Index: 181
+  Step  36: 12 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 105   Index: 218
+Waterfalls Lake                                                               Seed: 105   Index: 218
+Overworld (Kaipo)                                                             Seed: 105   Index: 219
+Overworld (Damcyan)                                                           Seed: 105   Index: 230
+Damcyan                                                                       Seed: 105   Index: 234
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 105   Index: 241
+Antlion B1F                                                                   Seed: 105   Index: 241
+  Step  38: 13 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 122   Index:  23
+  Antlion B2F                                                                 Seed: 122   Index:  23
+  Antlion B2F Treasure Room                                                   Seed: 122   Index:  56
+    Extra Steps: 4
+  Antlion B2F                                                                 Seed: 122   Index:  60
+    Step  26: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  28: 15 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 122   Index: 112
+Battle: Antlion                                                               Seed: 122   Index: 126
+Antlion's Nest                                                                Seed: 122   Index: 126
+Antlion B2F Outward Direct                                                    Seed: 122   Index: 141
+  Antlion B2F                                                                 Seed: 122   Index: 141
+    Step  14: 16 / Turtle x2 (7.464s)
+    Step  28: 17 / Cream x4 (7.523s)
+    Step  36: 18 / Basilisk x1, Imp x3 (6.783s)
+    Step  68: 19 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 122   Index: 221
+Overworld (Damcyan)                                                           Seed: 139   Index:   3
+Overworld (Kaipo)                                                             Seed: 139   Index:   3
+Kaipo Revisited                                                               Seed: 139   Index:   3
+Overworld (Kaipo)                                                             Seed: 139   Index:   3
+Overworld (Damcyan)                                                           Seed: 139   Index:   3
+Mt.Hobs-West                                                                  Seed: 139   Index:   3
+  Step  11: 20 / GrayBomb x2, Bomb x2 (10.938s)
+Mt.Hobs Summit                                                                Seed: 139   Index:  42
+Battle: MomBomb                                                               Seed: 139   Index:  57
+Mt.Hobs Summit                                                                Seed: 139   Index:  57
+Mt.Hobs-East                                                                  Seed: 139   Index:  63
+  Step   8: 21 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 139   Index: 109
+  Step   2: 22 / SwordRat x3, Needler x3 (7.663s)
+  Step  43: 23 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  59: 24 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 139   Index: 193
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 156   Index:   7
+Fabul Boat and Leviatan                                                       Seed: 156   Index:  14
+Overworld (Mysidia)                                                           Seed: 156   Index:  14
+Mysidia                                                                       Seed: 156   Index:  23
+Overworld (Mysidia)                                                           Seed: 156   Index:  23
+  Step   2: 25 / Imp Cap. x3, Needler x1 (7.932s)
+Overworld (Mt.Ordeals)                                                        Seed: 156   Index:  33
+  Step  11: 26 / Raven x1 (8.356s)
+  Step  50: 27 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  72: 28 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  75: 29 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 156   Index: 127
+  Step  27: 30 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 156   Index: 170
+  Step   3: 31 / Zombie x2, Ghoul x2 (7.661s)
+  Step  15: 32 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 156   Index: 193
+Mt.Ordeals-3rd station                                                        Seed: 156   Index: 193
+Mt.Ordeals-7th station                                                        Seed: 156   Index: 198
+  Step  13: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 156   Index: 240
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 173   Index:   2
+Mt.Ordeals Summit                                                             Seed: 173   Index:   2
+  Step   2: 34 / Revenant x1, Ghoul x3 (8.611s)
+Paladin                                                                       Seed: 173   Index:   6
+Mt.Ordeals Summit                                                             Seed: 173   Index:   6
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 173   Index:  29
+  Step  13: 35 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 173   Index:  71
+  Step  24: 36 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed: 173   Index: 101
+  Step  21: 37 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 173   Index: 145
+Take Chocobo to Mysidia                                                       Seed: 173   Index: 158
+Overworld (Mysidia)                                                           Seed: 173   Index: 158
+Town of Baron Serpent Road                                                    Seed: 173   Index: 158
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 173   Index: 164
+  Overworld (Baron)                                                           Seed: 173   Index: 164
+    Extra Steps: 12
+    Step   1: 38 / Eagle x3 (7.417s)
+    Step  12: 39 / Imp x4 (7.223s)
+   (Step  55: 40 / FloatEye x2)
+   (Step 110: 41 / Imp x3, SwordRat x1)
+   (Step 132: 42 / Imp x6)
+   (Step 155: 43 / Imp x3)
+   (Step 196: 44 / FloatEye x1, Eagle x2)
+
+Encounter Time:      304.571s
+Other Time:          497.214s
+Total Time:          801.786s
+
+Base Total Time:     943.161s
+Time Saved:          141.376s
+
+Optional Steps:      12
+Extra Steps:         31
+Encounters:          39
+
+Base Encounters:     48
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/089.txt
+++ b/data/routes/cw/089.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	89
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48968439
+VARS	FFFFFFFF:6 C307800:1 E302500:1 E302600:10 E307200:10 E307300:1 E307400:2 E307B00:2 E308000:4 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  89   Index:   0
+Overworld (Kaipo)                                                             Seed:  89   Index:   1
+  Step   7: 1 / Sand Man x4 (7.172s)
+  Step  19: 2 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  31: 3 / Imp x4 (6.882s)
+Kaipo                                                                         Seed:  89   Index:  37
+Overworld (Kaipo)                                                             Seed:  89   Index:  37
+Watery Pass-South B1F                                                         Seed:  89   Index:  69
+  Step   7: 4 / Pike x3 (6.935s)
+  Step  16: 5 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:  89   Index: 101
+Watery Pass-South B1F                                                         Seed:  89   Index: 101
+  Step  16: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  89   Index: 121
+Watery Pass-South B2F Save Room                                               Seed:  89   Index: 211
+Watery Pass-South B2F                                                         Seed:  89   Index: 215
+  Step  30: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  89   Index: 254
+  Step  14: 8 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 106   Index:  32
+  Extra Steps: 10
+  Step  30: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 106   Index:  63
+  Extra Steps: 1
+  Step  52: 10 / Zombie x4 (7.148s)
+  Step  53: 11 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 106   Index: 124
+Waterfalls B1F                                                                Seed: 106   Index: 133
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed: 106   Index: 136
+  Step  11: 12 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 106   Index: 181
+  Step  36: 13 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 106   Index: 218
+Waterfalls Lake                                                               Seed: 106   Index: 218
+Overworld (Kaipo)                                                             Seed: 106   Index: 219
+Overworld (Damcyan)                                                           Seed: 106   Index: 230
+Damcyan                                                                       Seed: 106   Index: 234
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 106   Index: 242
+Antlion B1F                                                                   Seed: 106   Index: 242
+  Step  37: 14 / Cream x4 (7.552s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 123   Index:  24
+  Antlion B2F                                                                 Seed: 123   Index:  24
+  Antlion B2F Treasure Room                                                   Seed: 123   Index:  57
+    Extra Steps: 2
+  Antlion B2F                                                                 Seed: 123   Index:  59
+    Step  21: 15 / Cream x4 (7.552s)
+    Step  27: 16 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 123   Index: 111
+Battle: Antlion                                                               Seed: 123   Index: 125
+Antlion's Nest                                                                Seed: 123   Index: 125
+Antlion B2F Outward Direct                                                    Seed: 123   Index: 140
+  Antlion B2F                                                                 Seed: 123   Index: 140
+    Step  15: 17 / Cream x4 (7.523s)
+    Step  29: 18 / Basilisk x1, Imp x3 (6.783s)
+    Step  37: 19 / SandWorm x2 (6.858s)
+    Step  69: 20 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 123   Index: 220
+Overworld (Damcyan)                                                           Seed: 140   Index:   2
+Overworld (Kaipo)                                                             Seed: 140   Index:   2
+Kaipo Revisited                                                               Seed: 140   Index:   2
+Overworld (Kaipo)                                                             Seed: 140   Index:   2
+Overworld (Damcyan)                                                           Seed: 140   Index:   2
+Mt.Hobs-West                                                                  Seed: 140   Index:   2
+  Step  12: 21 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed: 140   Index:  41
+Battle: MomBomb                                                               Seed: 140   Index:  56
+Mt.Hobs Summit                                                                Seed: 140   Index:  56
+Mt.Hobs-East                                                                  Seed: 140   Index:  62
+  Extra Steps: 4
+  Step   9: 22 / GrayBomb x2, Bomb x4 (9.348s)
+  Step  48: 23 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 140   Index: 112
+  Step  40: 24 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  56: 25 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 140   Index: 196
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 157   Index:  10
+Fabul Boat and Leviatan                                                       Seed: 157   Index:  17
+Overworld (Mysidia)                                                           Seed: 157   Index:  17
+  Step   8: 26 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 157   Index:  26
+Overworld (Mysidia)                                                           Seed: 157   Index:  26
+Overworld (Mt.Ordeals)                                                        Seed: 157   Index:  36
+  Step   8: 27 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  47: 28 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  69: 29 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  72: 30 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 157   Index: 130
+  Step  24: 31 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  43: 32 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 157   Index: 173
+  Step  12: 33 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed: 157   Index: 196
+Mt.Ordeals-3rd station                                                        Seed: 157   Index: 196
+Mt.Ordeals-7th station                                                        Seed: 157   Index: 201
+  Step  10: 34 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 157   Index: 243
+  Optional Steps: 0
+  Step   5: 35 / Lilith x1, Red Bone x2 (8.912s)
+  Step  17: 36 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 174   Index:   4
+Mt.Ordeals Summit                                                             Seed: 174   Index:   4
+Paladin                                                                       Seed: 174   Index:   8
+Mt.Ordeals Summit                                                             Seed: 174   Index:   8
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 174   Index:  31
+  Step  11: 37 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed: 174   Index:  73
+  Step  22: 38 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed: 174   Index: 103
+  Step  19: 39 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 174   Index: 147
+Take Chocobo to Mysidia                                                       Seed: 174   Index: 160
+Overworld (Mysidia)                                                           Seed: 174   Index: 160
+Town of Baron Serpent Road                                                    Seed: 174   Index: 160
+Credit Warp Fight Search                                                      Seed: 174   Index: 164
+  Overworld (Baron)                                                           Seed: 174   Index: 164
+    Extra Steps: 6
+    Step   1: 40 / FloatEye x2 (7.230s)
+    Step   6: 41 / Imp x3, SwordRat x1 (7.227s)
+   (Step  12: 42 / Imp x3)
+   (Step  55: 43 / Imp x3)
+   (Step 110: 44 / FloatEye x1, Eagle x2)
+   (Step 132: 45 / Imp x3)
+   (Step 155: 46 / Imp x3)
+   (Step 196: 47 / FloatEye x2)
+
+Encounter Time:      320.779s
+Other Time:          494.020s
+Total Time:          814.799s
+
+Base Total Time:     877.712s
+Time Saved:          62.913s
+
+Optional Steps:      12
+Extra Steps:         25
+Encounters:          41
+
+Base Encounters:     48
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/090.txt
+++ b/data/routes/cw/090.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	90
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48567229
+VARS	FFFFFFFF:6 E302500:5 E302600:10 E307300:2 E308000:17 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  90   Index:   0
+Overworld (Kaipo)                                                             Seed:  90   Index:   1
+  Step  19: 1 / Sand Man x4 (7.172s)
+  Step  31: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  90   Index:  37
+Overworld (Kaipo)                                                             Seed:  90   Index:  37
+Watery Pass-South B1F                                                         Seed:  90   Index:  69
+  Step   7: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  90   Index: 101
+Watery Pass-South B1F                                                         Seed:  90   Index: 101
+  Step  16: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed:  90   Index: 121
+  Step  84: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  90   Index: 211
+Watery Pass-South B2F                                                         Seed:  90   Index: 215
+  Step  30: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  90   Index: 254
+  Step  14: 7 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed: 107   Index:  32
+Watery Pass-North B1F                                                         Seed: 107   Index:  53
+  Extra Steps: 2
+  Step   9: 8 / CaveToad x4 (7.163s)
+  Step  29: 9 / Jelly x4 (7.324s)
+  Step  62: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 107   Index: 115
+  Step   1: 11 / Sandpede x1, Sand Man x2 (7.188s)
+Waterfalls B1F                                                                Seed: 107   Index: 124
+Waterfalls B2F                                                                Seed: 107   Index: 125
+  Step  11: 12 / Jelly x4 (7.324s)
+  Step  22: 13 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 107   Index: 170
+Battle: Octomamm                                                              Seed: 107   Index: 207
+Waterfalls Lake                                                               Seed: 107   Index: 207
+Overworld (Kaipo)                                                             Seed: 107   Index: 208
+Overworld (Damcyan)                                                           Seed: 107   Index: 219
+Damcyan                                                                       Seed: 107   Index: 223
+  Optional Steps: 1
+  Extra Steps: 4
+Overworld (Damcyan)                                                           Seed: 107   Index: 235
+Antlion B1F                                                                   Seed: 107   Index: 235
+Antlion B2F Inward Direct                                                     Seed: 124   Index:  17
+  Antlion B2F                                                                 Seed: 124   Index:  17
+    Step   6: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  63: 15 / Basilisk x1, Imp x3 (6.775s)
+    Step  69: 16 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 124   Index:  97
+Battle: Antlion                                                               Seed: 124   Index: 111
+Antlion's Nest                                                                Seed: 124   Index: 111
+  Step   1: 17 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed: 124   Index: 126
+  Antlion B2F                                                                 Seed: 124   Index: 126
+    Step  29: 18 / Basilisk x1, Imp x3 (6.783s)
+    Step  43: 19 / SandWorm x2 (6.858s)
+    Step  51: 20 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 124   Index: 206
+  Step   3: 21 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 124   Index: 244
+Overworld (Kaipo)                                                             Seed: 124   Index: 244
+Kaipo Revisited                                                               Seed: 124   Index: 244
+Overworld (Kaipo)                                                             Seed: 124   Index: 244
+Overworld (Damcyan)                                                           Seed: 124   Index: 244
+Mt.Hobs-West                                                                  Seed: 124   Index: 244
+  Step  26: 22 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 141   Index:  27
+Battle: MomBomb                                                               Seed: 141   Index:  42
+Mt.Hobs Summit                                                                Seed: 141   Index:  42
+Mt.Hobs-East                                                                  Seed: 141   Index:  48
+  Extra Steps: 17
+  Step  23: 23 / Turtle x2 (7.432s)
+  Step  62: 24 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 141   Index: 111
+  Step  31: 25 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  41: 26 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  57: 27 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 141   Index: 195
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 158   Index:   9
+Fabul Boat and Leviatan                                                       Seed: 158   Index:  16
+Overworld (Mysidia)                                                           Seed: 158   Index:  16
+  Step   9: 28 / Imp Cap. x4, Imp x2 (8.293s)
+Mysidia                                                                       Seed: 158   Index:  25
+Overworld (Mysidia)                                                           Seed: 158   Index:  25
+Overworld (Mt.Ordeals)                                                        Seed: 158   Index:  35
+  Step  48: 29 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  70: 30 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  73: 31 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 158   Index: 129
+  Step   9: 32 / Spirit x3, Soul x1 (8.687s)
+  Step  25: 33 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed: 158   Index: 172
+  Step  13: 34 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed: 158   Index: 195
+Mt.Ordeals-3rd station                                                        Seed: 158   Index: 195
+Mt.Ordeals-7th station                                                        Seed: 158   Index: 200
+  Step  11: 35 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 158   Index: 242
+  Optional Steps: 1
+  Step   6: 36 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  18: 37 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed: 175   Index:   4
+Mt.Ordeals Summit                                                             Seed: 175   Index:   4
+Paladin                                                                       Seed: 175   Index:   8
+Mt.Ordeals Summit                                                             Seed: 175   Index:   8
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 175   Index:  31
+  Step  11: 38 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 175   Index:  73
+Mt.Ordeals                                                                    Seed: 175   Index: 103
+  Step  19: 39 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 175   Index: 147
+Take Chocobo to Mysidia                                                       Seed: 175   Index: 160
+Overworld (Mysidia)                                                           Seed: 175   Index: 160
+Town of Baron Serpent Road                                                    Seed: 175   Index: 160
+Credit Warp Fight Search                                                      Seed: 175   Index: 164
+  Overworld (Baron)                                                           Seed: 175   Index: 164
+    Extra Steps: 6
+    Step   1: 40 / FloatEye x2 (7.230s)
+    Step   6: 41 / Imp x3, SwordRat x1 (7.227s)
+   (Step  38: 42 / Imp x3)
+   (Step  55: 43 / Imp x3)
+   (Step 110: 44 / FloatEye x1, Eagle x2)
+   (Step 132: 45 / Imp x3)
+   (Step 196: 46 / Imp x3)
+   (Step 198: 47 / FloatEye x2)
+
+Encounter Time:      317.631s
+Other Time:          490.492s
+Total Time:          808.123s
+
+Base Total Time:     929.009s
+Time Saved:          120.887s
+
+Optional Steps:      13
+Extra Steps:         29
+Encounters:          41
+
+Base Encounters:     48
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/091.txt
+++ b/data/routes/cw/091.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	91
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48402090
+VARS	FFFFFFFF:6 E302600:9 E308401:2 E308702:1 E309700:24
+
+Overworld (Kaipo)                                                             Seed:  91   Index:   0
+Overworld (Kaipo)                                                             Seed:  91   Index:   1
+  Step  19: 1 / Sand Man x4 (7.172s)
+  Step  31: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  91   Index:  37
+Overworld (Kaipo)                                                             Seed:  91   Index:  37
+Watery Pass-South B1F                                                         Seed:  91   Index:  69
+  Step   7: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed:  91   Index: 101
+Watery Pass-South B1F                                                         Seed:  91   Index: 101
+Watery Pass-South B2F                                                         Seed:  91   Index: 121
+  Step  84: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  91   Index: 211
+Watery Pass-South B2F                                                         Seed:  91   Index: 215
+  Step  15: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  30: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed:  91   Index: 254
+  Step  14: 7 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed: 108   Index:  32
+Watery Pass-North B1F                                                         Seed: 108   Index:  53
+  Step   9: 8 / CaveToad x4 (7.163s)
+  Step  29: 9 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 108   Index: 113
+  Step   1: 10 / SandMoth x2, Larva x2 (7.163s)
+  Step   3: 11 / Sandpede x1, Sand Man x2 (7.188s)
+Waterfalls B1F                                                                Seed: 108   Index: 122
+Waterfalls B2F                                                                Seed: 108   Index: 123
+  Step  13: 12 / Jelly x4 (7.324s)
+  Step  24: 13 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 108   Index: 168
+Battle: Octomamm                                                              Seed: 108   Index: 205
+Waterfalls Lake                                                               Seed: 108   Index: 205
+Overworld (Kaipo)                                                             Seed: 108   Index: 206
+Overworld (Damcyan)                                                           Seed: 108   Index: 217
+Damcyan                                                                       Seed: 108   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 108   Index: 228
+Antlion B1F                                                                   Seed: 108   Index: 228
+  Step   7: 14 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed: 125   Index:  10
+  Antlion B2F                                                                 Seed: 125   Index:  10
+    Step  13: 15 / Basilisk x1, Imp x3 (6.775s)
+    Step  70: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  76: 17 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 125   Index:  90
+Battle: Antlion                                                               Seed: 125   Index: 104
+Antlion's Nest                                                                Seed: 125   Index: 104
+  Step   8: 18 / Basilisk x1, Imp x3 (6.783s)
+Antlion B2F Outward Direct                                                    Seed: 125   Index: 119
+  Antlion B2F                                                                 Seed: 125   Index: 119
+    Step  36: 19 / SandWorm x2 (6.858s)
+    Step  41: 20 / SandWorm x2 (6.858s)
+    Step  58: 21 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 125   Index: 199
+  Step  10: 22 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 125   Index: 237
+Overworld (Kaipo)                                                             Seed: 125   Index: 237
+Kaipo Revisited                                                               Seed: 125   Index: 237
+Overworld (Kaipo)                                                             Seed: 125   Index: 237
+Overworld (Damcyan)                                                           Seed: 125   Index: 237
+Mt.Hobs-West                                                                  Seed: 125   Index: 237
+  Step  33: 23 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 142   Index:  20
+Battle: MomBomb                                                               Seed: 142   Index:  35
+Mt.Hobs Summit                                                                Seed: 142   Index:  35
+Mt.Hobs-East                                                                  Seed: 142   Index:  41
+  Step  30: 24 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 142   Index:  87
+  Step  23: 25 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  55: 26 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  65: 27 / Cocktric x3 (8.241s)
+  Step  81: 28 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 142   Index: 171
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed: 142   Index: 240
+Fabul Boat and Leviatan                                                       Seed: 142   Index: 247
+Overworld (Mysidia)                                                           Seed: 142   Index: 247
+Mysidia                                                                       Seed: 159   Index:   0
+Overworld (Mysidia)                                                           Seed: 159   Index:   0
+Overworld (Mt.Ordeals)                                                        Seed: 159   Index:  10
+  Step  15: 29 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  65: 30 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 159   Index: 104
+  Step   4: 31 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  34: 32 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 159   Index: 147
+  Step   7: 33 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed: 159   Index: 170
+Mt.Ordeals-3rd station                                                        Seed: 159   Index: 170
+Mt.Ordeals-7th station                                                        Seed: 159   Index: 175
+  Step  10: 34 / Revenant x1, Ghoul x3 (8.914s)
+  Step  36: 35 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 159   Index: 217
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 159   Index: 234
+Mt.Ordeals Summit                                                             Seed: 159   Index: 234
+Paladin                                                                       Seed: 159   Index: 238
+Mt.Ordeals Summit                                                             Seed: 159   Index: 238
+  Optional Steps: 1
+  Step  10: 36 / Lilith x1, Red Bone x2 (8.437s)
+  Step  22: 37 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed: 176   Index:   5
+  Step  37: 38 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 176   Index:  47
+Mt.Ordeals                                                                    Seed: 176   Index:  77
+  Extra Steps: 2
+  Step  45: 39 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 176   Index: 123
+Take Chocobo to Mysidia                                                       Seed: 176   Index: 136
+Overworld (Mysidia)                                                           Seed: 176   Index: 136
+Town of Baron Serpent Road                                                    Seed: 176   Index: 136
+  Extra Steps: 24
+Credit Warp Fight Search                                                      Seed: 176   Index: 164
+  Overworld (Baron)                                                           Seed: 176   Index: 164
+    Extra Steps: 6
+    Step   1: 40 / FloatEye x1, Eagle x2 (7.365s)
+    Step   6: 41 / Imp x6 (7.090s)
+   (Step  38: 42 / Imp x3)
+   (Step  70: 43 / Imp x3)
+   (Step 110: 44 / FloatEye x1, Eagle x2)
+   (Step 196: 45 / Imp x3)
+   (Step 198: 46 / Imp x3)
+   (Step 248: 47 / FloatEye x2)
+
+Encounter Time:      314.350s
+Other Time:          491.025s
+Total Time:          805.375s
+
+Base Total Time:     972.851s
+Time Saved:          167.476s
+
+Optional Steps:      10
+Extra Steps:         32
+Encounters:          41
+
+Base Encounters:     48
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/092.txt
+++ b/data/routes/cw/092.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	92
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49071625
+VARS	FFFFFFFF:4 C307801:1 E302500:77 E302600:10 E305400:104 E307400:8 E307B01:8 E308700:1 E308702:1 E309700:16
+
+Overworld (Kaipo)                                                             Seed:  92   Index:   0
+Overworld (Kaipo)                                                             Seed:  92   Index:   1
+  Step  19: 1 / Sand Man x4 (7.172s)
+  Step  31: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  92   Index:  37
+Overworld (Kaipo)                                                             Seed:  92   Index:  37
+  Step  13: 3 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  92   Index:  69
+Recruit Tellah                                                                Seed:  92   Index: 101
+Watery Pass-South B1F                                                         Seed:  92   Index: 101
+Watery Pass-South B2F                                                         Seed:  92   Index: 121
+  Step  84: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed:  92   Index: 211
+  Extra Steps: 104
+Watery Pass-South B2F                                                         Seed: 109   Index:  63
+  Step  19: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 109   Index: 102
+  Step  12: 6 / Pike x3 (7.152s)
+  Step  14: 7 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  34: 8 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 109   Index: 136
+Watery Pass-North B1F                                                         Seed: 109   Index: 157
+Overworld (Kaipo)                                                             Seed: 109   Index: 217
+Waterfalls B1F                                                                Seed: 109   Index: 226
+  Extra Steps: 8
+Waterfalls B2F                                                                Seed: 109   Index: 235
+  Step  44: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 126   Index:  24
+Battle: Octomamm                                                              Seed: 126   Index:  61
+Waterfalls Lake                                                               Seed: 126   Index:  61
+Overworld (Kaipo)                                                             Seed: 126   Index:  62
+Overworld (Damcyan)                                                           Seed: 126   Index:  73
+Damcyan                                                                       Seed: 126   Index:  77
+  Optional Steps: 1
+  Extra Steps: 76
+Overworld (Damcyan)                                                           Seed: 126   Index: 161
+Antlion B1F                                                                   Seed: 126   Index: 161
+Antlion B2F Inward Direct                                                     Seed: 126   Index: 199
+  Antlion B2F                                                                 Seed: 126   Index: 199
+    Step  10: 10 / Cream x4 (7.552s)
+    Step  16: 11 / Turtle x2 (7.487s)
+    Step  71: 12 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 143   Index:  23
+Battle: Antlion                                                               Seed: 143   Index:  37
+Antlion's Nest                                                                Seed: 143   Index:  37
+Antlion B2F Outward Charm Room Steps                                          Seed: 143   Index:  52
+  Antlion B2F                                                                 Seed: 143   Index:  52
+    Step  19: 13 / Basilisk x1, Imp x3 (6.783s)
+  Antlion B2F Treasure Room                                                   Seed: 143   Index: 103
+    Extra Steps: 8
+  Antlion B2F                                                                 Seed: 143   Index: 111
+    Step  31: 14 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed: 143   Index: 145
+  Step   7: 15 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  29: 16 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed: 143   Index: 183
+Overworld (Kaipo)                                                             Seed: 143   Index: 183
+Kaipo Revisited                                                               Seed: 143   Index: 183
+Overworld (Kaipo)                                                             Seed: 143   Index: 183
+Overworld (Damcyan)                                                           Seed: 143   Index: 183
+Mt.Hobs-West                                                                  Seed: 143   Index: 183
+Mt.Hobs Summit                                                                Seed: 143   Index: 222
+Battle: MomBomb                                                               Seed: 143   Index: 237
+Mt.Hobs Summit                                                                Seed: 143   Index: 237
+  Step   3: 17 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed: 143   Index: 243
+  Step  29: 18 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 160   Index:  33
+  Step  42: 19 / SwordRat x3, Needler x3 (7.663s)
+  Step  72: 20 / SwordRat x3, Needler x3 (7.663s)
+  Step  75: 21 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 160   Index: 117
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 160   Index: 187
+Fabul Boat and Leviatan                                                       Seed: 160   Index: 194
+Overworld (Mysidia)                                                           Seed: 160   Index: 194
+Mysidia                                                                       Seed: 160   Index: 203
+Overworld (Mysidia)                                                           Seed: 160   Index: 203
+  Step   8: 22 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 160   Index: 213
+  Step  35: 23 / Needler x2, SwordRat x2 (8.097s)
+  Step  47: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  52: 25 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  85: 26 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 177   Index:  51
+Mt.Ordeals-3rd station                                                        Seed: 177   Index:  94
+Recruit Tellah                                                                Seed: 177   Index: 117
+Mt.Ordeals-3rd station                                                        Seed: 177   Index: 117
+  Step   5: 27 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 177   Index: 122
+Mt.Ordeals Summit                                                             Seed: 177   Index: 164
+  Optional Steps: 1
+  Step   1: 28 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step   6: 29 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed: 177   Index: 182
+Mt.Ordeals Summit                                                             Seed: 177   Index: 182
+Paladin                                                                       Seed: 177   Index: 186
+Mt.Ordeals Summit                                                             Seed: 177   Index: 186
+  Optional Steps: 1
+  Step  16: 30 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed: 177   Index: 209
+  Step  25: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 177   Index: 251
+  Step  23: 32 / Ghoul x2, Soul x2 (8.971s)
+  Step  24: 33 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 194   Index:  25
+Overworld (Mt.Ordeals)                                                        Seed: 194   Index:  69
+Take Chocobo to Mysidia                                                       Seed: 194   Index:  82
+Overworld (Mysidia)                                                           Seed: 194   Index:  82
+Town of Baron Serpent Road                                                    Seed: 194   Index:  82
+  Extra Steps: 16
+Credit Warp Fight Search                                                      Seed: 194   Index: 102
+  Overworld (Baron)                                                           Seed: 194   Index: 102
+    Extra Steps: 4
+    Step   2: 34 / FloatEye x2 (7.230s)
+    Step   4: 35 / Imp x4 (7.223s)
+   (Step  54: 36 / Eagle x3)
+   (Step  82: 37 / Imp x4)
+   (Step 112: 38 / Eagle x3)
+   (Step 176: 39 / Imp x3, SwordRat x1)
+   (Step 238: 40 / FloatEye x1, Eagle x2)
+
+Encounter Time:      272.445s
+Other Time:          544.071s
+Total Time:          816.516s
+
+Base Total Time:     927.943s
+Time Saved:          111.427s
+
+Optional Steps:      13
+Extra Steps:         216
+Encounters:          35
+
+Base Encounters:     48
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/093.txt
+++ b/data/routes/cw/093.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	93
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50803477
+VARS	FFFFFFFF:8 C307801:1 E000501:6 E302500:92 E302600:26 E305400:30 E307000:34 E307200:20 E307400:12 E307B01:72 E308700:1 E308702:1 E309700:42
+
+Overworld (Kaipo)                                                             Seed:  93   Index:   0
+Overworld (Kaipo)                                                             Seed:  93   Index:   1
+  Step  19: 1 / Sand Man x4 (7.172s)
+  Step  31: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed:  93   Index:  37
+Overworld (Kaipo)                                                             Seed:  93   Index:  37
+  Step  13: 3 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed:  93   Index:  69
+Recruit Tellah                                                                Seed:  93   Index: 101
+Watery Pass-South B1F                                                         Seed:  93   Index: 101
+Watery Pass-South B2F                                                         Seed:  93   Index: 121
+  Step  27: 4 / Pike x3 (7.152s)
+  Step  84: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  93   Index: 211
+  Extra Steps: 30
+Watery Pass-South B2F                                                         Seed:  93   Index: 245
+  Extra Steps: 34
+  Step  44: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  73: 7 / Zombie x4 (7.148s)
+Watery Pass-South B3F                                                         Seed: 110   Index:  62
+  Step  20: 8 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 110   Index:  96
+  Extra Steps: 20
+  Step  18: 9 / Pike x2, EvilShel x2 (7.149s)
+  Step  20: 10 / Pike x3 (7.152s)
+  Step  40: 11 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 110   Index: 137
+Overworld (Kaipo)                                                             Seed: 110   Index: 197
+Waterfalls B1F                                                                Seed: 110   Index: 206
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed: 110   Index: 219
+Waterfalls Lake                                                               Seed: 127   Index:   8
+  Step  15: 12 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 127   Index:  45
+Waterfalls Lake                                                               Seed: 127   Index:  45
+Overworld (Kaipo)                                                             Seed: 127   Index:  46
+Overworld (Damcyan)                                                           Seed: 127   Index:  57
+Damcyan                                                                       Seed: 127   Index:  61
+  Optional Steps: 0
+  Extra Steps: 92
+Overworld (Damcyan)                                                           Seed: 127   Index: 160
+Antlion B1F                                                                   Seed: 127   Index: 160
+Antlion B2F Inward Direct                                                     Seed: 127   Index: 198
+  Antlion B2F                                                                 Seed: 127   Index: 198
+    Step  10: 13 / Basilisk x1, Imp x3 (6.775s)
+    Step  17: 14 / Basilisk x1, Turtle x1 (7.110s)
+    Step  72: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 144   Index:  22
+Battle: Antlion                                                               Seed: 144   Index:  36
+Antlion's Nest                                                                Seed: 144   Index:  36
+Antlion B2F Outward Charm Room Steps                                          Seed: 144   Index:  51
+  Antlion B2F                                                                 Seed: 144   Index:  51
+  Antlion B2F Treasure Room                                                   Seed: 144   Index: 102
+    Extra Steps: 72
+  Antlion B2F                                                                 Seed: 144   Index: 174
+Antlion B1F                                                                   Seed: 144   Index: 208
+  Step   8: 16 / Cream x4 (7.523s)
+  Step  32: 17 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 144   Index: 246
+Overworld (Kaipo)                                                             Seed: 144   Index: 246
+Kaipo Revisited                                                               Seed: 144   Index: 246
+Overworld (Kaipo)                                                             Seed: 144   Index: 246
+Overworld (Damcyan)                                                           Seed: 144   Index: 246
+Mt.Hobs-West                                                                  Seed: 144   Index: 246
+  Step  26: 18 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 161   Index:  29
+Battle: MomBomb                                                               Seed: 161   Index:  44
+Mt.Hobs Summit                                                                Seed: 161   Index:  44
+Mt.Hobs-East                                                                  Seed: 161   Index:  50
+  Step  25: 19 / GrayBomb x2, Bomb x4 (9.348s)
+Overworld (Fabul)                                                             Seed: 161   Index:  96
+  Step  12: 20 / SwordRat x3, Needler x3 (7.663s)
+  Step  42: 21 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  58: 22 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 161   Index: 180
+  Optional Steps: 10
+  Extra Steps: 16
+Overworld (Fabul)                                                             Seed: 178   Index:  10
+Fabul Boat and Leviatan                                                       Seed: 178   Index:  17
+Overworld (Mysidia)                                                           Seed: 178   Index:  17
+Mysidia                                                                       Seed: 178   Index:  26
+Overworld (Mysidia)                                                           Seed: 178   Index:  26
+  Extra Steps: 6
+  Step  15: 23 / Needler x2, SwordRat x2 (8.097s)
+Overworld (Mt.Ordeals)                                                        Seed: 178   Index:  42
+  Step  80: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 178   Index: 136
+  Step  29: 25 / Spirit x3, Soul x1 (8.687s)
+  Step  34: 26 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 178   Index: 179
+  Step  23: 27 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 178   Index: 202
+Mt.Ordeals-3rd station                                                        Seed: 178   Index: 202
+Mt.Ordeals-7th station                                                        Seed: 178   Index: 207
+  Step  27: 28 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 178   Index: 249
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 195   Index:  11
+Mt.Ordeals Summit                                                             Seed: 195   Index:  11
+Paladin                                                                       Seed: 195   Index:  15
+Mt.Ordeals Summit                                                             Seed: 195   Index:  15
+  Optional Steps: 1
+  Step   3: 29 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step   4: 30 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed: 195   Index:  38
+Mt.Ordeals-3rd station                                                        Seed: 195   Index:  80
+  Step  24: 31 / Zombie x2, Ghoul x2 (7.552s)
+  Step  26: 32 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed: 195   Index: 110
+Overworld (Mt.Ordeals)                                                        Seed: 195   Index: 154
+  Step   2: 33 / Imp Cap. x3, Needler x1 (7.897s)
+Take Chocobo to Mysidia                                                       Seed: 195   Index: 167
+Overworld (Mysidia)                                                           Seed: 195   Index: 167
+Town of Baron Serpent Road                                                    Seed: 195   Index: 167
+  Extra Steps: 42
+Credit Warp Fight Search                                                      Seed: 195   Index: 213
+  Overworld (Baron)                                                           Seed: 195   Index: 213
+    Extra Steps: 8
+    Step   1: 34 / FloatEye x2 (7.230s)
+    Step   8: 35 / Imp x4 (7.223s)
+   (Step  65: 36 / Eagle x3)
+   (Step 127: 37 / Imp x4)
+   (Step 144: 38 / Eagle x3)
+   (Step 182: 39 / Imp x3, SwordRat x1)
+   (Step 243: 40 / FloatEye x1, Eagle x2)
+   (Step 250: 41 / Imp x3)
+
+Encounter Time:      269.314s
+Other Time:          576.018s
+Total Time:          845.332s
+
+Base Total Time:     974.103s
+Time Saved:          128.771s
+
+Optional Steps:      12
+Extra Steps:         332
+Encounters:          35
+
+Base Encounters:     48
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/094.txt
+++ b/data/routes/cw/094.txt
@@ -1,0 +1,146 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	94
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	46756969
+VARS	FFFFFFFF:6 E302600:6 E305400:30
+
+Overworld (Kaipo)                                                             Seed:  94   Index:   0
+Overworld (Kaipo)                                                             Seed:  94   Index:   1
+  Step  19: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  94   Index:  37
+Overworld (Kaipo)                                                             Seed:  94   Index:  37
+  Step  13: 2 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  94   Index:  69
+Recruit Tellah                                                                Seed:  94   Index: 101
+Watery Pass-South B1F                                                         Seed:  94   Index: 101
+Watery Pass-South B2F                                                         Seed:  94   Index: 121
+  Step  27: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  60: 4 / Pike x3 (7.152s)
+  Step  84: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  94   Index: 211
+  Extra Steps: 30
+Watery Pass-South B2F                                                         Seed:  94   Index: 245
+Watery Pass-South B3F                                                         Seed: 111   Index:  28
+  Step   5: 6 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed: 111   Index:  62
+  Step  20: 7 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B1F                                                         Seed: 111   Index:  83
+  Step  31: 8 / CaveToad x4 (7.163s)
+  Step  33: 9 / Jelly x4 (7.324s)
+  Step  53: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 111   Index: 143
+Waterfalls B1F                                                                Seed: 111   Index: 152
+Waterfalls B2F                                                                Seed: 111   Index: 153
+Waterfalls Lake                                                               Seed: 111   Index: 198
+  Step  20: 11 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  28: 12 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 111   Index: 235
+Waterfalls Lake                                                               Seed: 111   Index: 235
+Overworld (Kaipo)                                                             Seed: 111   Index: 236
+Overworld (Damcyan)                                                           Seed: 111   Index: 247
+Damcyan                                                                       Seed: 111   Index: 251
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 128   Index:   2
+Antlion B1F                                                                   Seed: 128   Index:   2
+Antlion B2F Inward Direct                                                     Seed: 128   Index:  40
+  Antlion B2F                                                                 Seed: 128   Index:  40
+    Step   6: 13 / Basilisk x1, Imp x3 (6.775s)
+    Step  40: 14 / Basilisk x1, Turtle x1 (7.110s)
+    Step  46: 15 / Basilisk x1, Imp x3 (6.775s)
+    Step  72: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 128   Index: 120
+Battle: Antlion                                                               Seed: 128   Index: 134
+Antlion's Nest                                                                Seed: 128   Index: 134
+Antlion B2F Outward Direct                                                    Seed: 128   Index: 149
+  Antlion B2F                                                                 Seed: 128   Index: 149
+    Step   6: 17 / Cream x4 (7.523s)
+    Step  11: 18 / Basilisk x1, Imp x3 (6.783s)
+    Step  59: 19 / SandWorm x1, Sandpede x1 (6.848s)
+    Step  66: 20 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 128   Index: 229
+Overworld (Damcyan)                                                           Seed: 145   Index:  11
+Overworld (Kaipo)                                                             Seed: 145   Index:  11
+Kaipo Revisited                                                               Seed: 145   Index:  11
+Overworld (Kaipo)                                                             Seed: 145   Index:  11
+Overworld (Damcyan)                                                           Seed: 145   Index:  11
+Mt.Hobs-West                                                                  Seed: 145   Index:  11
+Mt.Hobs Summit                                                                Seed: 145   Index:  50
+Battle: MomBomb                                                               Seed: 145   Index:  65
+Mt.Hobs Summit                                                                Seed: 145   Index:  65
+Mt.Hobs-East                                                                  Seed: 145   Index:  71
+  Step  36: 21 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  39: 22 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 145   Index: 117
+  Step  25: 23 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  35: 24 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  57: 25 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 145   Index: 201
+  Optional Steps: 6
+Overworld (Fabul)                                                             Seed: 162   Index:  11
+  Step   5: 26 / Imp Cap. x3, Needler x1 (7.956s)
+Fabul Boat and Leviatan                                                       Seed: 162   Index:  18
+Overworld (Mysidia)                                                           Seed: 162   Index:  18
+Mysidia                                                                       Seed: 162   Index:  27
+Overworld (Mysidia)                                                           Seed: 162   Index:  27
+Overworld (Mt.Ordeals)                                                        Seed: 162   Index:  37
+  Step  38: 27 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  71: 28 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 162   Index: 131
+  Step   7: 29 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed: 162   Index: 174
+  Step  11: 30 / Revenant x1, Ghoul x3 (8.911s)
+  Step  22: 31 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed: 162   Index: 197
+Mt.Ordeals-3rd station                                                        Seed: 162   Index: 197
+Mt.Ordeals-7th station                                                        Seed: 162   Index: 202
+Mt.Ordeals Summit                                                             Seed: 162   Index: 244
+  Optional Steps: 0
+  Step   4: 32 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 179   Index:   5
+Mt.Ordeals Summit                                                             Seed: 179   Index:   5
+  Step   4: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.808s)
+Paladin                                                                       Seed: 179   Index:   9
+Mt.Ordeals Summit                                                             Seed: 179   Index:   9
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 179   Index:  31
+  Step  10: 34 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 179   Index:  73
+Mt.Ordeals                                                                    Seed: 179   Index: 103
+  Step  19: 35 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 179   Index: 147
+Take Chocobo to Mysidia                                                       Seed: 179   Index: 160
+Overworld (Mysidia)                                                           Seed: 179   Index: 160
+Town of Baron Serpent Road                                                    Seed: 179   Index: 160
+Credit Warp Fight Search                                                      Seed: 179   Index: 164
+  Overworld (Baron)                                                           Seed: 179   Index: 164
+    Extra Steps: 6
+    Step   1: 36 / Eagle x3 (7.417s)
+    Step   6: 37 / Imp x4 (7.223s)
+   (Step  23: 38 / Eagle x3)
+   (Step  38: 39 / Imp x3, SwordRat x1)
+   (Step  70: 40 / FloatEye x1, Eagle x2)
+   (Step 111: 41 / Imp x3)
+   (Step 195: 42 / Imp x3)
+   (Step 198: 43 / Imp x3)
+   (Step 248: 44 / FloatEye x1, Eagle x2)
+
+Encounter Time:      285.912s
+Other Time:          492.090s
+Total Time:          778.002s
+
+Base Total Time:     997.645s
+Time Saved:          219.643s
+
+Optional Steps:      6
+Extra Steps:         36
+Encounters:          37
+
+Base Encounters:     48
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/095.txt
+++ b/data/routes/cw/095.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	95
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47882471
+VARS	FFFFFFFF:18 E302500:1 E302600:40
+
+Overworld (Kaipo)                                                             Seed:  95   Index:   0
+Overworld (Kaipo)                                                             Seed:  95   Index:   1
+  Step  19: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  95   Index:  37
+Overworld (Kaipo)                                                             Seed:  95   Index:  37
+  Step   2: 2 / Sandpede x1, Sand Man x2 (7.096s)
+  Step  13: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  95   Index:  69
+Recruit Tellah                                                                Seed:  95   Index: 101
+Watery Pass-South B1F                                                         Seed:  95   Index: 101
+Watery Pass-South B2F                                                         Seed:  95   Index: 121
+  Step  27: 4 / Pike x3 (7.152s)
+  Step  60: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  84: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  95   Index: 211
+Watery Pass-South B2F                                                         Seed:  95   Index: 215
+  Step  15: 7 / Zombie x4 (7.148s)
+Watery Pass-South B3F                                                         Seed:  95   Index: 254
+Watery Pass-North B2F                                                         Seed: 112   Index:  32
+  Step   1: 8 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 112   Index:  53
+  Step  29: 9 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 112   Index: 113
+  Step   1: 10 / SandMoth x2, Larva x2 (7.163s)
+  Step   3: 11 / Sandpede x1, Sand Man x2 (7.188s)
+Waterfalls B1F                                                                Seed: 112   Index: 122
+Waterfalls B2F                                                                Seed: 112   Index: 123
+  Step  13: 12 / Jelly x4 (7.324s)
+  Step  43: 13 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 112   Index: 168
+Battle: Octomamm                                                              Seed: 112   Index: 205
+Waterfalls Lake                                                               Seed: 112   Index: 205
+Overworld (Kaipo)                                                             Seed: 112   Index: 206
+Overworld (Damcyan)                                                           Seed: 112   Index: 217
+  Step   1: 14 / SandWorm x1 (7.264s)
+Damcyan                                                                       Seed: 112   Index: 221
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 112   Index: 229
+Antlion B1F                                                                   Seed: 112   Index: 229
+Antlion B2F Inward Direct                                                     Seed: 129   Index:  11
+  Antlion B2F                                                                 Seed: 129   Index:  11
+    Step  35: 15 / Basilisk x1, Imp x3 (6.775s)
+    Step  69: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  75: 17 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 129   Index:  91
+Battle: Antlion                                                               Seed: 129   Index: 105
+Antlion's Nest                                                                Seed: 129   Index: 105
+  Step   7: 18 / Basilisk x1, Imp x3 (6.783s)
+Antlion B2F Outward Direct                                                    Seed: 129   Index: 120
+  Antlion B2F                                                                 Seed: 129   Index: 120
+    Step  40: 19 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed: 129   Index: 200
+  Step   8: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Step  15: 21 / Turtle x1, Imp x2 (7.009s)
+  Step  37: 22 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 129   Index: 238
+Overworld (Kaipo)                                                             Seed: 129   Index: 238
+Kaipo Revisited                                                               Seed: 129   Index: 238
+Overworld (Kaipo)                                                             Seed: 129   Index: 238
+Overworld (Damcyan)                                                           Seed: 129   Index: 238
+Mt.Hobs-West                                                                  Seed: 129   Index: 238
+Mt.Hobs Summit                                                                Seed: 146   Index:  21
+Battle: MomBomb                                                               Seed: 146   Index:  36
+Mt.Hobs Summit                                                                Seed: 146   Index:  36
+Mt.Hobs-East                                                                  Seed: 146   Index:  42
+  Step   3: 23 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 146   Index:  88
+  Step  19: 24 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  22: 25 / Cocktric x3 (8.241s)
+  Step  54: 26 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  64: 27 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 146   Index: 172
+  Optional Steps: 10
+  Extra Steps: 30
+Overworld (Fabul)                                                             Seed: 163   Index:  16
+Fabul Boat and Leviatan                                                       Seed: 163   Index:  23
+Overworld (Mysidia)                                                           Seed: 163   Index:  23
+Mysidia                                                                       Seed: 163   Index:  32
+Overworld (Mysidia)                                                           Seed: 163   Index:  32
+Overworld (Mt.Ordeals)                                                        Seed: 163   Index:  42
+  Step  33: 28 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  66: 29 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 163   Index: 136
+  Step   2: 30 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed: 163   Index: 179
+  Step  17: 31 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed: 163   Index: 202
+Mt.Ordeals-3rd station                                                        Seed: 163   Index: 202
+  Step   2: 32 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 163   Index: 207
+  Step  41: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 163   Index: 249
+  Optional Steps: 0
+  Step  16: 34 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed: 180   Index:  10
+Mt.Ordeals Summit                                                             Seed: 180   Index:  10
+Paladin                                                                       Seed: 180   Index:  14
+Mt.Ordeals Summit                                                             Seed: 180   Index:  14
+  Optional Steps: 0
+  Step   7: 35 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed: 180   Index:  36
+  Step   5: 36 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 180   Index:  78
+Mt.Ordeals                                                                    Seed: 180   Index: 108
+Overworld (Mt.Ordeals)                                                        Seed: 180   Index: 152
+  Step  13: 37 / Needler x2, SwordRat x2 (8.094s)
+Take Chocobo to Mysidia                                                       Seed: 180   Index: 165
+Overworld (Mysidia)                                                           Seed: 180   Index: 165
+Town of Baron Serpent Road                                                    Seed: 180   Index: 165
+Credit Warp Fight Search                                                      Seed: 180   Index: 169
+  Overworld (Baron)                                                           Seed: 180   Index: 169
+    Extra Steps: 18
+    Step   1: 38 / Eagle x3 (7.417s)
+    Step  18: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  33: 40 / FloatEye x1, Eagle x2)
+   (Step  65: 41 / Imp x3)
+   (Step 106: 42 / Imp x3)
+   (Step 190: 43 / Imp x3)
+   (Step 193: 44 / FloatEye x1, Eagle x2)
+   (Step 222: 45 / Imp x3)
+   (Step 243: 46 / FloatEye x2)
+
+Encounter Time:      298.250s
+Other Time:          498.479s
+Total Time:          796.729s
+
+Base Total Time:     987.996s
+Time Saved:          191.267s
+
+Optional Steps:      11
+Extra Steps:         48
+Encounters:          39
+
+Base Encounters:     48
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/096.txt
+++ b/data/routes/cw/096.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	96
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49427331
+VARS	FFFFFFFF:4 C307800:1 C307801:1 E302500:37 E302600:22 E305400:74 E307100:10 E307400:20 E307700:10 E307803:6 E307B00:22 E307B01:18 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  96   Index:   0
+Overworld (Kaipo)                                                             Seed:  96   Index:   1
+  Step  19: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed:  96   Index:  37
+Overworld (Kaipo)                                                             Seed:  96   Index:  37
+  Step   2: 2 / Sandpede x1, Sand Man x2 (7.096s)
+  Step  13: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  96   Index:  69
+Recruit Tellah                                                                Seed:  96   Index: 101
+Watery Pass-South B1F                                                         Seed:  96   Index: 101
+  Step   1: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed:  96   Index: 121
+  Step  27: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  60: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  84: 7 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed:  96   Index: 211
+  Extra Steps: 74
+Watery Pass-South B2F                                                         Seed: 113   Index:  33
+Watery Pass-South B3F                                                         Seed: 113   Index:  72
+  Extra Steps: 10
+  Step  10: 8 / Zombie x4 (7.148s)
+  Step  42: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed: 113   Index: 116
+Watery Pass-North B1F                                                         Seed: 113   Index: 137
+  Step  29: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 113   Index: 197
+Waterfalls B1F                                                                Seed: 113   Index: 206
+  Extra Steps: 20
+Waterfalls B2F                                                                Seed: 113   Index: 227
+Waterfalls Lake                                                               Seed: 130   Index:  16
+  Step  30: 11 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed: 130   Index:  53
+Waterfalls Lake                                                               Seed: 130   Index:  53
+Overworld (Kaipo)                                                             Seed: 130   Index:  54
+Overworld (Damcyan)                                                           Seed: 130   Index:  65
+Damcyan                                                                       Seed: 130   Index:  69
+  Optional Steps: 1
+  Extra Steps: 36
+Overworld (Damcyan)                                                           Seed: 130   Index: 113
+Antlion B1F                                                                   Seed: 130   Index: 113
+  Extra Steps: 10
+  Step  47: 12 / Imp x3 (6.649s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 130   Index: 161
+  Antlion B2F                                                                 Seed: 130   Index: 161
+  Antlion B2F Treasure Room                                                   Seed: 130   Index: 194
+    Extra Steps: 22
+  Antlion B2F                                                                 Seed: 130   Index: 216
+    Step  21: 13 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 147   Index:  12
+Battle: Antlion                                                               Seed: 147   Index:  26
+Antlion's Nest                                                                Seed: 147   Index:  26
+Antlion B2F Outward Charm Room Steps                                          Seed: 147   Index:  41
+  Antlion B2F                                                                 Seed: 147   Index:  41
+    Step   4: 14 / Basilisk x1, Turtle x1 (7.124s)
+  Antlion B2F Treasure Room                                                   Seed: 147   Index:  92
+    Extra Steps: 18
+  Antlion B2F                                                                 Seed: 147   Index: 110
+    Extra Steps: 6
+    Step  32: 15 / Basilisk x1, Imp x3 (6.783s)
+    Step  39: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 147   Index: 150
+  Step  24: 17 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 147   Index: 188
+Overworld (Kaipo)                                                             Seed: 147   Index: 188
+Kaipo Revisited                                                               Seed: 147   Index: 188
+Overworld (Kaipo)                                                             Seed: 147   Index: 188
+Overworld (Damcyan)                                                           Seed: 147   Index: 188
+Mt.Hobs-West                                                                  Seed: 147   Index: 188
+  Step  28: 18 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 147   Index: 227
+Battle: MomBomb                                                               Seed: 147   Index: 242
+Mt.Hobs Summit                                                                Seed: 147   Index: 242
+  Step   1: 19 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed: 147   Index: 248
+  Step  19: 20 / GrayBomb x2, Bomb x4 (9.348s)
+  Step  24: 21 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 164   Index:  38
+  Step  37: 22 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  70: 23 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed: 164   Index: 122
+  Optional Steps: 10
+  Extra Steps: 12
+Overworld (Fabul)                                                             Seed: 164   Index: 204
+Fabul Boat and Leviatan                                                       Seed: 164   Index: 211
+Overworld (Mysidia)                                                           Seed: 164   Index: 211
+Mysidia                                                                       Seed: 164   Index: 220
+Overworld (Mysidia)                                                           Seed: 164   Index: 220
+Overworld (Mt.Ordeals)                                                        Seed: 164   Index: 230
+  Step  18: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  35: 25 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  47: 26 / Raven x1 (8.356s)
+  Step  67: 27 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 181   Index:  68
+Mt.Ordeals-3rd station                                                        Seed: 181   Index: 111
+Recruit Tellah                                                                Seed: 181   Index: 134
+Mt.Ordeals-3rd station                                                        Seed: 181   Index: 134
+Mt.Ordeals-7th station                                                        Seed: 181   Index: 139
+  Step  31: 28 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 181   Index: 181
+  Optional Steps: 0
+  Step   6: 29 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 181   Index: 198
+Mt.Ordeals Summit                                                             Seed: 181   Index: 198
+  Step   4: 30 / Lilith x1, Red Bone x2 (8.744s)
+Paladin                                                                       Seed: 181   Index: 202
+Mt.Ordeals Summit                                                             Seed: 181   Index: 202
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 181   Index: 225
+  Step   9: 31 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  27: 32 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed: 198   Index:  11
+  Step   8: 33 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 198   Index:  41
+Overworld (Mt.Ordeals)                                                        Seed: 198   Index:  85
+Take Chocobo to Mysidia                                                       Seed: 198   Index:  98
+Overworld (Mysidia)                                                           Seed: 198   Index:  98
+Town of Baron Serpent Road                                                    Seed: 198   Index:  98
+Credit Warp Fight Search                                                      Seed: 198   Index: 102
+  Overworld (Baron)                                                           Seed: 198   Index: 102
+    Extra Steps: 4
+    Step   1: 34 / FloatEye x2 (7.230s)
+    Step   4: 35 / Imp x4 (7.223s)
+   (Step   7: 36 / Eagle x3)
+   (Step  33: 37 / Imp x4)
+   (Step  54: 38 / Eagle x3)
+   (Step 119: 39 / Imp x3, SwordRat x1)
+   (Step 176: 40 / FloatEye x1, Eagle x2)
+   (Step 255: 41 / Imp x3)
+
+Encounter Time:      274.836s
+Other Time:          547.598s
+Total Time:          822.434s
+
+Base Total Time:     971.625s
+Time Saved:          149.191s
+
+Optional Steps:      12
+Extra Steps:         212
+Encounters:          35
+
+Base Encounters:     48
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/097.txt
+++ b/data/routes/cw/097.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	97
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48969281
+VARS	FFFFFFFF:20 E000600:2 E302600:12 E305400:74 E307700:6 E307E00:8 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  97   Index:   0
+Overworld (Kaipo)                                                             Seed:  97   Index:   1
+Kaipo                                                                         Seed:  97   Index:  37
+Overworld (Kaipo)                                                             Seed:  97   Index:  37
+  Step   2: 1 / Sand Man x4 (7.242s)
+  Step  13: 2 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed:  97   Index:  69
+  Step  22: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed:  97   Index: 101
+Watery Pass-South B1F                                                         Seed:  97   Index: 101
+  Step   1: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed:  97   Index: 121
+  Step  27: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  60: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed:  97   Index: 211
+  Extra Steps: 74
+Watery Pass-South B2F                                                         Seed: 114   Index:  33
+  Step  16: 7 / Zombie x4 (7.148s)
+Watery Pass-South B3F                                                         Seed: 114   Index:  72
+Watery Pass-North B2F                                                         Seed: 114   Index: 106
+  Step   8: 8 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 114   Index: 127
+  Step  39: 9 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 114   Index: 187
+Waterfalls B1F                                                                Seed: 114   Index: 196
+Waterfalls B2F                                                                Seed: 114   Index: 197
+  Step  21: 10 / Jelly x4 (7.324s)
+  Step  29: 11 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 114   Index: 242
+Battle: Octomamm                                                              Seed: 131   Index:  23
+Waterfalls Lake                                                               Seed: 131   Index:  23
+Overworld (Kaipo)                                                             Seed: 131   Index:  24
+Overworld (Damcyan)                                                           Seed: 131   Index:  35
+Damcyan                                                                       Seed: 131   Index:  39
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 131   Index:  46
+Antlion B1F                                                                   Seed: 131   Index:  46
+  Extra Steps: 6
+  Step  33: 12 / Imp x3 (6.649s)
+  Step  44: 13 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 131   Index:  90
+  Antlion B2F                                                                 Seed: 131   Index:  90
+    Step  22: 14 / Basilisk x1, Turtle x1 (7.110s)
+    Step  70: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 131   Index: 170
+Battle: Antlion                                                               Seed: 131   Index: 184
+Antlion's Nest                                                                Seed: 131   Index: 184
+Antlion B2F Outward Direct                                                    Seed: 131   Index: 199
+  Antlion B2F                                                                 Seed: 131   Index: 199
+    Step   9: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  16: 17 / Cream x4 (7.523s)
+    Step  38: 18 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 148   Index:  23
+  Step  21: 19 / Imp x3 (6.648s)
+  Step  22: 20 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 148   Index:  61
+Overworld (Kaipo)                                                             Seed: 148   Index:  61
+Kaipo Revisited                                                               Seed: 148   Index:  61
+Overworld (Kaipo)                                                             Seed: 148   Index:  61
+Overworld (Damcyan)                                                           Seed: 148   Index:  61
+Mt.Hobs-West                                                                  Seed: 148   Index:  61
+  Extra Steps: 8
+  Step  46: 21 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed: 148   Index: 108
+Battle: MomBomb                                                               Seed: 148   Index: 123
+Mt.Hobs Summit                                                                Seed: 148   Index: 123
+Mt.Hobs-East                                                                  Seed: 148   Index: 129
+  Step  13: 22 / Spirit x2, Skelton x2 (8.237s)
+  Step  20: 23 / Gargoyle x2 (7.630s)
+  Step  45: 24 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 148   Index: 175
+  Step  41: 25 / Cocktric x3 (8.241s)
+  Step  68: 26 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 165   Index:   3
+  Optional Steps: 10
+  Extra Steps: 2
+Overworld (Fabul)                                                             Seed: 165   Index:  75
+Fabul Boat and Leviatan                                                       Seed: 165   Index:  82
+Overworld (Mysidia)                                                           Seed: 165   Index:  82
+Mysidia                                                                       Seed: 165   Index:  91
+Overworld (Mysidia)                                                           Seed: 165   Index:  91
+Overworld (Mt.Ordeals)                                                        Seed: 165   Index: 101
+  Extra Steps: 2
+  Step   7: 27 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  37: 28 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  88: 29 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  95: 30 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 165   Index: 197
+  Step   7: 31 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 165   Index: 240
+Recruit Tellah                                                                Seed: 182   Index:   7
+Mt.Ordeals-3rd station                                                        Seed: 182   Index:   7
+  Step   2: 32 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 182   Index:  12
+  Step   9: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  29: 34 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 182   Index:  54
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 182   Index:  72
+Mt.Ordeals Summit                                                             Seed: 182   Index:  72
+Paladin                                                                       Seed: 182   Index:  76
+Mt.Ordeals Summit                                                             Seed: 182   Index:  76
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 182   Index:  99
+Mt.Ordeals-3rd station                                                        Seed: 182   Index: 141
+  Step   4: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 182   Index: 171
+  Step  16: 36 / Soul x2, Red Bone x2 (8.881s)
+  Step  31: 37 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 182   Index: 215
+Take Chocobo to Mysidia                                                       Seed: 182   Index: 228
+Overworld (Mysidia)                                                           Seed: 182   Index: 228
+Town of Baron Serpent Road                                                    Seed: 182   Index: 228
+Credit Warp Fight Search                                                      Seed: 182   Index: 232
+  Overworld (Baron)                                                           Seed: 182   Index: 232
+    Extra Steps: 20
+    Step   2: 38 / Eagle x3 (7.417s)
+    Step  20: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  43: 40 / FloatEye x1, Eagle x2)
+   (Step 127: 41 / Imp x3)
+   (Step 133: 42 / Imp x3)
+   (Step 159: 43 / Imp x3)
+   (Step 180: 44 / FloatEye x1, Eagle x2)
+   (Step 223: 45 / FloatEye x2)
+   (Step 245: 46 / FloatEye x2)
+
+Encounter Time:      298.763s
+Other Time:          516.050s
+Total Time:          814.813s
+
+Base Total Time:     972.989s
+Time Saved:          158.177s
+
+Optional Steps:      12
+Extra Steps:         112
+Encounters:          39
+
+Base Encounters:     48
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/098.txt
+++ b/data/routes/cw/098.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	98
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48000076
+VARS	FFFFFFFF:16 C307800:1 E302500:1 E302600:18 E307B00:2 E308000:15 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  98   Index:   0
+Overworld (Kaipo)                                                             Seed:  98   Index:   1
+Kaipo                                                                         Seed:  98   Index:  37
+Overworld (Kaipo)                                                             Seed:  98   Index:  37
+  Step   2: 1 / Sand Man x4 (7.242s)
+  Step  13: 2 / Sandpede x1, Sand Man x2 (7.096s)
+  Step  14: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  98   Index:  69
+  Step  22: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  98   Index: 101
+Watery Pass-South B1F                                                         Seed:  98   Index: 101
+  Step   1: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  98   Index: 121
+  Step  27: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  60: 7 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed:  98   Index: 211
+Watery Pass-South B2F                                                         Seed:  98   Index: 215
+Watery Pass-South B3F                                                         Seed:  98   Index: 254
+  Step  19: 8 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 115   Index:  32
+  Step   1: 9 / Pike x2, EvilShel x2 (7.149s)
+  Step  17: 10 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed: 115   Index:  53
+  Step  35: 11 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 115   Index: 113
+  Step   1: 12 / SandMoth x2, Larva x2 (7.163s)
+Waterfalls B1F                                                                Seed: 115   Index: 122
+Waterfalls B2F                                                                Seed: 115   Index: 123
+  Step  43: 13 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 115   Index: 168
+Battle: Octomamm                                                              Seed: 115   Index: 205
+Waterfalls Lake                                                               Seed: 115   Index: 205
+Overworld (Kaipo)                                                             Seed: 115   Index: 206
+Overworld (Damcyan)                                                           Seed: 115   Index: 217
+  Step   1: 14 / SandWorm x1 (7.264s)
+Damcyan                                                                       Seed: 115   Index: 221
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 115   Index: 229
+Antlion B1F                                                                   Seed: 115   Index: 229
+Antlion B2F Inward Charm Room Steps                                           Seed: 132   Index:  11
+  Antlion B2F                                                                 Seed: 132   Index:  11
+  Antlion B2F Treasure Room                                                   Seed: 132   Index:  44
+    Extra Steps: 2
+  Antlion B2F                                                                 Seed: 132   Index:  46
+    Step  33: 15 / Basilisk x1, Imp x3 (6.775s)
+    Step  44: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 132   Index:  98
+  Step  13: 17 / Cream x4 (7.552s)
+Battle: Antlion                                                               Seed: 132   Index: 112
+Antlion's Nest                                                                Seed: 132   Index: 112
+Antlion B2F Outward Direct                                                    Seed: 132   Index: 127
+  Antlion B2F                                                                 Seed: 132   Index: 127
+    Step  33: 18 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 132   Index: 207
+  Step   1: 19 / Imp x3 (6.648s)
+  Step   8: 20 / Imp x3 (6.648s)
+  Step  30: 21 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 132   Index: 245
+Overworld (Kaipo)                                                             Seed: 132   Index: 245
+Kaipo Revisited                                                               Seed: 132   Index: 245
+Overworld (Kaipo)                                                             Seed: 132   Index: 245
+Overworld (Damcyan)                                                           Seed: 132   Index: 245
+Mt.Hobs-West                                                                  Seed: 132   Index: 245
+Mt.Hobs Summit                                                                Seed: 149   Index:  28
+Battle: MomBomb                                                               Seed: 149   Index:  43
+Mt.Hobs Summit                                                                Seed: 149   Index:  43
+  Step   1: 22 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step   2: 23 / Gargoyle x2 (7.630s)
+Mt.Hobs-East                                                                  Seed: 149   Index:  49
+  Extra Steps: 15
+  Step  34: 24 / Gargoyle x2 (7.630s)
+  Step  58: 25 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 149   Index: 110
+  Step  32: 26 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  39: 27 / Cocktric x3 (8.241s)
+  Step  64: 28 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 149   Index: 194
+  Optional Steps: 10
+  Extra Steps: 8
+Overworld (Fabul)                                                             Seed: 166   Index:  16
+Fabul Boat and Leviatan                                                       Seed: 166   Index:  23
+Overworld (Mysidia)                                                           Seed: 166   Index:  23
+Mysidia                                                                       Seed: 166   Index:  32
+Overworld (Mysidia)                                                           Seed: 166   Index:  32
+Overworld (Mt.Ordeals)                                                        Seed: 166   Index:  42
+  Step  33: 29 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 166   Index: 136
+  Step  35: 30 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed: 166   Index: 179
+  Step  10: 31 / Ghoul x2, Soul x2 (9.357s)
+  Step  17: 32 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 166   Index: 202
+Mt.Ordeals-3rd station                                                        Seed: 166   Index: 202
+  Step   2: 33 / Zombie x2, Ghoul x2 (7.616s)
+Mt.Ordeals-7th station                                                        Seed: 166   Index: 207
+Mt.Ordeals Summit                                                             Seed: 166   Index: 249
+  Optional Steps: 1
+  Step  16: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed: 183   Index:  11
+Mt.Ordeals Summit                                                             Seed: 183   Index:  11
+Paladin                                                                       Seed: 183   Index:  15
+Mt.Ordeals Summit                                                             Seed: 183   Index:  15
+  Optional Steps: 1
+  Step   6: 35 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed: 183   Index:  38
+  Step   3: 36 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 183   Index:  80
+Mt.Ordeals                                                                    Seed: 183   Index: 110
+  Step  35: 37 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 183   Index: 154
+Take Chocobo to Mysidia                                                       Seed: 183   Index: 167
+Overworld (Mysidia)                                                           Seed: 183   Index: 167
+Town of Baron Serpent Road                                                    Seed: 183   Index: 167
+Credit Warp Fight Search                                                      Seed: 183   Index: 171
+  Overworld (Baron)                                                           Seed: 183   Index: 171
+    Extra Steps: 16
+    Step   1: 38 / Eagle x3 (7.417s)
+    Step  16: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  81: 40 / FloatEye x1, Eagle x2)
+   (Step 104: 41 / Imp x3)
+   (Step 188: 42 / Imp x3)
+   (Step 194: 43 / Imp x3)
+   (Step 220: 44 / Imp x3, SwordRat x1)
+   (Step 236: 45 / FloatEye x2)
+
+Encounter Time:      297.744s
+Other Time:          500.942s
+Total Time:          798.686s
+
+Base Total Time:     850.509s
+Time Saved:          51.823s
+
+Optional Steps:      13
+Extra Steps:         41
+Encounters:          39
+
+Base Encounters:     44
+Encounters Saved:    5
+
+Number of Variables: 54

--- a/data/routes/cw/099.txt
+++ b/data/routes/cw/099.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	99
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48533503
+VARS	FFFFFFFF:16 C307800:1 E305400:2 E307B00:34 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed:  99   Index:   0
+Overworld (Kaipo)                                                             Seed:  99   Index:   1
+Kaipo                                                                         Seed:  99   Index:  37
+Overworld (Kaipo)                                                             Seed:  99   Index:  37
+  Step   2: 1 / SandMoth x2, Larva x2 (7.049s)
+  Step  13: 2 / Sandpede x1, Sand Man x2 (7.096s)
+  Step  14: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed:  99   Index:  69
+  Step  22: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed:  99   Index: 101
+Watery Pass-South B1F                                                         Seed:  99   Index: 101
+  Step   1: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed:  99   Index: 121
+  Step  27: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  60: 7 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed:  99   Index: 211
+  Extra Steps: 2
+Watery Pass-South B2F                                                         Seed:  99   Index: 217
+Watery Pass-South B3F                                                         Seed: 116   Index:   0
+  Step  17: 8 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 116   Index:  34
+  Step  15: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 116   Index:  55
+  Step   4: 10 / Zombie x4 (7.148s)
+  Step  33: 11 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 116   Index: 115
+Waterfalls B1F                                                                Seed: 116   Index: 124
+Waterfalls B2F                                                                Seed: 116   Index: 125
+  Step  41: 12 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 116   Index: 170
+Battle: Octomamm                                                              Seed: 116   Index: 207
+Waterfalls Lake                                                               Seed: 116   Index: 207
+Overworld (Kaipo)                                                             Seed: 116   Index: 208
+  Step  10: 13 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed: 116   Index: 219
+Damcyan                                                                       Seed: 116   Index: 223
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 116   Index: 230
+Antlion B1F                                                                   Seed: 116   Index: 230
+Antlion B2F Inward Charm Room Steps                                           Seed: 133   Index:  12
+  Antlion B2F                                                                 Seed: 133   Index:  12
+  Antlion B2F Treasure Room                                                   Seed: 133   Index:  45
+    Extra Steps: 34
+  Antlion B2F                                                                 Seed: 133   Index:  79
+    Step  11: 14 / Basilisk x1, Turtle x1 (7.110s)
+    Step  32: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 133   Index: 131
+Battle: Antlion                                                               Seed: 133   Index: 145
+Antlion's Nest                                                                Seed: 133   Index: 145
+Antlion B2F Outward Direct                                                    Seed: 133   Index: 160
+  Antlion B2F                                                                 Seed: 133   Index: 160
+    Step  48: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  55: 17 / Cream x4 (7.523s)
+    Step  77: 18 / Basilisk x1, Imp x3 (6.783s)
+    Step  78: 19 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed: 133   Index: 240
+Overworld (Damcyan)                                                           Seed: 150   Index:  22
+Overworld (Kaipo)                                                             Seed: 150   Index:  22
+Kaipo Revisited                                                               Seed: 150   Index:  22
+Overworld (Kaipo)                                                             Seed: 150   Index:  22
+Overworld (Damcyan)                                                           Seed: 150   Index:  22
+Mt.Hobs-West                                                                  Seed: 150   Index:  22
+  Step  22: 20 / Skelton x4 (8.683s)
+  Step  23: 21 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed: 150   Index:  61
+Battle: MomBomb                                                               Seed: 150   Index:  76
+Mt.Hobs Summit                                                                Seed: 150   Index:  76
+Mt.Hobs-East                                                                  Seed: 150   Index:  82
+  Step   1: 22 / Spirit x2, Skelton x2 (8.237s)
+  Step  25: 23 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 150   Index: 128
+  Step  14: 24 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  21: 25 / Cocktric x3 (8.241s)
+  Step  45: 26 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  46: 27 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 150   Index: 212
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 167   Index:  16
+Fabul Boat and Leviatan                                                       Seed: 167   Index:  23
+Overworld (Mysidia)                                                           Seed: 167   Index:  23
+Mysidia                                                                       Seed: 167   Index:  32
+Overworld (Mysidia)                                                           Seed: 167   Index:  32
+Overworld (Mt.Ordeals)                                                        Seed: 167   Index:  42
+  Step  33: 28 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  53: 29 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 167   Index: 136
+  Step  35: 30 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed: 167   Index: 179
+  Step  10: 31 / Ghoul x2, Soul x2 (9.357s)
+  Step  17: 32 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 167   Index: 202
+Mt.Ordeals-3rd station                                                        Seed: 167   Index: 202
+  Step   2: 33 / Zombie x2, Ghoul x2 (7.616s)
+Mt.Ordeals-7th station                                                        Seed: 167   Index: 207
+Mt.Ordeals Summit                                                             Seed: 167   Index: 249
+  Optional Steps: 1
+  Step  16: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed: 184   Index:  11
+Mt.Ordeals Summit                                                             Seed: 184   Index:  11
+Paladin                                                                       Seed: 184   Index:  15
+Mt.Ordeals Summit                                                             Seed: 184   Index:  15
+  Optional Steps: 1
+  Step   6: 35 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed: 184   Index:  38
+  Step   3: 36 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 184   Index:  80
+Mt.Ordeals                                                                    Seed: 184   Index: 110
+  Step  35: 37 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 184   Index: 154
+Take Chocobo to Mysidia                                                       Seed: 184   Index: 167
+Overworld (Mysidia)                                                           Seed: 184   Index: 167
+Town of Baron Serpent Road                                                    Seed: 184   Index: 167
+Credit Warp Fight Search                                                      Seed: 184   Index: 171
+  Overworld (Baron)                                                           Seed: 184   Index: 171
+    Extra Steps: 16
+    Step   1: 38 / Eagle x3 (7.417s)
+    Step  16: 39 / Imp x6 (7.090s)
+   (Step  62: 40 / FloatEye x1, Eagle x2)
+   (Step  81: 41 / Imp x3)
+   (Step  91: 42 / Imp x3)
+   (Step 188: 43 / Imp x3)
+   (Step 194: 44 / Imp x3, SwordRat x1)
+   (Step 220: 45 / FloatEye x2)
+   (Step 236: 46 / FloatEye x2)
+
+Encounter Time:      303.958s
+Other Time:          503.604s
+Total Time:          807.562s
+
+Base Total Time:     846.714s
+Time Saved:          39.152s
+
+Optional Steps:      2
+Extra Steps:         52
+Encounters:          39
+
+Base Encounters:     44
+Encounters Saved:    5
+
+Number of Variables: 54

--- a/data/routes/cw/100.txt
+++ b/data/routes/cw/100.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	100
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48699961
+VARS	FFFFFFFF:16 C307800:1 E305400:2 E307B00:34 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 100   Index:   0
+Overworld (Kaipo)                                                             Seed: 100   Index:   1
+Kaipo                                                                         Seed: 100   Index:  37
+Overworld (Kaipo)                                                             Seed: 100   Index:  37
+  Step   2: 1 / SandMoth x2, Larva x2 (7.049s)
+  Step  14: 2 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 100   Index:  69
+  Step  22: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 100   Index: 101
+Watery Pass-South B1F                                                         Seed: 100   Index: 101
+  Step   1: 4 / Pike x3 (7.152s)
+  Step  14: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 100   Index: 121
+  Step  60: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 100   Index: 211
+  Extra Steps: 2
+Watery Pass-South B2F                                                         Seed: 100   Index: 217
+Watery Pass-South B3F                                                         Seed: 117   Index:   0
+  Step  17: 7 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed: 117   Index:  34
+  Step  15: 8 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 117   Index:  55
+  Step   4: 9 / Jelly x4 (7.324s)
+  Step  33: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 117   Index: 115
+Waterfalls B1F                                                                Seed: 117   Index: 124
+Waterfalls B2F                                                                Seed: 117   Index: 125
+  Step  41: 11 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  44: 12 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 117   Index: 170
+Battle: Octomamm                                                              Seed: 117   Index: 207
+Waterfalls Lake                                                               Seed: 117   Index: 207
+Overworld (Kaipo)                                                             Seed: 117   Index: 208
+  Step  10: 13 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed: 117   Index: 219
+Damcyan                                                                       Seed: 117   Index: 223
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 117   Index: 230
+Antlion B1F                                                                   Seed: 117   Index: 230
+Antlion B2F Inward Charm Room Steps                                           Seed: 134   Index:  12
+  Antlion B2F                                                                 Seed: 134   Index:  12
+  Antlion B2F Treasure Room                                                   Seed: 134   Index:  45
+    Extra Steps: 34
+  Antlion B2F                                                                 Seed: 134   Index:  79
+    Step  11: 14 / Basilisk x1, Turtle x1 (7.110s)
+    Step  32: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 134   Index: 131
+Battle: Antlion                                                               Seed: 134   Index: 145
+Antlion's Nest                                                                Seed: 134   Index: 145
+Antlion B2F Outward Direct                                                    Seed: 134   Index: 160
+  Antlion B2F                                                                 Seed: 134   Index: 160
+    Step   8: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  48: 17 / Cream x4 (7.523s)
+    Step  77: 18 / Turtle x2 (7.464s)
+    Step  78: 19 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed: 134   Index: 240
+Overworld (Damcyan)                                                           Seed: 151   Index:  22
+Overworld (Kaipo)                                                             Seed: 151   Index:  22
+Kaipo Revisited                                                               Seed: 151   Index:  22
+Overworld (Kaipo)                                                             Seed: 151   Index:  22
+Overworld (Damcyan)                                                           Seed: 151   Index:  22
+Mt.Hobs-West                                                                  Seed: 151   Index:  22
+  Step  22: 20 / Skelton x4 (8.683s)
+  Step  23: 21 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed: 151   Index:  61
+Battle: MomBomb                                                               Seed: 151   Index:  76
+Mt.Hobs Summit                                                                Seed: 151   Index:  76
+Mt.Hobs-East                                                                  Seed: 151   Index:  82
+  Step   1: 22 / Spirit x2, Skelton x2 (8.237s)
+  Step  23: 23 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 151   Index: 128
+  Step  21: 24 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  45: 25 / Cocktric x3 (8.241s)
+  Step  46: 26 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 151   Index: 212
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 168   Index:  16
+Fabul Boat and Leviatan                                                       Seed: 168   Index:  23
+Overworld (Mysidia)                                                           Seed: 168   Index:  23
+Mysidia                                                                       Seed: 168   Index:  32
+Overworld (Mysidia)                                                           Seed: 168   Index:  32
+Overworld (Mt.Ordeals)                                                        Seed: 168   Index:  42
+  Step  33: 27 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  53: 28 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 168   Index: 136
+  Step  35: 29 / Spirit x3, Soul x1 (8.687s)
+  Step  40: 30 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed: 168   Index: 179
+  Step  10: 31 / Ghoul x2, Soul x2 (9.357s)
+  Step  17: 32 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 168   Index: 202
+Mt.Ordeals-3rd station                                                        Seed: 168   Index: 202
+  Step   2: 33 / Zombie x2, Ghoul x2 (7.616s)
+Mt.Ordeals-7th station                                                        Seed: 168   Index: 207
+Mt.Ordeals Summit                                                             Seed: 168   Index: 249
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 185   Index:  11
+Mt.Ordeals Summit                                                             Seed: 185   Index:  11
+Paladin                                                                       Seed: 185   Index:  15
+Mt.Ordeals Summit                                                             Seed: 185   Index:  15
+  Optional Steps: 1
+  Step   6: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 185   Index:  38
+  Step   3: 35 / Lilith x1 (8.563s)
+  Step  25: 36 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 185   Index:  80
+Mt.Ordeals                                                                    Seed: 185   Index: 110
+  Step  35: 37 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 185   Index: 154
+Take Chocobo to Mysidia                                                       Seed: 185   Index: 167
+Overworld (Mysidia)                                                           Seed: 185   Index: 167
+Town of Baron Serpent Road                                                    Seed: 185   Index: 167
+Credit Warp Fight Search                                                      Seed: 185   Index: 171
+  Overworld (Baron)                                                           Seed: 185   Index: 171
+    Extra Steps: 16
+    Step   1: 38 / Imp x4 (7.223s)
+    Step  16: 39 / Imp x6 (7.090s)
+   (Step  62: 40 / FloatEye x1, Eagle x2)
+   (Step  81: 41 / Imp x3)
+   (Step  91: 42 / Imp x3)
+   (Step 123: 43 / Imp x3)
+   (Step 188: 44 / Imp x3, SwordRat x1)
+   (Step 194: 45 / FloatEye x2)
+   (Step 220: 46 / FloatEye x2)
+   (Step 236: 47 / FloatEye x2)
+
+Encounter Time:      306.728s
+Other Time:          503.604s
+Total Time:          810.331s
+
+Base Total Time:     847.290s
+Time Saved:          36.959s
+
+Optional Steps:      2
+Extra Steps:         52
+Encounters:          39
+
+Base Encounters:     44
+Encounters Saved:    5
+
+Number of Variables: 54

--- a/data/routes/cw/101.txt
+++ b/data/routes/cw/101.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	101
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49259062
+VARS	FFFFFFFF:20 C307800:1 E305400:2 E307701:2 E307802:1 E307B00:34 E308700:1 E308702:1 E309700:58
+
+Overworld (Kaipo)                                                             Seed: 101   Index:   0
+Overworld (Kaipo)                                                             Seed: 101   Index:   1
+Kaipo                                                                         Seed: 101   Index:  37
+Overworld (Kaipo)                                                             Seed: 101   Index:  37
+  Step   2: 1 / SandMoth x2, Larva x2 (7.049s)
+  Step  14: 2 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 101   Index:  69
+  Step  22: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 101   Index: 101
+Watery Pass-South B1F                                                         Seed: 101   Index: 101
+  Step   1: 4 / Pike x3 (7.152s)
+  Step  14: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 101   Index: 121
+  Step  26: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 101   Index: 211
+  Extra Steps: 2
+Watery Pass-South B2F                                                         Seed: 101   Index: 217
+Watery Pass-South B3F                                                         Seed: 118   Index:   0
+  Step  17: 7 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed: 118   Index:  34
+  Step  15: 8 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B1F                                                         Seed: 118   Index:  55
+  Step   4: 9 / Jelly x4 (7.324s)
+  Step  33: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 118   Index: 115
+Waterfalls B1F                                                                Seed: 118   Index: 124
+Waterfalls B2F                                                                Seed: 118   Index: 125
+  Step  41: 11 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  44: 12 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 118   Index: 170
+  Step   7: 13 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed: 118   Index: 207
+Waterfalls Lake                                                               Seed: 118   Index: 207
+Overworld (Kaipo)                                                             Seed: 118   Index: 208
+Overworld (Damcyan)                                                           Seed: 118   Index: 219
+Damcyan                                                                       Seed: 118   Index: 223
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 118   Index: 230
+Antlion B1F                                                                   Seed: 118   Index: 230
+Antlion B2F Inward Charm Room Steps                                           Seed: 135   Index:  12
+  Antlion B2F                                                                 Seed: 135   Index:  12
+  Antlion B2F Treasure Room                                                   Seed: 135   Index:  45
+    Extra Steps: 34
+  Antlion B2F                                                                 Seed: 135   Index:  79
+    Step  11: 14 / Basilisk x1, Turtle x1 (7.110s)
+    Step  32: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 135   Index: 131
+Battle: Antlion                                                               Seed: 135   Index: 145
+Antlion's Nest                                                                Seed: 135   Index: 145
+Antlion B2F Outward Direct                                                    Seed: 135   Index: 160
+  Antlion B2F                                                                 Seed: 135   Index: 160
+    Extra Steps: 1
+    Step   8: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  38: 17 / Cream x4 (7.523s)
+    Step  77: 18 / Turtle x2 (7.464s)
+    Step  78: 19 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed: 135   Index: 241
+  Extra Steps: 2
+  Step  40: 20 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 152   Index:  25
+Overworld (Kaipo)                                                             Seed: 152   Index:  25
+Kaipo Revisited                                                               Seed: 152   Index:  25
+Overworld (Kaipo)                                                             Seed: 152   Index:  25
+Overworld (Damcyan)                                                           Seed: 152   Index:  25
+Mt.Hobs-West                                                                  Seed: 152   Index:  25
+  Step  19: 21 / Gargoyle x1, Cocktric x2 (9.399s)
+  Step  20: 22 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 152   Index:  64
+Battle: MomBomb                                                               Seed: 152   Index:  79
+Mt.Hobs Summit                                                                Seed: 152   Index:  79
+  Step   4: 23 / Gargoyle x2 (7.630s)
+Mt.Hobs-East                                                                  Seed: 152   Index:  85
+  Step  20: 24 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 152   Index: 131
+  Step  18: 25 / Cocktric x3 (8.241s)
+  Step  42: 26 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 152   Index: 215
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 169   Index:  19
+Fabul Boat and Leviatan                                                       Seed: 169   Index:  26
+Overworld (Mysidia)                                                           Seed: 169   Index:  26
+Mysidia                                                                       Seed: 169   Index:  35
+Overworld (Mysidia)                                                           Seed: 169   Index:  35
+Overworld (Mt.Ordeals)                                                        Seed: 169   Index:  45
+  Step  50: 27 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 169   Index: 139
+  Step  32: 28 / Spirit x3, Soul x1 (8.687s)
+  Step  37: 29 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 169   Index: 182
+  Step   7: 30 / Revenant x1, Ghoul x3 (8.911s)
+  Step  22: 31 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 169   Index: 205
+Mt.Ordeals-3rd station                                                        Seed: 169   Index: 205
+Mt.Ordeals-7th station                                                        Seed: 169   Index: 210
+  Step   9: 32 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 169   Index: 252
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 186   Index:  14
+Mt.Ordeals Summit                                                             Seed: 186   Index:  14
+Paladin                                                                       Seed: 186   Index:  18
+Mt.Ordeals Summit                                                             Seed: 186   Index:  18
+  Optional Steps: 1
+  Step   3: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  22: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 186   Index:  41
+  Step  22: 35 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed: 186   Index:  83
+Mt.Ordeals                                                                    Seed: 186   Index: 113
+  Step  32: 36 / Soul x2, Red Bone x2 (8.881s)
+Overworld (Mt.Ordeals)                                                        Seed: 186   Index: 157
+Take Chocobo to Mysidia                                                       Seed: 186   Index: 170
+Overworld (Mysidia)                                                           Seed: 186   Index: 170
+Town of Baron Serpent Road                                                    Seed: 186   Index: 170
+  Extra Steps: 58
+Credit Warp Fight Search                                                      Seed: 186   Index: 232
+  Overworld (Baron)                                                           Seed: 186   Index: 232
+    Extra Steps: 20
+    Step   1: 37 / Imp x3, SwordRat x1 (7.227s)
+    Step  20: 38 / Imp x4 (7.223s)
+   (Step  30: 39 / Imp x3)
+   (Step  62: 40 / FloatEye x1, Eagle x2)
+   (Step  94: 41 / Imp x3)
+   (Step 133: 42 / Imp x3)
+   (Step 159: 43 / Imp x3)
+   (Step 175: 44 / Imp x3, SwordRat x1)
+   (Step 223: 45 / FloatEye x2)
+
+Encounter Time:      297.395s
+Other Time:          522.240s
+Total Time:          819.635s
+
+Base Total Time:     847.925s
+Time Saved:          28.291s
+
+Optional Steps:      2
+Extra Steps:         117
+Encounters:          38
+
+Base Encounters:     44
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/102.txt
+++ b/data/routes/cw/102.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	102
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50247489
+VARS	FFFFFFFF:28 E302500:1 E302600:10 E307F01:4 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 102   Index:   0
+Overworld (Kaipo)                                                             Seed: 102   Index:   1
+Kaipo                                                                         Seed: 102   Index:  37
+Overworld (Kaipo)                                                             Seed: 102   Index:  37
+  Step   2: 1 / SandMoth x2, Larva x2 (7.049s)
+  Step  14: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 102   Index:  69
+  Step  22: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 102   Index: 101
+Watery Pass-South B1F                                                         Seed: 102   Index: 101
+  Step   1: 4 / Pike x3 (7.152s)
+  Step  14: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 102   Index: 121
+  Step  26: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 102   Index: 211
+Watery Pass-South B2F                                                         Seed: 102   Index: 215
+  Step   2: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  20: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 102   Index: 254
+  Step  19: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed: 119   Index:  32
+  Step  17: 10 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed: 119   Index:  53
+  Step   6: 11 / Jelly x4 (7.324s)
+  Step  35: 12 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 119   Index: 113
+Waterfalls B1F                                                                Seed: 119   Index: 122
+Waterfalls B2F                                                                Seed: 119   Index: 123
+  Step  43: 13 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 119   Index: 168
+  Step   1: 14 / Aligator x2 (7.544s)
+  Step   9: 15 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 119   Index: 205
+Waterfalls Lake                                                               Seed: 119   Index: 205
+Overworld (Kaipo)                                                             Seed: 119   Index: 206
+  Step   3: 16 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed: 119   Index: 217
+Damcyan                                                                       Seed: 119   Index: 221
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 119   Index: 229
+Antlion B1F                                                                   Seed: 119   Index: 229
+Antlion B2F Inward Direct                                                     Seed: 136   Index:  11
+  Antlion B2F                                                                 Seed: 136   Index:  11
+    Step  60: 17 / Basilisk x1, Imp x3 (6.775s)
+    Step  68: 18 / Turtle x2 (7.487s)
+    Step  79: 19 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 136   Index:  91
+Battle: Antlion                                                               Seed: 136   Index: 105
+Antlion's Nest                                                                Seed: 136   Index: 105
+  Step   6: 20 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed: 136   Index: 120
+  Antlion B2F                                                                 Seed: 136   Index: 120
+    Step  48: 21 / Turtle x2 (7.464s)
+    Step  78: 22 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed: 136   Index: 200
+  Step  37: 23 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Step  38: 24 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 136   Index: 238
+Overworld (Kaipo)                                                             Seed: 136   Index: 238
+Kaipo Revisited                                                               Seed: 136   Index: 238
+Overworld (Kaipo)                                                             Seed: 136   Index: 238
+Overworld (Damcyan)                                                           Seed: 136   Index: 238
+Mt.Hobs-West                                                                  Seed: 136   Index: 238
+Mt.Hobs Summit                                                                Seed: 153   Index:  21
+  Step   4: 25 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed: 153   Index:  36
+Mt.Hobs Summit                                                                Seed: 153   Index:  36
+  Extra Steps: 4
+  Step   8: 26 / Spirit x2 (7.652s)
+  Step   9: 27 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed: 153   Index:  46
+  Step  37: 28 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 153   Index:  92
+  Step  13: 29 / Cocktric x3 (8.241s)
+  Step  57: 30 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  81: 31 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 153   Index: 176
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 153   Index: 246
+Fabul Boat and Leviatan                                                       Seed: 153   Index: 253
+Overworld (Mysidia)                                                           Seed: 153   Index: 253
+  Step   8: 32 / Imp Cap. x4, Imp x2 (8.293s)
+Mysidia                                                                       Seed: 170   Index:   6
+Overworld (Mysidia)                                                           Seed: 170   Index:   6
+Overworld (Mt.Ordeals)                                                        Seed: 170   Index:  16
+  Step  26: 33 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  79: 34 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 170   Index: 110
+Mt.Ordeals-3rd station                                                        Seed: 170   Index: 153
+  Step  18: 35 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+  Step  23: 36 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed: 170   Index: 176
+Mt.Ordeals-3rd station                                                        Seed: 170   Index: 176
+Mt.Ordeals-7th station                                                        Seed: 170   Index: 181
+  Step   8: 37 / Soul x3, Ghoul x1, Revenant x1 (9.933s)
+  Step  23: 38 / Lilith x1 (8.745s)
+  Step  38: 39 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 170   Index: 223
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 170   Index: 240
+Mt.Ordeals Summit                                                             Seed: 170   Index: 240
+Paladin                                                                       Seed: 170   Index: 244
+Mt.Ordeals Summit                                                             Seed: 170   Index: 244
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 187   Index:  11
+  Step  10: 40 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  29: 41 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 187   Index:  53
+  Step  10: 42 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 187   Index:  83
+Overworld (Mt.Ordeals)                                                        Seed: 187   Index: 127
+Take Chocobo to Mysidia                                                       Seed: 187   Index: 140
+Overworld (Mysidia)                                                           Seed: 187   Index: 140
+Town of Baron Serpent Road                                                    Seed: 187   Index: 140
+Credit Warp Fight Search                                                      Seed: 187   Index: 144
+  Overworld (Baron)                                                           Seed: 187   Index: 144
+    Extra Steps: 28
+    Step   1: 43 / Imp x3 (7.174s)
+    Step  28: 44 / Imp x3, SwordRat x1 (7.227s)
+   (Step  47: 45 / FloatEye x2)
+   (Step  89: 46 / FloatEye x2)
+   (Step 108: 47 / FloatEye x2)
+   (Step 118: 48 / Imp x3, SwordRat x1)
+   (Step 150: 49 / Imp x3, SwordRat x1)
+   (Step 182: 50 / FloatEye x1, Eagle x2)
+   (Step 221: 51 / FloatEye x1, Eagle x2)
+
+Encounter Time:      339.200s
+Other Time:          496.882s
+Total Time:          836.081s
+
+Base Total Time:     845.309s
+Time Saved:          9.228s
+
+Optional Steps:      12
+Extra Steps:         32
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/103.txt
+++ b/data/routes/cw/103.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	103
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48108169
+VARS	FFFFFFFF:20 C307801:1 E302600:8 E305400:20 E307000:6 E307B01:2 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 103   Index:   0
+Overworld (Kaipo)                                                             Seed: 103   Index:   1
+  Step  11: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 103   Index:  37
+Overworld (Kaipo)                                                             Seed: 103   Index:  37
+  Step  14: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 103   Index:  69
+  Step  22: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 103   Index: 101
+Watery Pass-South B1F                                                         Seed: 103   Index: 101
+  Step  14: 4 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 103   Index: 121
+  Step  26: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 103   Index: 211
+  Extra Steps: 20
+Watery Pass-South B2F                                                         Seed: 103   Index: 235
+  Extra Steps: 6
+  Step  44: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 120   Index:  24
+  Step  25: 7 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed: 120   Index:  58
+  Step   1: 8 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B1F                                                         Seed: 120   Index:  79
+  Step   9: 9 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 120   Index: 139
+Waterfalls B1F                                                                Seed: 120   Index: 148
+Waterfalls B2F                                                                Seed: 120   Index: 149
+  Step  20: 10 / Jelly x4 (7.324s)
+  Step  28: 11 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 120   Index: 194
+  Step  15: 12 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 120   Index: 231
+Waterfalls Lake                                                               Seed: 120   Index: 231
+Overworld (Kaipo)                                                             Seed: 120   Index: 232
+Overworld (Damcyan)                                                           Seed: 120   Index: 243
+Damcyan                                                                       Seed: 120   Index: 247
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 120   Index: 254
+Antlion B1F                                                                   Seed: 120   Index: 254
+  Step  16: 13 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 137   Index:  36
+  Antlion B2F                                                                 Seed: 137   Index:  36
+    Step  35: 14 / Basilisk x1, Turtle x1 (7.110s)
+    Step  43: 15 / Basilisk x1, Imp x3 (6.775s)
+    Step  54: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  75: 17 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 137   Index: 116
+Battle: Antlion                                                               Seed: 137   Index: 130
+Antlion's Nest                                                                Seed: 137   Index: 130
+Antlion B2F Outward Charm Room Steps                                          Seed: 137   Index: 145
+  Antlion B2F                                                                 Seed: 137   Index: 145
+    Step  23: 18 / Turtle x2 (7.464s)
+  Antlion B2F Treasure Room                                                   Seed: 137   Index: 196
+    Extra Steps: 2
+  Antlion B2F                                                                 Seed: 137   Index: 198
+Antlion B1F                                                                   Seed: 137   Index: 232
+  Step   6: 19 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 154   Index:  14
+Overworld (Kaipo)                                                             Seed: 154   Index:  14
+Kaipo Revisited                                                               Seed: 154   Index:  14
+Overworld (Kaipo)                                                             Seed: 154   Index:  14
+Overworld (Damcyan)                                                           Seed: 154   Index:  14
+Mt.Hobs-West                                                                  Seed: 154   Index:  14
+  Step  11: 20 / Skelton x4 (8.683s)
+  Step  30: 21 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed: 154   Index:  53
+Battle: MomBomb                                                               Seed: 154   Index:  68
+Mt.Hobs Summit                                                                Seed: 154   Index:  68
+Mt.Hobs-East                                                                  Seed: 154   Index:  74
+  Step   9: 22 / Spirit x2, Skelton x2 (8.237s)
+  Step  31: 23 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 154   Index: 120
+  Step  29: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  34: 25 / Cocktric x3 (8.241s)
+  Step  53: 26 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 154   Index: 204
+  Optional Steps: 8
+Overworld (Fabul)                                                             Seed: 171   Index:  16
+Fabul Boat and Leviatan                                                       Seed: 171   Index:  23
+Overworld (Mysidia)                                                           Seed: 171   Index:  23
+Mysidia                                                                       Seed: 171   Index:  32
+Overworld (Mysidia)                                                           Seed: 171   Index:  32
+  Step  10: 27 / Imp Cap. x4, Imp x2 (8.344s)
+Overworld (Mt.Ordeals)                                                        Seed: 171   Index:  42
+  Step  53: 28 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 171   Index: 136
+  Step  35: 29 / Spirit x3, Soul x1 (8.687s)
+  Step  40: 30 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed: 171   Index: 179
+  Step  10: 31 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 171   Index: 202
+Mt.Ordeals-3rd station                                                        Seed: 171   Index: 202
+Mt.Ordeals-7th station                                                        Seed: 171   Index: 207
+  Step  12: 32 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 171   Index: 249
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 188   Index:  11
+Mt.Ordeals Summit                                                             Seed: 188   Index:  11
+Paladin                                                                       Seed: 188   Index:  15
+Mt.Ordeals Summit                                                             Seed: 188   Index:  15
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 188   Index:  38
+  Step   2: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  25: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 188   Index:  80
+  Step  24: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 188   Index: 110
+  Step  35: 36 / Soul x2, Red Bone x2 (8.881s)
+Overworld (Mt.Ordeals)                                                        Seed: 188   Index: 154
+Take Chocobo to Mysidia                                                       Seed: 188   Index: 167
+Overworld (Mysidia)                                                           Seed: 188   Index: 167
+Town of Baron Serpent Road                                                    Seed: 188   Index: 167
+Credit Warp Fight Search                                                      Seed: 188   Index: 171
+  Overworld (Baron)                                                           Seed: 188   Index: 171
+    Extra Steps: 20
+    Step   1: 37 / Imp x3, SwordRat x1 (7.227s)
+    Step  20: 38 / Imp x4 (7.223s)
+   (Step  62: 39 / Imp x3)
+   (Step  91: 40 / FloatEye x1, Eagle x2)
+   (Step 123: 41 / Imp x3)
+   (Step 155: 42 / Imp x3)
+   (Step 219: 43 / Imp x3)
+   (Step 236: 44 / Imp x3, SwordRat x1)
+
+Encounter Time:      296.881s
+Other Time:          503.604s
+Total Time:          800.485s
+
+Base Total Time:     878.782s
+Time Saved:          78.297s
+
+Optional Steps:      10
+Extra Steps:         48
+Encounters:          38
+
+Base Encounters:     44
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/104.txt
+++ b/data/routes/cw/104.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	104
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48960873
+VARS	FFFFFFFF:30 C307801:1 E302500:1 E302600:10 E305400:20 E307400:34 E307803:6 E307900:10 E307B01:6 E308700:1 E308702:1 E309700:10
+
+Overworld (Kaipo)                                                             Seed: 104   Index:   0
+Overworld (Kaipo)                                                             Seed: 104   Index:   1
+  Step  11: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 104   Index:  37
+Overworld (Kaipo)                                                             Seed: 104   Index:  37
+  Step  14: 2 / Imp x4 (6.944s)
+  Step  25: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 104   Index:  69
+Recruit Tellah                                                                Seed: 104   Index: 101
+Watery Pass-South B1F                                                         Seed: 104   Index: 101
+  Step  14: 4 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 104   Index: 121
+  Step  26: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 104   Index: 211
+  Extra Steps: 20
+Watery Pass-South B2F                                                         Seed: 104   Index: 235
+Watery Pass-South B3F                                                         Seed: 121   Index:  18
+  Step   5: 6 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 121   Index:  52
+  Step   7: 7 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed: 121   Index:  73
+  Step  15: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 121   Index: 133
+Waterfalls B1F                                                                Seed: 121   Index: 142
+  Extra Steps: 34
+Waterfalls B2F                                                                Seed: 121   Index: 177
+  Step  32: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 121   Index: 222
+Battle: Octomamm                                                              Seed: 138   Index:   3
+Waterfalls Lake                                                               Seed: 138   Index:   3
+Overworld (Kaipo)                                                             Seed: 138   Index:   4
+  Step  10: 10 / SandMoth x2, Larva x2 (7.188s)
+Overworld (Damcyan)                                                           Seed: 138   Index:  15
+Damcyan                                                                       Seed: 138   Index:  19
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 138   Index:  27
+Antlion B1F                                                                   Seed: 138   Index:  27
+Antlion B2F Inward Direct                                                     Seed: 138   Index:  65
+  Antlion B2F                                                                 Seed: 138   Index:  65
+    Step   6: 11 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  14: 12 / Basilisk x1, Imp x3 (6.775s)
+    Step  46: 13 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 138   Index: 145
+  Extra Steps: 10
+  Step  23: 14 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 138   Index: 169
+Antlion's Nest                                                                Seed: 138   Index: 169
+Antlion B2F Outward Charm Room Steps                                          Seed: 138   Index: 184
+  Antlion B2F                                                                 Seed: 138   Index: 184
+    Step  14: 15 / Basilisk x1, Imp x3 (6.783s)
+  Antlion B2F Treasure Room                                                   Seed: 138   Index: 235
+    Extra Steps: 6
+  Antlion B2F                                                                 Seed: 138   Index: 241
+    Extra Steps: 6
+    Step  40: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 155   Index:  25
+  Step  19: 17 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 155   Index:  63
+Overworld (Kaipo)                                                             Seed: 155   Index:  63
+Kaipo Revisited                                                               Seed: 155   Index:  63
+Overworld (Kaipo)                                                             Seed: 155   Index:  63
+Overworld (Damcyan)                                                           Seed: 155   Index:  63
+Mt.Hobs-West                                                                  Seed: 155   Index:  63
+  Step  20: 18 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed: 155   Index: 102
+  Step   3: 19 / Gargoyle x1, Cocktric x2 (9.399s)
+Battle: MomBomb                                                               Seed: 155   Index: 117
+Mt.Hobs Summit                                                                Seed: 155   Index: 117
+Mt.Hobs-East                                                                  Seed: 155   Index: 123
+  Step  31: 20 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 155   Index: 169
+  Step   4: 21 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  16: 22 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  42: 23 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed: 155   Index: 253
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 172   Index:  67
+Fabul Boat and Leviatan                                                       Seed: 172   Index:  74
+Overworld (Mysidia)                                                           Seed: 172   Index:  74
+Mysidia                                                                       Seed: 172   Index:  83
+Overworld (Mysidia)                                                           Seed: 172   Index:  83
+Overworld (Mt.Ordeals)                                                        Seed: 172   Index:  93
+  Step   2: 24 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  29: 25 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  78: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  83: 27 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 172   Index: 187
+  Step  32: 28 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 172   Index: 230
+Recruit Tellah                                                                Seed: 172   Index: 253
+Mt.Ordeals-3rd station                                                        Seed: 172   Index: 253
+Mt.Ordeals-7th station                                                        Seed: 189   Index:   2
+  Step  16: 29 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  38: 30 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 189   Index:  44
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 189   Index:  62
+Mt.Ordeals Summit                                                             Seed: 189   Index:  62
+  Step   1: 31 / Soul x2, Ghoul x2, Revenant x2 (10.046s)
+Paladin                                                                       Seed: 189   Index:  66
+Mt.Ordeals Summit                                                             Seed: 189   Index:  66
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 189   Index:  89
+  Step  15: 32 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 189   Index: 131
+  Step  14: 33 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 189   Index: 161
+  Step  11: 34 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+  Step  30: 35 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 189   Index: 205
+Take Chocobo to Mysidia                                                       Seed: 189   Index: 218
+Overworld (Mysidia)                                                           Seed: 189   Index: 218
+Town of Baron Serpent Road                                                    Seed: 189   Index: 218
+  Extra Steps: 10
+Credit Warp Fight Search                                                      Seed: 189   Index: 232
+  Overworld (Baron)                                                           Seed: 189   Index: 232
+    Extra Steps: 30
+    Step   1: 36 / Eagle x3 (7.417s)
+    Step  30: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step  62: 38 / Imp x4)
+   (Step  94: 39 / Imp x3)
+   (Step 158: 40 / FloatEye x1, Eagle x2)
+   (Step 175: 41 / Imp x3)
+
+Encounter Time:      290.303s
+Other Time:          524.370s
+Total Time:          814.673s
+
+Base Total Time:     885.060s
+Time Saved:          70.387s
+
+Optional Steps:      13
+Extra Steps:         116
+Encounters:          37
+
+Base Encounters:     44
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/105.txt
+++ b/data/routes/cw/105.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	105
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50866760
+VARS	FFFFFFFF:24 E000202:2 E000302:2 E302600:26 E308401:2 E308700:1 E308702:1 E309700:28
+
+Overworld (Kaipo)                                                             Seed: 105   Index:   0
+Overworld (Kaipo)                                                             Seed: 105   Index:   1
+  Step  11: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 105   Index:  37
+Overworld (Kaipo)                                                             Seed: 105   Index:  37
+  Step  14: 2 / Imp x4 (6.944s)
+  Step  25: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 105   Index:  69
+Recruit Tellah                                                                Seed: 105   Index: 101
+Watery Pass-South B1F                                                         Seed: 105   Index: 101
+  Step  14: 4 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 105   Index: 121
+  Step  15: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  26: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 105   Index: 211
+Watery Pass-South B2F                                                         Seed: 105   Index: 215
+  Step   2: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  20: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 105   Index: 254
+  Step  25: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed: 122   Index:  32
+Watery Pass-North B1F                                                         Seed: 122   Index:  53
+  Step   6: 10 / Zombie x4 (7.148s)
+  Step  33: 11 / CaveToad x4 (7.163s)
+  Step  35: 12 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 122   Index: 113
+Waterfalls B1F                                                                Seed: 122   Index: 122
+Waterfalls B2F                                                                Seed: 122   Index: 123
+  Step  32: 13 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 122   Index: 168
+  Step   1: 14 / Aligator x2 (7.544s)
+  Step   9: 15 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 122   Index: 205
+Waterfalls Lake                                                               Seed: 122   Index: 205
+Overworld (Kaipo)                                                             Seed: 122   Index: 206
+  Step   3: 16 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed: 122   Index: 217
+Damcyan                                                                       Seed: 122   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 122   Index: 228
+Antlion B1F                                                                   Seed: 122   Index: 228
+Antlion B2F Inward Direct                                                     Seed: 139   Index:  10
+  Antlion B2F                                                                 Seed: 139   Index:  10
+    Step   4: 17 / Basilisk x1, Imp x3 (6.775s)
+    Step  61: 18 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 139   Index:  90
+Battle: Antlion                                                               Seed: 139   Index: 104
+Antlion's Nest                                                                Seed: 139   Index: 104
+  Step   7: 19 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed: 139   Index: 119
+  Antlion B2F                                                                 Seed: 139   Index: 119
+    Step  33: 20 / Cream x4 (7.523s)
+    Step  49: 21 / Turtle x2 (7.464s)
+    Step  79: 22 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed: 139   Index: 199
+Overworld (Damcyan)                                                           Seed: 139   Index: 237
+  Extra Steps: 2
+  Step   1: 23 / SandWorm x2 (7.125s)
+Overworld (Kaipo)                                                             Seed: 139   Index: 239
+  Extra Steps: 2
+  Step   1: 24 / Sandpede x1, Sand Man x2 (7.135s)
+Kaipo Revisited                                                               Seed: 139   Index: 241
+Overworld (Kaipo)                                                             Seed: 139   Index: 241
+Overworld (Damcyan)                                                           Seed: 139   Index: 241
+Mt.Hobs-West                                                                  Seed: 139   Index: 241
+Mt.Hobs Summit                                                                Seed: 156   Index:  24
+  Step   1: 25 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed: 156   Index:  39
+Mt.Hobs Summit                                                                Seed: 156   Index:  39
+Mt.Hobs-East                                                                  Seed: 156   Index:  45
+  Step  38: 26 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 156   Index:  91
+  Step  14: 27 / Cocktric x3 (8.241s)
+  Step  17: 28 / Cocktric x3 (8.241s)
+  Step  58: 29 / Cocktric x3 (8.241s)
+  Step  63: 30 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  82: 31 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 156   Index: 175
+  Optional Steps: 10
+  Extra Steps: 16
+Overworld (Fabul)                                                             Seed: 173   Index:   5
+Fabul Boat and Leviatan                                                       Seed: 173   Index:  12
+Overworld (Mysidia)                                                           Seed: 173   Index:  12
+Mysidia                                                                       Seed: 173   Index:  21
+Overworld (Mysidia)                                                           Seed: 173   Index:  21
+Overworld (Mt.Ordeals)                                                        Seed: 173   Index:  31
+  Step  11: 32 / Raven x1 (8.356s)
+  Step  64: 33 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  91: 34 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 173   Index: 125
+  Step  40: 35 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 173   Index: 168
+  Step   3: 36 / Revenant x1, Ghoul x3 (8.911s)
+  Step   8: 37 / Lilith x1, Red Bone x2 (9.259s)
+Recruit Tellah                                                                Seed: 173   Index: 191
+Mt.Ordeals-3rd station                                                        Seed: 173   Index: 191
+Mt.Ordeals-7th station                                                        Seed: 173   Index: 196
+  Step  23: 38 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 173   Index: 238
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 190   Index:   0
+Mt.Ordeals Summit                                                             Seed: 190   Index:   0
+Paladin                                                                       Seed: 190   Index:   4
+Mt.Ordeals Summit                                                             Seed: 190   Index:   4
+  Optional Steps: 1
+  Step  14: 39 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed: 190   Index:  27
+  Step  13: 40 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  36: 41 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 190   Index:  69
+Mt.Ordeals                                                                    Seed: 190   Index:  99
+  Extra Steps: 2
+  Step   5: 42 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 190   Index: 145
+Take Chocobo to Mysidia                                                       Seed: 190   Index: 158
+Overworld (Mysidia)                                                           Seed: 190   Index: 158
+Town of Baron Serpent Road                                                    Seed: 190   Index: 158
+  Extra Steps: 28
+Credit Warp Fight Search                                                      Seed: 190   Index: 190
+  Overworld (Baron)                                                           Seed: 190   Index: 190
+    Extra Steps: 24
+    Step   1: 43 / Imp x3 (7.174s)
+    Step  24: 44 / Imp x3, SwordRat x1 (7.227s)
+   (Step  43: 45 / FloatEye x2)
+   (Step  72: 46 / FloatEye x2)
+   (Step 104: 47 / FloatEye x2)
+   (Step 136: 48 / Imp x3, SwordRat x1)
+   (Step 200: 49 / Imp x3, SwordRat x1)
+
+Encounter Time:      339.387s
+Other Time:          506.998s
+Total Time:          846.385s
+
+Base Total Time:     945.632s
+Time Saved:          99.247s
+
+Optional Steps:      12
+Extra Steps:         74
+Encounters:          44
+
+Base Encounters:     48
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/106.txt
+++ b/data/routes/cw/106.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	106
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47556063
+VARS	FFFFFFFF:8 E305400:20 E307000:6 E307100:2 E307400:18 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed: 106   Index:   0
+Overworld (Kaipo)                                                             Seed: 106   Index:   1
+  Step  11: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 106   Index:  37
+Overworld (Kaipo)                                                             Seed: 106   Index:  37
+  Step  25: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 106   Index:  69
+Recruit Tellah                                                                Seed: 106   Index: 101
+Watery Pass-South B1F                                                         Seed: 106   Index: 101
+  Step  14: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  15: 4 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 106   Index: 121
+  Step  15: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  26: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 106   Index: 211
+  Extra Steps: 20
+Watery Pass-South B2F                                                         Seed: 106   Index: 235
+  Extra Steps: 6
+  Step  44: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 123   Index:  24
+  Extra Steps: 2
+Watery Pass-North B2F                                                         Seed: 123   Index:  60
+  Step  20: 8 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B1F                                                         Seed: 123   Index:  81
+  Step   5: 9 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 123   Index: 141
+Waterfalls B1F                                                                Seed: 123   Index: 150
+  Extra Steps: 18
+Waterfalls B2F                                                                Seed: 123   Index: 169
+  Step   8: 10 / Jelly x4 (7.324s)
+  Step  40: 11 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 123   Index: 214
+Battle: Octomamm                                                              Seed: 123   Index: 251
+Waterfalls Lake                                                               Seed: 123   Index: 251
+Overworld (Kaipo)                                                             Seed: 123   Index: 252
+Overworld (Damcyan)                                                           Seed: 140   Index:   7
+Damcyan                                                                       Seed: 140   Index:  11
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 140   Index:  18
+Antlion B1F                                                                   Seed: 140   Index:  18
+Antlion B2F Inward Direct                                                     Seed: 140   Index:  56
+  Antlion B2F                                                                 Seed: 140   Index:  56
+    Step  15: 12 / Basilisk x1, Imp x3 (6.775s)
+    Step  54: 13 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 140   Index: 136
+Battle: Antlion                                                               Seed: 140   Index: 150
+Antlion's Nest                                                                Seed: 140   Index: 150
+  Step   2: 14 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B2F Outward Direct                                                    Seed: 140   Index: 165
+  Antlion B2F                                                                 Seed: 140   Index: 165
+    Step   3: 15 / Basilisk x1, Imp x3 (6.783s)
+    Step  33: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  73: 17 / Basilisk x1, Imp x3 (6.783s)
+    Step  75: 18 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 140   Index: 245
+  Step  36: 19 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 157   Index:  27
+Overworld (Kaipo)                                                             Seed: 157   Index:  27
+Kaipo Revisited                                                               Seed: 157   Index:  27
+Overworld (Kaipo)                                                             Seed: 157   Index:  27
+Overworld (Damcyan)                                                           Seed: 157   Index:  27
+Mt.Hobs-West                                                                  Seed: 157   Index:  27
+Mt.Hobs Summit                                                                Seed: 157   Index:  66
+Battle: MomBomb                                                               Seed: 157   Index:  81
+Mt.Hobs Summit                                                                Seed: 157   Index:  81
+Mt.Hobs-East                                                                  Seed: 157   Index:  87
+  Step  18: 20 / Spirit x2, Skelton x2 (8.237s)
+  Step  21: 21 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 157   Index: 133
+  Step  21: 22 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  40: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  52: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  78: 25 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 157   Index: 217
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 174   Index:  21
+Fabul Boat and Leviatan                                                       Seed: 174   Index:  28
+Overworld (Mysidia)                                                           Seed: 174   Index:  28
+Mysidia                                                                       Seed: 174   Index:  37
+Overworld (Mysidia)                                                           Seed: 174   Index:  37
+  Step   5: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Overworld (Mt.Ordeals)                                                        Seed: 174   Index:  47
+  Step  48: 27 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  75: 28 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 174   Index: 141
+  Step  24: 29 / Spirit x3, Soul x1 (8.687s)
+  Step  29: 30 / Soul x2, Red Bone x2 (9.583s)
+  Step  35: 31 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 174   Index: 184
+Recruit Tellah                                                                Seed: 174   Index: 207
+Mt.Ordeals-3rd station                                                        Seed: 174   Index: 207
+Mt.Ordeals-7th station                                                        Seed: 174   Index: 212
+  Step   7: 32 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 174   Index: 254
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 191   Index:  15
+Mt.Ordeals Summit                                                             Seed: 191   Index:  15
+  Step   3: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.808s)
+Paladin                                                                       Seed: 191   Index:  19
+Mt.Ordeals Summit                                                             Seed: 191   Index:  19
+  Optional Steps: 1
+  Step  21: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 191   Index:  42
+  Step  21: 35 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed: 191   Index:  84
+  Step  20: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed: 191   Index: 114
+Overworld (Mt.Ordeals)                                                        Seed: 191   Index: 158
+Take Chocobo to Mysidia                                                       Seed: 191   Index: 171
+Overworld (Mysidia)                                                           Seed: 191   Index: 171
+Town of Baron Serpent Road                                                    Seed: 191   Index: 171
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed: 191   Index: 183
+  Overworld (Baron)                                                           Seed: 191   Index: 183
+    Extra Steps: 8
+    Step   1: 37 / Imp x3, SwordRat x1 (7.227s)
+    Step   8: 38 / Imp x4 (7.223s)
+   (Step  31: 39 / Imp x3)
+   (Step 111: 40 / FloatEye x1, Eagle x2)
+   (Step 143: 41 / Imp x3)
+   (Step 157: 42 / Imp x3)
+   (Step 207: 43 / Imp x3)
+
+Encounter Time:      291.754s
+Other Time:          499.544s
+Total Time:          791.298s
+
+Base Total Time:     873.174s
+Time Saved:          81.876s
+
+Optional Steps:      1
+Extra Steps:         62
+Encounters:          38
+
+Base Encounters:     44
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/107.txt
+++ b/data/routes/cw/107.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	107
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49871748
+VARS	FFFFFFFF:6 C307801:1 E302500:94 E302600:8 E305400:20 E307000:6 E307400:60 E307700:8 E307B01:52 E308502:4 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 107   Index:   0
+Overworld (Kaipo)                                                             Seed: 107   Index:   1
+  Step  11: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 107   Index:  37
+Overworld (Kaipo)                                                             Seed: 107   Index:  37
+  Step  25: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 107   Index:  69
+  Step  13: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 107   Index: 101
+Watery Pass-South B1F                                                         Seed: 107   Index: 101
+  Step  15: 4 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 107   Index: 121
+  Step  15: 5 / Pike x3 (7.152s)
+  Step  26: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 107   Index: 211
+  Extra Steps: 20
+Watery Pass-South B2F                                                         Seed: 107   Index: 235
+  Extra Steps: 6
+  Step  44: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 124   Index:  24
+Watery Pass-North B2F                                                         Seed: 124   Index:  58
+Watery Pass-North B1F                                                         Seed: 124   Index:  79
+  Step   1: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step   7: 9 / CaveToad x4 (7.163s)
+  Step  33: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 124   Index: 139
+Waterfalls B1F                                                                Seed: 124   Index: 148
+  Extra Steps: 60
+Waterfalls B2F                                                                Seed: 124   Index: 209
+Waterfalls Lake                                                               Seed: 124   Index: 254
+  Step  16: 11 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed: 141   Index:  35
+Waterfalls Lake                                                               Seed: 141   Index:  35
+Overworld (Kaipo)                                                             Seed: 141   Index:  36
+Overworld (Damcyan)                                                           Seed: 141   Index:  47
+Damcyan                                                                       Seed: 141   Index:  51
+  Optional Steps: 0
+  Extra Steps: 94
+Overworld (Damcyan)                                                           Seed: 141   Index: 152
+Antlion B1F                                                                   Seed: 141   Index: 152
+  Extra Steps: 8
+  Step  16: 12 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  46: 13 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 141   Index: 198
+  Antlion B2F                                                                 Seed: 141   Index: 198
+    Step  42: 14 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 158   Index:  22
+  Step   3: 15 / Basilisk x1, Imp x3 (6.775s)
+Battle: Antlion                                                               Seed: 158   Index:  36
+Antlion's Nest                                                                Seed: 158   Index:  36
+Antlion B2F Outward Charm Room Steps                                          Seed: 158   Index:  51
+  Antlion B2F                                                                 Seed: 158   Index:  51
+  Antlion B2F Treasure Room                                                   Seed: 158   Index: 102
+    Extra Steps: 52
+  Antlion B2F                                                                 Seed: 158   Index: 154
+    Step  31: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 158   Index: 188
+  Step  23: 17 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 158   Index: 226
+Overworld (Kaipo)                                                             Seed: 158   Index: 226
+Kaipo Revisited                                                               Seed: 158   Index: 226
+Overworld (Kaipo)                                                             Seed: 158   Index: 226
+Overworld (Damcyan)                                                           Seed: 158   Index: 226
+Mt.Hobs-West                                                                  Seed: 158   Index: 226
+  Step  22: 18 / Gargoyle x1, Cocktric x2 (9.399s)
+  Step  34: 19 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 175   Index:   9
+Battle: MomBomb                                                               Seed: 175   Index:  24
+Mt.Hobs Summit                                                                Seed: 175   Index:  24
+Mt.Hobs-East                                                                  Seed: 175   Index:  30
+  Step  12: 20 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 175   Index:  76
+  Step  19: 21 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  46: 22 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 175   Index: 160
+  Optional Steps: 8
+Overworld (Fabul)                                                             Seed: 175   Index: 228
+Fabul Boat and Leviatan                                                       Seed: 175   Index: 235
+Overworld (Mysidia)                                                           Seed: 175   Index: 235
+Mysidia                                                                       Seed: 175   Index: 244
+Overworld (Mysidia)                                                           Seed: 175   Index: 244
+Overworld (Mt.Ordeals)                                                        Seed: 175   Index: 254
+  Step  20: 23 / Raven x1 (8.356s)
+  Step  42: 24 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  65: 25 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 192   Index:  92
+  Step  12: 26 / Red Bone x1, Skelton x3 (8.067s)
+  Step  14: 27 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed: 192   Index: 135
+Recruit Tellah                                                                Seed: 192   Index: 158
+Mt.Ordeals-3rd station                                                        Seed: 192   Index: 158
+Mt.Ordeals-7th station                                                        Seed: 192   Index: 163
+  Step  21: 28 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  28: 29 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 192   Index: 205
+  Optional Steps: 1
+  Step   9: 30 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed: 192   Index: 223
+Mt.Ordeals Summit                                                             Seed: 192   Index: 223
+Paladin                                                                       Seed: 192   Index: 227
+Mt.Ordeals Summit                                                             Seed: 192   Index: 227
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 192   Index: 250
+Mt.Ordeals-3rd station                                                        Seed: 209   Index:  36
+  Extra Steps: 4
+  Step   2: 31 / Ghoul x2, Soul x2 (8.971s)
+  Step  34: 32 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed: 209   Index:  70
+  Step  14: 33 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 209   Index: 114
+Take Chocobo to Mysidia                                                       Seed: 209   Index: 127
+Overworld (Mysidia)                                                           Seed: 209   Index: 127
+Town of Baron Serpent Road                                                    Seed: 209   Index: 127
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 209   Index: 133
+  Overworld (Baron)                                                           Seed: 209   Index: 133
+    Extra Steps: 6
+    Step   1: 34 / FloatEye x1, Eagle x2 (7.365s)
+    Step   6: 35 / Imp x3, SwordRat x1 (7.227s)
+   (Step  74: 36 / Imp x4)
+   (Step 109: 37 / Imp x6)
+   (Step 111: 38 / Imp x4)
+   (Step 126: 39 / Imp x3)
+   (Step 178: 40 / FloatEye x1, Eagle x2)
+   (Step 223: 41 / Imp x3)
+   (Step 255: 42 / Imp x3)
+
+Encounter Time:      275.642s
+Other Time:          554.187s
+Total Time:          829.829s
+
+Base Total Time:     971.248s
+Time Saved:          141.419s
+
+Optional Steps:      10
+Extra Steps:         252
+Encounters:          35
+
+Base Encounters:     48
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/108.txt
+++ b/data/routes/cw/108.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	108
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50050277
+VARS	FFFFFFFF:6 C307800:1 C307801:1 E302500:1 E302600:14 E305400:20 E307000:6 E307400:60 E307B00:68 E307B01:80 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 108   Index:   0
+Overworld (Kaipo)                                                             Seed: 108   Index:   1
+  Step  11: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 108   Index:  37
+Overworld (Kaipo)                                                             Seed: 108   Index:  37
+  Step  25: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 108   Index:  69
+  Step  13: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 108   Index: 101
+Watery Pass-South B1F                                                         Seed: 108   Index: 101
+  Step  13: 4 / Zombie x4 (7.148s)
+  Step  15: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 108   Index: 121
+  Step  15: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 108   Index: 211
+  Extra Steps: 20
+Watery Pass-South B2F                                                         Seed: 108   Index: 235
+  Extra Steps: 6
+  Step  44: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 125   Index:  24
+Watery Pass-North B2F                                                         Seed: 125   Index:  58
+Watery Pass-North B1F                                                         Seed: 125   Index:  79
+  Step   1: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step   7: 9 / CaveToad x4 (7.163s)
+  Step  33: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 125   Index: 139
+Waterfalls B1F                                                                Seed: 125   Index: 148
+  Extra Steps: 60
+Waterfalls B2F                                                                Seed: 125   Index: 209
+Waterfalls Lake                                                               Seed: 125   Index: 254
+  Step  16: 11 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed: 142   Index:  35
+Waterfalls Lake                                                               Seed: 142   Index:  35
+Overworld (Kaipo)                                                             Seed: 142   Index:  36
+Overworld (Damcyan)                                                           Seed: 142   Index:  47
+Damcyan                                                                       Seed: 142   Index:  51
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 142   Index:  59
+Antlion B1F                                                                   Seed: 142   Index:  59
+  Step  12: 12 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 142   Index:  97
+  Antlion B2F                                                                 Seed: 142   Index:  97
+    Step  13: 13 / Turtle x2 (7.487s)
+  Antlion B2F Treasure Room                                                   Seed: 142   Index: 130
+    Extra Steps: 68
+  Antlion B2F                                                                 Seed: 142   Index: 198
+    Step  42: 14 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 142   Index: 250
+Battle: Antlion                                                               Seed: 159   Index:   8
+Antlion's Nest                                                                Seed: 159   Index:   8
+Antlion B2F Outward Charm Room Steps                                          Seed: 159   Index:  23
+  Antlion B2F                                                                 Seed: 159   Index:  23
+    Step   2: 15 / Basilisk x1, Imp x3 (6.783s)
+  Antlion B2F Treasure Room                                                   Seed: 159   Index:  74
+    Extra Steps: 80
+  Antlion B2F                                                                 Seed: 159   Index: 154
+    Step  31: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 159   Index: 188
+  Step  23: 17 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 159   Index: 226
+Overworld (Kaipo)                                                             Seed: 159   Index: 226
+Kaipo Revisited                                                               Seed: 159   Index: 226
+Overworld (Kaipo)                                                             Seed: 159   Index: 226
+Overworld (Damcyan)                                                           Seed: 159   Index: 226
+Mt.Hobs-West                                                                  Seed: 159   Index: 226
+  Step  22: 18 / Gargoyle x1, Cocktric x2 (9.399s)
+  Step  34: 19 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 176   Index:   9
+Battle: MomBomb                                                               Seed: 176   Index:  24
+Mt.Hobs Summit                                                                Seed: 176   Index:  24
+Mt.Hobs-East                                                                  Seed: 176   Index:  30
+  Step  12: 20 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 176   Index:  76
+  Step  19: 21 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  46: 22 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 176   Index: 160
+  Optional Steps: 10
+  Extra Steps: 4
+Overworld (Fabul)                                                             Seed: 176   Index: 234
+Fabul Boat and Leviatan                                                       Seed: 176   Index: 241
+Overworld (Mysidia)                                                           Seed: 176   Index: 241
+Mysidia                                                                       Seed: 176   Index: 250
+Overworld (Mysidia)                                                           Seed: 176   Index: 250
+Overworld (Mt.Ordeals)                                                        Seed: 193   Index:   4
+  Step  14: 23 / Raven x1 (8.356s)
+  Step  36: 24 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  59: 25 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 193   Index:  98
+  Step   6: 26 / Red Bone x1, Skelton x3 (8.067s)
+  Step   8: 27 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed: 193   Index: 141
+  Step  15: 28 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 193   Index: 164
+Mt.Ordeals-3rd station                                                        Seed: 193   Index: 164
+Mt.Ordeals-7th station                                                        Seed: 193   Index: 169
+  Step  15: 29 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  22: 30 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 193   Index: 211
+  Optional Steps: 1
+  Step   3: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 193   Index: 229
+Mt.Ordeals Summit                                                             Seed: 193   Index: 229
+Paladin                                                                       Seed: 193   Index: 233
+Mt.Ordeals Summit                                                             Seed: 193   Index: 233
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 210   Index:   0
+Mt.Ordeals-3rd station                                                        Seed: 210   Index:  42
+  Step  28: 32 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed: 210   Index:  72
+  Step  12: 33 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 210   Index: 116
+Take Chocobo to Mysidia                                                       Seed: 210   Index: 129
+Overworld (Mysidia)                                                           Seed: 210   Index: 129
+Town of Baron Serpent Road                                                    Seed: 210   Index: 129
+Credit Warp Fight Search                                                      Seed: 210   Index: 133
+  Overworld (Baron)                                                           Seed: 210   Index: 133
+    Extra Steps: 6
+    Step   1: 34 / FloatEye x1, Eagle x2 (7.365s)
+    Step   6: 35 / Imp x3, SwordRat x1 (7.227s)
+   (Step  67: 36 / Imp x4)
+   (Step  74: 37 / Imp x6)
+   (Step 109: 38 / Imp x4)
+   (Step 111: 39 / Imp x3)
+   (Step 126: 40 / FloatEye x1, Eagle x2)
+   (Step 178: 41 / Imp x3)
+   (Step 255: 42 / Imp x3)
+
+Encounter Time:      276.150s
+Other Time:          556.650s
+Total Time:          832.800s
+
+Base Total Time:     1004.891s
+Time Saved:          172.092s
+
+Optional Steps:      13
+Extra Steps:         244
+Encounters:          35
+
+Base Encounters:     49
+Encounters Saved:    14
+
+Number of Variables: 54

--- a/data/routes/cw/109.txt
+++ b/data/routes/cw/109.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	109
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50621598
+VARS	FFFFFFFF:30 E000401:14 E302500:1 E302600:10 E307701:2
+
+Overworld (Kaipo)                                                             Seed: 109   Index:   0
+Overworld (Kaipo)                                                             Seed: 109   Index:   1
+  Step  11: 1 / SandMoth x2, Larva x2 (7.009s)
+  Step  32: 2 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 109   Index:  37
+Overworld (Kaipo)                                                             Seed: 109   Index:  37
+  Step  25: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 109   Index:  69
+  Step  13: 4 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 109   Index: 101
+Watery Pass-South B1F                                                         Seed: 109   Index: 101
+  Step  13: 5 / Pike x3 (7.152s)
+  Step  15: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 109   Index: 121
+  Step  15: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 109   Index: 211
+Watery Pass-South B2F                                                         Seed: 109   Index: 215
+Watery Pass-South B3F                                                         Seed: 109   Index: 254
+  Step  25: 8 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B2F                                                         Seed: 126   Index:  32
+Watery Pass-North B1F                                                         Seed: 126   Index:  53
+  Step  27: 9 / CaveToad x4 (7.163s)
+  Step  33: 10 / Zombie x4 (7.148s)
+  Step  59: 11 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 126   Index: 113
+Waterfalls B1F                                                                Seed: 126   Index: 122
+Waterfalls B2F                                                                Seed: 126   Index: 123
+  Step  32: 12 / Aligator x1, Pike x2 (7.368s)
+  Step  37: 13 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 126   Index: 168
+Battle: Octomamm                                                              Seed: 126   Index: 205
+Waterfalls Lake                                                               Seed: 126   Index: 205
+Overworld (Kaipo)                                                             Seed: 126   Index: 206
+  Step   3: 14 / SandMoth x2, Larva x2 (7.188s)
+  Step   9: 15 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 126   Index: 217
+Damcyan                                                                       Seed: 126   Index: 221
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 126   Index: 229
+Antlion B1F                                                                   Seed: 126   Index: 229
+Antlion B2F Inward Direct                                                     Seed: 143   Index:  11
+  Antlion B2F                                                                 Seed: 143   Index:  11
+    Step   3: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  60: 17 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 143   Index:  91
+Battle: Antlion                                                               Seed: 143   Index: 105
+Antlion's Nest                                                                Seed: 143   Index: 105
+  Step   2: 18 / Turtle x2 (7.464s)
+  Step   5: 19 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed: 143   Index: 120
+  Antlion B2F                                                                 Seed: 143   Index: 120
+    Step  22: 20 / Cream x4 (7.523s)
+    Step  32: 21 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  54: 22 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed: 143   Index: 200
+  Extra Steps: 2
+  Step  40: 23 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 143   Index: 240
+Overworld (Kaipo)                                                             Seed: 143   Index: 240
+Kaipo Revisited                                                               Seed: 143   Index: 240
+Overworld (Kaipo)                                                             Seed: 143   Index: 240
+Overworld (Damcyan)                                                           Seed: 143   Index: 240
+Mt.Hobs-West                                                                  Seed: 143   Index: 240
+  Step  32: 24 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed: 160   Index:  23
+Battle: MomBomb                                                               Seed: 160   Index:  38
+Mt.Hobs Summit                                                                Seed: 160   Index:  38
+Mt.Hobs-East                                                                  Seed: 160   Index:  44
+  Step  31: 25 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 160   Index:  90
+  Step  15: 26 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  18: 27 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  48: 28 / Cocktric x3 (8.241s)
+  Step  64: 29 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 160   Index: 174
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 160   Index: 244
+  Extra Steps: 14
+  Step   4: 30 / GrayBomb x2, Bomb x2 (8.759s)
+  Step  16: 31 / Cocktric x3 (8.218s)
+  Step  21: 32 / Gargoyle x1, Cocktric x2 (8.236s)
+Fabul Boat and Leviatan                                                       Seed: 177   Index:   9
+Overworld (Mysidia)                                                           Seed: 177   Index:   9
+Mysidia                                                                       Seed: 177   Index:  18
+Overworld (Mysidia)                                                           Seed: 177   Index:  18
+Overworld (Mt.Ordeals)                                                        Seed: 177   Index:  28
+  Step  14: 33 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  94: 34 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 177   Index: 122
+  Step  43: 35 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed: 177   Index: 165
+  Step   5: 36 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed: 177   Index: 188
+Mt.Ordeals-3rd station                                                        Seed: 177   Index: 188
+Mt.Ordeals-7th station                                                        Seed: 177   Index: 193
+  Step   9: 37 / Ghoul x2, Soul x2 (9.197s)
+  Step  41: 38 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 177   Index: 235
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 177   Index: 252
+Mt.Ordeals Summit                                                             Seed: 177   Index: 252
+Paladin                                                                       Seed: 194   Index:   0
+Mt.Ordeals Summit                                                             Seed: 194   Index:   0
+  Optional Steps: 0
+  Step  18: 39 / Ghoul x2, Soul x2 (8.971s)
+  Step  19: 40 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 194   Index:  22
+Mt.Ordeals-3rd station                                                        Seed: 194   Index:  64
+Mt.Ordeals                                                                    Seed: 194   Index:  94
+  Step  10: 41 / Spirit x2, Skelton x2 (8.065s)
+  Step  12: 42 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 194   Index: 138
+Take Chocobo to Mysidia                                                       Seed: 194   Index: 151
+Overworld (Mysidia)                                                           Seed: 194   Index: 151
+Town of Baron Serpent Road                                                    Seed: 194   Index: 151
+Credit Warp Fight Search                                                      Seed: 194   Index: 155
+  Overworld (Baron)                                                           Seed: 194   Index: 155
+    Extra Steps: 30
+    Step   1: 43 / FloatEye x2 (7.230s)
+    Step  29: 44 / Imp x3, SwordRat x1 (7.227s)
+   (Step  59: 45 / FloatEye x2)
+   (Step 123: 46 / FloatEye x2)
+   (Step 185: 47 / FloatEye x1, Eagle x2)
+   (Step 235: 48 / Eagle x3)
+   (Step 240: 49 / Imp x3, SwordRat x1)
+
+Encounter Time:      341.165s
+Other Time:          501.141s
+Total Time:          842.306s
+
+Base Total Time:     854.919s
+Time Saved:          12.613s
+
+Optional Steps:      11
+Extra Steps:         46
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/110.txt
+++ b/data/routes/cw/110.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	110
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48219036
+VARS	FFFFFFFF:8 C307800:1 E302500:5 E302600:9 E305400:4 E307400:34 E307B00:24 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 110   Index:   0
+Overworld (Kaipo)                                                             Seed: 110   Index:   1
+  Step  11: 1 / SandMoth x2, Larva x2 (7.009s)
+  Step  32: 2 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 110   Index:  37
+Overworld (Kaipo)                                                             Seed: 110   Index:  37
+  Step  25: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 110   Index:  69
+  Step  13: 4 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 110   Index: 101
+Watery Pass-South B1F                                                         Seed: 110   Index: 101
+  Step  13: 5 / Pike x3 (7.152s)
+  Step  15: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 110   Index: 121
+  Step  15: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 110   Index: 211
+  Extra Steps: 4
+Watery Pass-South B2F                                                         Seed: 110   Index: 219
+Watery Pass-South B3F                                                         Seed: 127   Index:   2
+Watery Pass-North B2F                                                         Seed: 127   Index:  36
+Watery Pass-North B1F                                                         Seed: 127   Index:  57
+  Step  23: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  29: 9 / CaveToad x4 (7.163s)
+  Step  55: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 127   Index: 117
+Waterfalls B1F                                                                Seed: 127   Index: 126
+  Extra Steps: 34
+Waterfalls B2F                                                                Seed: 127   Index: 161
+Waterfalls Lake                                                               Seed: 127   Index: 206
+  Step   2: 11 / Zombie x6 (7.489s)
+  Step   9: 12 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 127   Index: 243
+Waterfalls Lake                                                               Seed: 127   Index: 243
+Overworld (Kaipo)                                                             Seed: 127   Index: 244
+Overworld (Damcyan)                                                           Seed: 127   Index: 255
+Damcyan                                                                       Seed: 144   Index:   3
+  Optional Steps: 1
+  Extra Steps: 4
+Overworld (Damcyan)                                                           Seed: 144   Index:  15
+Antlion B1F                                                                   Seed: 144   Index:  15
+Antlion B2F Inward Charm Room Steps                                           Seed: 144   Index:  53
+  Antlion B2F                                                                 Seed: 144   Index:  53
+  Antlion B2F Treasure Room                                                   Seed: 144   Index:  86
+    Extra Steps: 24
+  Antlion B2F                                                                 Seed: 144   Index: 110
+    Step  32: 13 / Turtle x2 (7.487s)
+    Step  42: 14 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 144   Index: 162
+  Step  12: 15 / Basilisk x1, Imp x3 (6.775s)
+Battle: Antlion                                                               Seed: 144   Index: 176
+Antlion's Nest                                                                Seed: 144   Index: 176
+Antlion B2F Outward Direct                                                    Seed: 144   Index: 191
+  Antlion B2F                                                                 Seed: 144   Index: 191
+    Step  25: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  49: 17 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 161   Index:  15
+  Step   1: 18 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 161   Index:  53
+Overworld (Kaipo)                                                             Seed: 161   Index:  53
+Kaipo Revisited                                                               Seed: 161   Index:  53
+Overworld (Kaipo)                                                             Seed: 161   Index:  53
+Overworld (Damcyan)                                                           Seed: 161   Index:  53
+Mt.Hobs-West                                                                  Seed: 161   Index:  53
+  Step  22: 19 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 161   Index:  92
+Battle: MomBomb                                                               Seed: 161   Index: 107
+Mt.Hobs Summit                                                                Seed: 161   Index: 107
+  Step   1: 20 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed: 161   Index: 113
+  Step  25: 21 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  41: 22 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 161   Index: 159
+  Step  26: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  37: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  52: 25 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 161   Index: 243
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed: 178   Index:  56
+Fabul Boat and Leviatan                                                       Seed: 178   Index:  63
+Overworld (Mysidia)                                                           Seed: 178   Index:  63
+Mysidia                                                                       Seed: 178   Index:  72
+Overworld (Mysidia)                                                           Seed: 178   Index:  72
+Overworld (Mt.Ordeals)                                                        Seed: 178   Index:  82
+  Step  40: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  83: 27 / Raven x1 (8.356s)
+  Step  88: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 178   Index: 176
+  Step  26: 29 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 178   Index: 219
+  Step  15: 30 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed: 178   Index: 242
+Mt.Ordeals-3rd station                                                        Seed: 178   Index: 242
+Mt.Ordeals-7th station                                                        Seed: 178   Index: 247
+  Step  27: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  28: 32 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 195   Index:  33
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 195   Index:  51
+Mt.Ordeals Summit                                                             Seed: 195   Index:  51
+Paladin                                                                       Seed: 195   Index:  55
+Mt.Ordeals Summit                                                             Seed: 195   Index:  55
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 195   Index:  78
+  Step  26: 33 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  28: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 195   Index: 120
+Mt.Ordeals                                                                    Seed: 195   Index: 150
+  Step   6: 35 / Lilith x1, Red Bone x2 (8.437s)
+  Step  34: 36 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 195   Index: 194
+Take Chocobo to Mysidia                                                       Seed: 195   Index: 207
+Overworld (Mysidia)                                                           Seed: 195   Index: 207
+Town of Baron Serpent Road                                                    Seed: 195   Index: 207
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 195   Index: 213
+  Overworld (Baron)                                                           Seed: 195   Index: 213
+    Extra Steps: 8
+    Step   1: 37 / Imp x3 (7.174s)
+    Step   8: 38 / Imp x4 (7.223s)
+   (Step  65: 39 / Imp x3)
+   (Step 127: 40 / FloatEye x1, Eagle x2)
+   (Step 144: 41 / Imp x3)
+   (Step 182: 42 / Imp x3)
+   (Step 243: 43 / FloatEye x2)
+   (Step 250: 44 / Imp x3, SwordRat x1)
+
+Encounter Time:      294.466s
+Other Time:          507.864s
+Total Time:          802.329s
+
+Base Total Time:     853.907s
+Time Saved:          51.578s
+
+Optional Steps:      12
+Extra Steps:         76
+Encounters:          38
+
+Base Encounters:     44
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/111.txt
+++ b/data/routes/cw/111.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	111
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49685121
+VARS	FFFFFFFF:8 C307800:1 E302500:46 E302600:14 E305400:122 E307100:2 E307B00:60 E307E00:10
+
+Overworld (Kaipo)                                                             Seed: 111   Index:   0
+Overworld (Kaipo)                                                             Seed: 111   Index:   1
+  Step  32: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 111   Index:  37
+Overworld (Kaipo)                                                             Seed: 111   Index:  37
+  Step  25: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 111   Index:  69
+  Step  13: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 111   Index: 101
+Watery Pass-South B1F                                                         Seed: 111   Index: 101
+  Step  13: 4 / Zombie x4 (7.148s)
+  Step  15: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 111   Index: 121
+  Step  15: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 111   Index: 211
+  Extra Steps: 122
+Watery Pass-South B2F                                                         Seed: 128   Index:  81
+  Step   5: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  31: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 128   Index: 120
+  Extra Steps: 2
+Watery Pass-North B2F                                                         Seed: 128   Index: 156
+  Step   4: 9 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 128   Index: 177
+  Step  31: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  38: 11 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 128   Index: 237
+Waterfalls B1F                                                                Seed: 128   Index: 246
+Waterfalls B2F                                                                Seed: 128   Index: 247
+Waterfalls Lake                                                               Seed: 145   Index:  36
+Battle: Octomamm                                                              Seed: 145   Index:  73
+Waterfalls Lake                                                               Seed: 145   Index:  73
+Overworld (Kaipo)                                                             Seed: 145   Index:  74
+Overworld (Damcyan)                                                           Seed: 145   Index:  85
+Damcyan                                                                       Seed: 145   Index:  89
+  Optional Steps: 0
+  Extra Steps: 46
+Overworld (Damcyan)                                                           Seed: 145   Index: 142
+Antlion B1F                                                                   Seed: 145   Index: 142
+  Step  10: 12 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  32: 13 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 145   Index: 180
+  Antlion B2F                                                                 Seed: 145   Index: 180
+  Antlion B2F Treasure Room                                                   Seed: 145   Index: 213
+    Extra Steps: 60
+  Antlion B2F                                                                 Seed: 162   Index:  17
+Antlion's Nest                                                                Seed: 162   Index:  69
+  Step   6: 14 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed: 162   Index:  83
+Antlion's Nest                                                                Seed: 162   Index:  83
+Antlion B2F Outward Direct                                                    Seed: 162   Index:  98
+  Antlion B2F                                                                 Seed: 162   Index:  98
+    Step  10: 15 / Basilisk x1, Imp x3 (6.783s)
+    Step  40: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 162   Index: 178
+  Step   7: 17 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  18: 18 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 162   Index: 216
+Overworld (Kaipo)                                                             Seed: 162   Index: 216
+Kaipo Revisited                                                               Seed: 162   Index: 216
+Overworld (Kaipo)                                                             Seed: 162   Index: 216
+Overworld (Damcyan)                                                           Seed: 162   Index: 216
+Mt.Hobs-West                                                                  Seed: 162   Index: 216
+  Extra Steps: 10
+  Step  32: 19 / Skelton x4 (8.683s)
+  Step  49: 20 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 179   Index:   9
+Battle: MomBomb                                                               Seed: 179   Index:  24
+Mt.Hobs Summit                                                                Seed: 179   Index:  24
+Mt.Hobs-East                                                                  Seed: 179   Index:  30
+  Step  11: 21 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 179   Index:  76
+  Step  46: 22 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 179   Index: 160
+  Optional Steps: 10
+  Extra Steps: 4
+Overworld (Fabul)                                                             Seed: 179   Index: 234
+Fabul Boat and Leviatan                                                       Seed: 179   Index: 241
+Overworld (Mysidia)                                                           Seed: 179   Index: 241
+Mysidia                                                                       Seed: 179   Index: 250
+Overworld (Mysidia)                                                           Seed: 179   Index: 250
+Overworld (Mt.Ordeals)                                                        Seed: 196   Index:   4
+  Step  14: 23 / Raven x1 (8.356s)
+  Step  15: 24 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 196   Index:  98
+  Step   5: 25 / Spirit x3, Soul x1 (8.687s)
+  Step   8: 26 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 196   Index: 141
+  Step  15: 27 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed: 196   Index: 164
+Mt.Ordeals-3rd station                                                        Seed: 196   Index: 164
+Mt.Ordeals-7th station                                                        Seed: 196   Index: 169
+  Step  15: 28 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 196   Index: 211
+  Optional Steps: 0
+  Step   3: 29 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  10: 30 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed: 196   Index: 228
+Mt.Ordeals Summit                                                             Seed: 196   Index: 228
+Paladin                                                                       Seed: 196   Index: 232
+Mt.Ordeals Summit                                                             Seed: 196   Index: 232
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 196   Index: 254
+  Step  24: 31 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed: 213   Index:  40
+Mt.Ordeals                                                                    Seed: 213   Index:  70
+  Step  14: 32 / Soul x2, Red Bone x2 (8.881s)
+  Step  31: 33 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 213   Index: 114
+Take Chocobo to Mysidia                                                       Seed: 213   Index: 127
+Overworld (Mysidia)                                                           Seed: 213   Index: 127
+Town of Baron Serpent Road                                                    Seed: 213   Index: 127
+Credit Warp Fight Search                                                      Seed: 213   Index: 131
+  Overworld (Baron)                                                           Seed: 213   Index: 131
+    Extra Steps: 8
+    Step   2: 34 / FloatEye x1, Eagle x2 (7.365s)
+    Step   8: 35 / Imp x3, SwordRat x1 (7.227s)
+   (Step  69: 36 / Imp x4)
+   (Step  76: 37 / Imp x3)
+   (Step 128: 38 / Imp x4)
+   (Step 256: 39 / Imp x3)
+
+Encounter Time:      272.004s
+Other Time:          554.720s
+Total Time:          826.724s
+
+Base Total Time:     914.112s
+Time Saved:          87.388s
+
+Optional Steps:      10
+Extra Steps:         252
+Encounters:          35
+
+Base Encounters:     49
+Encounters Saved:    14
+
+Number of Variables: 54

--- a/data/routes/cw/112.txt
+++ b/data/routes/cw/112.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	112
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48808299
+VARS	FFFFFFFF:30 E302600:8 E305400:12 E308401:2 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 112   Index:   0
+Overworld (Kaipo)                                                             Seed: 112   Index:   1
+  Step  32: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 112   Index:  37
+Overworld (Kaipo)                                                             Seed: 112   Index:  37
+Watery Pass-South B1F                                                         Seed: 112   Index:  69
+  Step  13: 2 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 112   Index: 101
+Watery Pass-South B1F                                                         Seed: 112   Index: 101
+  Step  13: 3 / Pike x3 (7.152s)
+  Step  15: 4 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 112   Index: 121
+  Step  45: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 112   Index: 211
+  Extra Steps: 12
+Watery Pass-South B2F                                                         Seed: 112   Index: 227
+Watery Pass-South B3F                                                         Seed: 129   Index:  10
+Watery Pass-North B2F                                                         Seed: 129   Index:  44
+  Step   2: 6 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 129   Index:  65
+  Step  15: 7 / Zombie x4 (7.148s)
+  Step  21: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  47: 9 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 129   Index: 125
+Waterfalls B1F                                                                Seed: 129   Index: 134
+Waterfalls B2F                                                                Seed: 129   Index: 135
+  Step  25: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 129   Index: 180
+  Step  28: 11 / Zombie x6 (7.489s)
+  Step  35: 12 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 129   Index: 217
+Waterfalls Lake                                                               Seed: 129   Index: 217
+Overworld (Kaipo)                                                             Seed: 129   Index: 218
+Overworld (Damcyan)                                                           Seed: 129   Index: 229
+Damcyan                                                                       Seed: 129   Index: 233
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 129   Index: 240
+Antlion B1F                                                                   Seed: 129   Index: 240
+Antlion B2F Inward Direct                                                     Seed: 146   Index:  22
+  Antlion B2F                                                                 Seed: 146   Index:  22
+    Step  23: 13 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 146   Index: 102
+  Step   5: 14 / Weeper x2 (7.114s)
+  Step   8: 15 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed: 146   Index: 116
+Antlion's Nest                                                                Seed: 146   Index: 116
+Antlion B2F Outward Direct                                                    Seed: 146   Index: 131
+  Antlion B2F                                                                 Seed: 146   Index: 131
+    Step  11: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  21: 17 / Basilisk x1, Imp x3 (6.783s)
+    Step  43: 18 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 146   Index: 211
+  Step   5: 19 / Imp x3 (6.648s)
+  Step  32: 20 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 146   Index: 249
+Overworld (Kaipo)                                                             Seed: 146   Index: 249
+Kaipo Revisited                                                               Seed: 146   Index: 249
+Overworld (Kaipo)                                                             Seed: 146   Index: 249
+Overworld (Damcyan)                                                           Seed: 146   Index: 249
+Mt.Hobs-West                                                                  Seed: 146   Index: 249
+  Step  18: 21 / Bomb x3 (8.832s)
+  Step  23: 22 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 163   Index:  32
+Battle: MomBomb                                                               Seed: 163   Index:  47
+Mt.Hobs Summit                                                                Seed: 163   Index:  47
+Mt.Hobs-East                                                                  Seed: 163   Index:  53
+  Step  22: 23 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 163   Index:  99
+  Step   9: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  39: 25 / Cocktric x3 (8.241s)
+  Step  55: 26 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 163   Index: 183
+  Optional Steps: 8
+Overworld (Fabul)                                                             Seed: 163   Index: 251
+Fabul Boat and Leviatan                                                       Seed: 180   Index:   2
+Overworld (Mysidia)                                                           Seed: 180   Index:   2
+  Step   7: 27 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 180   Index:  11
+Overworld (Mysidia)                                                           Seed: 180   Index:  11
+  Step  10: 28 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 180   Index:  21
+  Step  20: 29 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 180   Index: 115
+Mt.Ordeals-3rd station                                                        Seed: 180   Index: 158
+  Step   7: 30 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+  Step  12: 31 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 180   Index: 181
+Mt.Ordeals-3rd station                                                        Seed: 180   Index: 181
+Mt.Ordeals-7th station                                                        Seed: 180   Index: 186
+  Step   1: 32 / Lilith x1, Red Bone x2 (8.912s)
+  Step  16: 33 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 180   Index: 228
+  Optional Steps: 1
+  Step   6: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed: 180   Index: 246
+Mt.Ordeals Summit                                                             Seed: 180   Index: 246
+Paladin                                                                       Seed: 180   Index: 250
+Mt.Ordeals Summit                                                             Seed: 180   Index: 250
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 197   Index:  17
+  Step   2: 35 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-3rd station                                                        Seed: 197   Index:  59
+Mt.Ordeals                                                                    Seed: 197   Index:  89
+  Extra Steps: 2
+  Step  14: 36 / Skelton x3, Red Bone x2 (7.997s)
+  Step  17: 37 / Spirit x2, Skelton x2 (8.065s)
+  Step  46: 38 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 197   Index: 135
+Take Chocobo to Mysidia                                                       Seed: 197   Index: 148
+Overworld (Mysidia)                                                           Seed: 197   Index: 148
+Town of Baron Serpent Road                                                    Seed: 197   Index: 148
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 197   Index: 154
+  Overworld (Baron)                                                           Seed: 197   Index: 154
+    Extra Steps: 30
+    Step   2: 39 / Imp x3 (7.174s)
+    Step  30: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  67: 41 / Imp x3)
+   (Step 124: 42 / FloatEye x2)
+   (Step 186: 43 / FloatEye x2)
+   (Step 203: 44 / Imp x3, SwordRat x1)
+   (Step 235: 45 / FloatEye x2)
+   (Step 241: 46 / FloatEye x2)
+
+Encounter Time:      310.993s
+Other Time:          501.141s
+Total Time:          812.134s
+
+Base Total Time:     839.206s
+Time Saved:          27.071s
+
+Optional Steps:      10
+Extra Steps:         46
+Encounters:          40
+
+Base Encounters:     44
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/113.txt
+++ b/data/routes/cw/113.txt
@@ -1,0 +1,147 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	113
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49861240
+VARS	FFFFFFFF:66 E302500:1 E302600:10 E305400:12 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 113   Index:   0
+Overworld (Kaipo)                                                             Seed: 113   Index:   1
+  Step  16: 1 / SandMoth x2, Larva x2 (7.009s)
+  Step  32: 2 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 113   Index:  37
+Overworld (Kaipo)                                                             Seed: 113   Index:  37
+Watery Pass-South B1F                                                         Seed: 113   Index:  69
+  Step  13: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 113   Index: 101
+Watery Pass-South B1F                                                         Seed: 113   Index: 101
+  Step  13: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 113   Index: 121
+  Step  45: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 113   Index: 211
+  Extra Steps: 12
+Watery Pass-South B2F                                                         Seed: 113   Index: 227
+Watery Pass-South B3F                                                         Seed: 130   Index:  10
+Watery Pass-North B2F                                                         Seed: 130   Index:  44
+  Step   2: 6 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 130   Index:  65
+  Step  15: 7 / Zombie x4 (7.148s)
+  Step  25: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  47: 9 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 130   Index: 125
+Waterfalls B1F                                                                Seed: 130   Index: 134
+Waterfalls B2F                                                                Seed: 130   Index: 135
+  Step  25: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 130   Index: 180
+  Step  28: 11 / Zombie x6 (7.489s)
+  Step  35: 12 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 130   Index: 217
+Waterfalls Lake                                                               Seed: 130   Index: 217
+Overworld (Kaipo)                                                             Seed: 130   Index: 218
+Overworld (Damcyan)                                                           Seed: 130   Index: 229
+Damcyan                                                                       Seed: 130   Index: 233
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 130   Index: 241
+Antlion B1F                                                                   Seed: 130   Index: 241
+Antlion B2F Inward Direct                                                     Seed: 147   Index:  23
+  Antlion B2F                                                                 Seed: 147   Index:  23
+    Step  22: 13 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 147   Index: 103
+  Step   4: 14 / Weeper x2 (7.114s)
+  Step   7: 15 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed: 147   Index: 117
+Antlion's Nest                                                                Seed: 147   Index: 117
+Antlion B2F Outward Direct                                                    Seed: 147   Index: 132
+  Antlion B2F                                                                 Seed: 147   Index: 132
+    Step  10: 16 / Basilisk x1, Turtle x1 (7.124s)
+    Step  17: 17 / Basilisk x1, Imp x3 (6.783s)
+    Step  42: 18 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 147   Index: 212
+  Step   4: 19 / Imp x3 (6.648s)
+  Step  31: 20 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 147   Index: 250
+Overworld (Kaipo)                                                             Seed: 147   Index: 250
+Kaipo Revisited                                                               Seed: 147   Index: 250
+Overworld (Kaipo)                                                             Seed: 147   Index: 250
+Overworld (Damcyan)                                                           Seed: 147   Index: 250
+Mt.Hobs-West                                                                  Seed: 147   Index: 250
+  Step  17: 21 / Bomb x3 (8.832s)
+  Step  22: 22 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 164   Index:  33
+Battle: MomBomb                                                               Seed: 164   Index:  48
+Mt.Hobs Summit                                                                Seed: 164   Index:  48
+Mt.Hobs-East                                                                  Seed: 164   Index:  54
+  Step  21: 23 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 164   Index: 100
+  Step   8: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  38: 25 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 164   Index: 184
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 164   Index: 254
+Fabul Boat and Leviatan                                                       Seed: 181   Index:   5
+Overworld (Mysidia)                                                           Seed: 181   Index:   5
+  Step   4: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.462s)
+Mysidia                                                                       Seed: 181   Index:  14
+Overworld (Mysidia)                                                           Seed: 181   Index:  14
+  Step   7: 27 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 181   Index:  24
+  Step  17: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 181   Index: 118
+Mt.Ordeals-3rd station                                                        Seed: 181   Index: 161
+  Step   9: 29 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 181   Index: 184
+Mt.Ordeals-3rd station                                                        Seed: 181   Index: 184
+  Step   3: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed: 181   Index: 189
+  Step  13: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 181   Index: 231
+  Optional Steps: 1
+  Step   3: 32 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed: 181   Index: 249
+Mt.Ordeals Summit                                                             Seed: 181   Index: 249
+  Step   3: 33 / Soul x2, Ghoul x2, Revenant x2 (10.046s)
+Paladin                                                                       Seed: 181   Index: 253
+Mt.Ordeals Summit                                                             Seed: 181   Index: 253
+  Optional Steps: 1
+  Step  22: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 198   Index:  20
+Mt.Ordeals-3rd station                                                        Seed: 198   Index:  62
+Mt.Ordeals                                                                    Seed: 198   Index:  92
+  Step  11: 35 / Lilith x1, Red Bone x2 (8.437s)
+  Step  14: 36 / Skelton x3, Red Bone x2 (7.997s)
+  Step  17: 37 / Spirit x2, Skelton x2 (8.065s)
+  Step  43: 38 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 198   Index: 136
+Take Chocobo to Mysidia                                                       Seed: 198   Index: 149
+Overworld (Mysidia)                                                           Seed: 198   Index: 149
+Town of Baron Serpent Road                                                    Seed: 198   Index: 149
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 198   Index: 155
+  Overworld (Baron)                                                           Seed: 198   Index: 155
+    Extra Steps: 66
+    Step   1: 39 / Imp x3 (7.174s)
+    Step  66: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step 123: 41 / Imp x3)
+   (Step 202: 42 / FloatEye x2)
+   (Step 234: 43 / FloatEye x2)
+   (Step 240: 44 / Imp x3, SwordRat x1)
+
+Encounter Time:      309.877s
+Other Time:          519.777s
+Total Time:          829.654s
+
+Base Total Time:     873.130s
+Time Saved:          43.475s
+
+Optional Steps:      13
+Extra Steps:         80
+Encounters:          40
+
+Base Encounters:     44
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/114.txt
+++ b/data/routes/cw/114.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	114
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49163673
+VARS	FFFFFFFF:24 E000202:12 E000500:4 E302600:22 E305400:12 E308702:1 E309700:18
+
+Overworld (Kaipo)                                                             Seed: 114   Index:   0
+Overworld (Kaipo)                                                             Seed: 114   Index:   1
+  Step  16: 1 / SandMoth x2, Larva x2 (7.009s)
+  Step  32: 2 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 114   Index:  37
+Overworld (Kaipo)                                                             Seed: 114   Index:  37
+  Step  12: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 114   Index:  69
+Recruit Tellah                                                                Seed: 114   Index: 101
+Watery Pass-South B1F                                                         Seed: 114   Index: 101
+  Step  13: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 114   Index: 121
+  Step  45: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 114   Index: 211
+  Extra Steps: 12
+Watery Pass-South B2F                                                         Seed: 114   Index: 227
+Watery Pass-South B3F                                                         Seed: 131   Index:  10
+Watery Pass-North B2F                                                         Seed: 131   Index:  44
+  Step   2: 6 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 131   Index:  65
+  Step  14: 7 / Zombie x4 (7.148s)
+  Step  25: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  47: 9 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 131   Index: 125
+Waterfalls B1F                                                                Seed: 131   Index: 134
+Waterfalls B2F                                                                Seed: 131   Index: 135
+  Step  25: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 131   Index: 180
+  Step  28: 11 / Zombie x6 (7.489s)
+  Step  35: 12 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 131   Index: 217
+Waterfalls Lake                                                               Seed: 131   Index: 217
+Overworld (Kaipo)                                                             Seed: 131   Index: 218
+Overworld (Damcyan)                                                           Seed: 131   Index: 229
+Damcyan                                                                       Seed: 131   Index: 233
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 131   Index: 240
+Antlion B1F                                                                   Seed: 131   Index: 240
+Antlion B2F Inward Direct                                                     Seed: 148   Index:  22
+  Antlion B2F                                                                 Seed: 148   Index:  22
+    Step  22: 13 / Turtle x2 (7.487s)
+    Step  23: 14 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 148   Index: 102
+  Step   5: 15 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed: 148   Index: 116
+Antlion's Nest                                                                Seed: 148   Index: 116
+Antlion B2F Outward Direct                                                    Seed: 148   Index: 131
+  Antlion B2F                                                                 Seed: 148   Index: 131
+    Step  11: 16 / Basilisk x1, Turtle x1 (7.124s)
+    Step  18: 17 / Basilisk x1, Imp x3 (6.783s)
+    Step  43: 18 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 148   Index: 211
+  Step   5: 19 / Imp x3 (6.648s)
+  Step  32: 20 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 148   Index: 249
+Overworld (Kaipo)                                                             Seed: 148   Index: 249
+  Extra Steps: 12
+  Step  12: 21 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed: 165   Index:   5
+Overworld (Kaipo)                                                             Seed: 165   Index:   5
+Overworld (Damcyan)                                                           Seed: 165   Index:   5
+Mt.Hobs-West                                                                  Seed: 165   Index:   5
+  Step   6: 22 / Spirit x2 (8.028s)
+  Step  11: 23 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 165   Index:  44
+Battle: MomBomb                                                               Seed: 165   Index:  59
+Mt.Hobs Summit                                                                Seed: 165   Index:  59
+Mt.Hobs-East                                                                  Seed: 165   Index:  65
+  Step  10: 24 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 165   Index: 111
+  Step  27: 25 / Cocktric x3 (8.241s)
+  Step  78: 26 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 165   Index: 195
+  Optional Steps: 10
+  Extra Steps: 12
+Overworld (Fabul)                                                             Seed: 182   Index:  21
+Fabul Boat and Leviatan                                                       Seed: 182   Index:  28
+Overworld (Mysidia)                                                           Seed: 182   Index:  28
+  Extra Steps: 4
+  Step  13: 27 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 182   Index:  41
+Overworld (Mysidia)                                                           Seed: 182   Index:  41
+Overworld (Mt.Ordeals)                                                        Seed: 182   Index:  51
+  Step  94: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 182   Index: 145
+  Step  42: 29 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 182   Index: 188
+  Step  14: 30 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed: 182   Index: 211
+Mt.Ordeals-3rd station                                                        Seed: 182   Index: 211
+Mt.Ordeals-7th station                                                        Seed: 182   Index: 216
+  Step  18: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  36: 32 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 199   Index:   2
+  Optional Steps: 0
+  Step  17: 33 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 199   Index:  19
+Mt.Ordeals Summit                                                             Seed: 199   Index:  19
+Paladin                                                                       Seed: 199   Index:  23
+Mt.Ordeals Summit                                                             Seed: 199   Index:  23
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 199   Index:  46
+Mt.Ordeals-3rd station                                                        Seed: 199   Index:  88
+  Step  15: 34 / Zombie x2, Ghoul x2 (7.552s)
+  Step  18: 35 / Lilith x1, Red Bone x2 (8.437s)
+  Step  21: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 199   Index: 118
+  Step  17: 37 / Spirit x2, Skelton x2 (8.065s)
+  Step  38: 38 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 199   Index: 162
+Take Chocobo to Mysidia                                                       Seed: 199   Index: 175
+Overworld (Mysidia)                                                           Seed: 199   Index: 175
+Town of Baron Serpent Road                                                    Seed: 199   Index: 175
+  Extra Steps: 18
+Credit Warp Fight Search                                                      Seed: 199   Index: 197
+  Overworld (Baron)                                                           Seed: 199   Index: 197
+    Extra Steps: 24
+    Step   2: 39 / Imp x3 (7.174s)
+    Step  24: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  81: 41 / Imp x3)
+   (Step 160: 42 / FloatEye x2)
+   (Step 192: 43 / FloatEye x2)
+   (Step 234: 44 / Imp x3, SwordRat x1)
+   (Step 256: 45 / FloatEye x2)
+
+Encounter Time:      308.919s
+Other Time:          509.128s
+Total Time:          818.047s
+
+Base Total Time:     860.561s
+Time Saved:          42.513s
+
+Optional Steps:      11
+Extra Steps:         82
+Encounters:          40
+
+Base Encounters:     44
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/115.txt
+++ b/data/routes/cw/115.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	115
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49222092
+VARS	FFFFFFFF:24 E302500:1 E302600:10 E305400:12 E308700:1 E308702:1 E309700:44
+
+Overworld (Kaipo)                                                             Seed: 115   Index:   0
+Overworld (Kaipo)                                                             Seed: 115   Index:   1
+  Step  16: 1 / SandWorm x1 (6.973s)
+  Step  32: 2 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 115   Index:  37
+Overworld (Kaipo)                                                             Seed: 115   Index:  37
+  Step  12: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 115   Index:  69
+  Step  19: 4 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 115   Index: 101
+Watery Pass-South B1F                                                         Seed: 115   Index: 101
+Watery Pass-South B2F                                                         Seed: 115   Index: 121
+  Step  45: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 115   Index: 211
+  Extra Steps: 12
+Watery Pass-South B2F                                                         Seed: 115   Index: 227
+Watery Pass-South B3F                                                         Seed: 132   Index:  10
+Watery Pass-North B2F                                                         Seed: 132   Index:  44
+  Step   2: 6 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 132   Index:  65
+  Step  14: 7 / Zombie x4 (7.148s)
+  Step  25: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  46: 9 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 132   Index: 125
+Waterfalls B1F                                                                Seed: 132   Index: 134
+Waterfalls B2F                                                                Seed: 132   Index: 135
+  Step  25: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 132   Index: 180
+  Step  28: 11 / Zombie x6 (7.489s)
+  Step  35: 12 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 132   Index: 217
+Waterfalls Lake                                                               Seed: 132   Index: 217
+Overworld (Kaipo)                                                             Seed: 132   Index: 218
+Overworld (Damcyan)                                                           Seed: 132   Index: 229
+Damcyan                                                                       Seed: 132   Index: 233
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 132   Index: 241
+Antlion B1F                                                                   Seed: 132   Index: 241
+Antlion B2F Inward Direct                                                     Seed: 149   Index:  23
+  Antlion B2F                                                                 Seed: 149   Index:  23
+    Step  21: 13 / Turtle x2 (7.487s)
+    Step  22: 14 / Weeper x2 (7.114s)
+    Step  60: 15 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 149   Index: 103
+  Step   4: 16 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 149   Index: 117
+Antlion's Nest                                                                Seed: 149   Index: 117
+Antlion B2F Outward Direct                                                    Seed: 149   Index: 132
+  Antlion B2F                                                                 Seed: 149   Index: 132
+    Step  17: 17 / Basilisk x1, Imp x3 (6.783s)
+    Step  42: 18 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 149   Index: 212
+  Step   4: 19 / Imp x3 (6.648s)
+  Step  31: 20 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 149   Index: 250
+Overworld (Kaipo)                                                             Seed: 149   Index: 250
+Kaipo Revisited                                                               Seed: 149   Index: 250
+Overworld (Kaipo)                                                             Seed: 149   Index: 250
+Overworld (Damcyan)                                                           Seed: 149   Index: 250
+Mt.Hobs-West                                                                  Seed: 149   Index: 250
+  Step  11: 21 / Bomb x3 (8.832s)
+  Step  17: 22 / Spirit x2 (8.028s)
+  Step  22: 23 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 166   Index:  33
+Battle: MomBomb                                                               Seed: 166   Index:  48
+Mt.Hobs Summit                                                                Seed: 166   Index:  48
+Mt.Hobs-East                                                                  Seed: 166   Index:  54
+  Step  21: 24 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 166   Index: 100
+  Step  38: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  71: 26 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 166   Index: 184
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 166   Index: 254
+Fabul Boat and Leviatan                                                       Seed: 183   Index:   5
+Overworld (Mysidia)                                                           Seed: 183   Index:   5
+  Step   4: 27 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 183   Index:  14
+Overworld (Mysidia)                                                           Seed: 183   Index:  14
+  Step   7: 28 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 183   Index:  24
+  Step  17: 29 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 183   Index: 118
+  Step  27: 30 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 183   Index: 161
+  Step  11: 31 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 183   Index: 184
+Mt.Ordeals-3rd station                                                        Seed: 183   Index: 184
+  Step   3: 32 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals-7th station                                                        Seed: 183   Index: 189
+Mt.Ordeals Summit                                                             Seed: 183   Index: 231
+  Optional Steps: 1
+  Step   3: 33 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 183   Index: 249
+Mt.Ordeals Summit                                                             Seed: 183   Index: 249
+  Step   3: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.808s)
+Paladin                                                                       Seed: 183   Index: 253
+Mt.Ordeals Summit                                                             Seed: 183   Index: 253
+  Optional Steps: 1
+  Step  22: 35 / Lilith x2 (9.169s)
+Mt.Ordeals-7th station                                                        Seed: 200   Index:  20
+Mt.Ordeals-3rd station                                                        Seed: 200   Index:  62
+Mt.Ordeals                                                                    Seed: 200   Index:  92
+  Step  11: 36 / Skelton x3, Red Bone x2 (7.997s)
+  Step  17: 37 / Spirit x2, Skelton x2 (8.065s)
+  Step  43: 38 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 200   Index: 136
+Take Chocobo to Mysidia                                                       Seed: 200   Index: 149
+Overworld (Mysidia)                                                           Seed: 200   Index: 149
+Town of Baron Serpent Road                                                    Seed: 200   Index: 149
+  Extra Steps: 44
+Credit Warp Fight Search                                                      Seed: 200   Index: 197
+  Overworld (Baron)                                                           Seed: 200   Index: 197
+    Extra Steps: 24
+    Step   2: 39 / Imp x3 (7.174s)
+    Step  24: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  81: 41 / FloatEye x2)
+   (Step 133: 42 / FloatEye x2)
+   (Step 160: 43 / FloatEye x2)
+   (Step 192: 44 / Imp x3, SwordRat x1)
+   (Step 234: 45 / FloatEye x2)
+   (Step 256: 46 / FloatEye x2)
+
+Encounter Time:      310.424s
+Other Time:          508.596s
+Total Time:          819.019s
+
+Base Total Time:     871.344s
+Time Saved:          52.325s
+
+Optional Steps:      13
+Extra Steps:         80
+Encounters:          40
+
+Base Encounters:     44
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/116.txt
+++ b/data/routes/cw/116.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	116
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49212119
+VARS	FFFFFFFF:24 E000202:12 E302600:42 E305400:12 E308501:2 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 116   Index:   0
+Overworld (Kaipo)                                                             Seed: 116   Index:   1
+  Step  16: 1 / SandWorm x1 (6.973s)
+  Step  32: 2 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 116   Index:  37
+Overworld (Kaipo)                                                             Seed: 116   Index:  37
+  Step  12: 3 / SandMoth x2, Larva x2 (7.049s)
+  Step  22: 4 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 116   Index:  69
+  Step  19: 5 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 116   Index: 101
+Watery Pass-South B1F                                                         Seed: 116   Index: 101
+Watery Pass-South B2F                                                         Seed: 116   Index: 121
+  Step  45: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 116   Index: 211
+  Extra Steps: 12
+Watery Pass-South B2F                                                         Seed: 116   Index: 227
+Watery Pass-South B3F                                                         Seed: 133   Index:  10
+Watery Pass-North B2F                                                         Seed: 133   Index:  44
+  Step   2: 7 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed: 133   Index:  65
+  Step  14: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  25: 9 / CaveToad x4 (7.163s)
+  Step  46: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 133   Index: 125
+Waterfalls B1F                                                                Seed: 133   Index: 134
+Waterfalls B2F                                                                Seed: 133   Index: 135
+Waterfalls Lake                                                               Seed: 133   Index: 180
+  Step  28: 11 / Zombie x6 (7.489s)
+  Step  35: 12 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 133   Index: 217
+Waterfalls Lake                                                               Seed: 133   Index: 217
+Overworld (Kaipo)                                                             Seed: 133   Index: 218
+Overworld (Damcyan)                                                           Seed: 133   Index: 229
+Damcyan                                                                       Seed: 133   Index: 233
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 133   Index: 240
+Antlion B1F                                                                   Seed: 133   Index: 240
+Antlion B2F Inward Direct                                                     Seed: 150   Index:  22
+  Antlion B2F                                                                 Seed: 150   Index:  22
+    Step  22: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  23: 14 / Weeper x2 (7.114s)
+    Step  61: 15 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 150   Index: 102
+  Step   5: 16 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 150   Index: 116
+Antlion's Nest                                                                Seed: 150   Index: 116
+Antlion B2F Outward Direct                                                    Seed: 150   Index: 131
+  Antlion B2F                                                                 Seed: 150   Index: 131
+    Step  18: 17 / Basilisk x1, Imp x3 (6.783s)
+    Step  42: 18 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 150   Index: 211
+  Step   5: 19 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  32: 20 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 150   Index: 249
+Overworld (Kaipo)                                                             Seed: 150   Index: 249
+  Extra Steps: 12
+  Step  12: 21 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed: 167   Index:   5
+Overworld (Kaipo)                                                             Seed: 167   Index:   5
+Overworld (Damcyan)                                                           Seed: 167   Index:   5
+Mt.Hobs-West                                                                  Seed: 167   Index:   5
+  Step   6: 22 / Spirit x2 (8.028s)
+  Step  11: 23 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 167   Index:  44
+Battle: MomBomb                                                               Seed: 167   Index:  59
+Mt.Hobs Summit                                                                Seed: 167   Index:  59
+Mt.Hobs-East                                                                  Seed: 167   Index:  65
+  Step  30: 24 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 167   Index: 111
+  Step  27: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  60: 26 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  78: 27 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 167   Index: 195
+  Optional Steps: 10
+  Extra Steps: 32
+Overworld (Fabul)                                                             Seed: 184   Index:  41
+Fabul Boat and Leviatan                                                       Seed: 184   Index:  48
+Overworld (Mysidia)                                                           Seed: 184   Index:  48
+Mysidia                                                                       Seed: 184   Index:  57
+Overworld (Mysidia)                                                           Seed: 184   Index:  57
+Overworld (Mt.Ordeals)                                                        Seed: 184   Index:  67
+  Step  78: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 184   Index: 161
+  Step  11: 29 / Spirit x3, Soul x1 (8.687s)
+  Step  26: 30 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 184   Index: 204
+Recruit Tellah                                                                Seed: 184   Index: 227
+Mt.Ordeals-3rd station                                                        Seed: 184   Index: 227
+  Extra Steps: 2
+  Step   6: 31 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 184   Index: 234
+  Step  18: 32 / Lilith x1, Red Bone x2 (8.912s)
+  Step  28: 33 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  41: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 201   Index:  20
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 201   Index:  37
+Mt.Ordeals Summit                                                             Seed: 201   Index:  37
+Paladin                                                                       Seed: 201   Index:  41
+Mt.Ordeals Summit                                                             Seed: 201   Index:  41
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 201   Index:  64
+  Step  39: 35 / Lilith x2 (9.169s)
+Mt.Ordeals-3rd station                                                        Seed: 201   Index: 106
+  Step   3: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  29: 37 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 201   Index: 136
+  Step  15: 38 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 201   Index: 180
+Take Chocobo to Mysidia                                                       Seed: 201   Index: 193
+Overworld (Mysidia)                                                           Seed: 201   Index: 193
+Town of Baron Serpent Road                                                    Seed: 201   Index: 193
+Credit Warp Fight Search                                                      Seed: 201   Index: 197
+  Overworld (Baron)                                                           Seed: 201   Index: 197
+    Extra Steps: 24
+    Step   2: 39 / Imp x3 (7.174s)
+    Step  24: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  95: 41 / FloatEye x2)
+   (Step 133: 42 / FloatEye x2)
+   (Step 160: 43 / FloatEye x2)
+   (Step 192: 44 / Imp x3, SwordRat x1)
+   (Step 234: 45 / FloatEye x2)
+   (Step 256: 46 / FloatEye x1, Eagle x2)
+
+Encounter Time:      309.725s
+Other Time:          509.128s
+Total Time:          818.853s
+
+Base Total Time:     835.995s
+Time Saved:          17.141s
+
+Optional Steps:      11
+Extra Steps:         82
+Encounters:          40
+
+Base Encounters:     44
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/117.txt
+++ b/data/routes/cw/117.txt
@@ -1,0 +1,146 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	117
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49351739
+VARS	FFFFFFFF:50 E302600:9 E305400:12
+
+Overworld (Kaipo)                                                             Seed: 117   Index:   0
+Overworld (Kaipo)                                                             Seed: 117   Index:   1
+  Step  16: 1 / SandWorm x1 (6.973s)
+Kaipo                                                                         Seed: 117   Index:  37
+Overworld (Kaipo)                                                             Seed: 117   Index:  37
+  Step  12: 2 / Imp x4 (6.944s)
+  Step  22: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 117   Index:  69
+  Step  19: 4 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 117   Index: 101
+Watery Pass-South B1F                                                         Seed: 117   Index: 101
+Watery Pass-South B2F                                                         Seed: 117   Index: 121
+  Step  45: 5 / Pike x3 (7.152s)
+  Step  48: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 117   Index: 211
+  Extra Steps: 12
+Watery Pass-South B2F                                                         Seed: 117   Index: 227
+Watery Pass-South B3F                                                         Seed: 134   Index:  10
+Watery Pass-North B2F                                                         Seed: 134   Index:  44
+  Step   2: 7 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed: 134   Index:  65
+  Step  14: 8 / Aligator x1, Pike x2 (7.368s)
+  Step  25: 9 / CaveToad x4 (7.163s)
+  Step  46: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 134   Index: 125
+Waterfalls B1F                                                                Seed: 134   Index: 134
+Waterfalls B2F                                                                Seed: 134   Index: 135
+  Step  33: 11 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 134   Index: 180
+  Step  28: 12 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 134   Index: 217
+Waterfalls Lake                                                               Seed: 134   Index: 217
+Overworld (Kaipo)                                                             Seed: 134   Index: 218
+Overworld (Damcyan)                                                           Seed: 134   Index: 229
+Damcyan                                                                       Seed: 134   Index: 233
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 134   Index: 240
+Antlion B1F                                                                   Seed: 134   Index: 240
+Antlion B2F Inward Direct                                                     Seed: 151   Index:  22
+  Antlion B2F                                                                 Seed: 151   Index:  22
+    Step  22: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  23: 14 / Weeper x2 (7.114s)
+    Step  61: 15 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 151   Index: 102
+  Step   3: 16 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 151   Index: 116
+Antlion's Nest                                                                Seed: 151   Index: 116
+Antlion B2F Outward Direct                                                    Seed: 151   Index: 131
+  Antlion B2F                                                                 Seed: 151   Index: 131
+    Step  18: 17 / Basilisk x1, Imp x3 (6.783s)
+    Step  42: 18 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 151   Index: 211
+  Step   5: 19 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  32: 20 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 151   Index: 249
+Overworld (Kaipo)                                                             Seed: 151   Index: 249
+Kaipo Revisited                                                               Seed: 151   Index: 249
+Overworld (Kaipo)                                                             Seed: 151   Index: 249
+Overworld (Damcyan)                                                           Seed: 151   Index: 249
+Mt.Hobs-West                                                                  Seed: 151   Index: 249
+  Step  12: 21 / Bomb x3 (8.832s)
+  Step  18: 22 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 168   Index:  32
+Battle: MomBomb                                                               Seed: 168   Index:  47
+Mt.Hobs Summit                                                                Seed: 168   Index:  47
+Mt.Hobs-East                                                                  Seed: 168   Index:  53
+  Step  42: 23 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 168   Index:  99
+  Step  72: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  77: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 168   Index: 183
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed: 168   Index: 252
+Fabul Boat and Leviatan                                                       Seed: 185   Index:   3
+Overworld (Mysidia)                                                           Seed: 185   Index:   3
+Mysidia                                                                       Seed: 185   Index:  12
+Overworld (Mysidia)                                                           Seed: 185   Index:  12
+  Step   9: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Overworld (Mt.Ordeals)                                                        Seed: 185   Index:  22
+  Step  19: 27 / Raven x1 (8.356s)
+  Step  41: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 185   Index: 116
+  Step  29: 29 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed: 185   Index: 159
+  Step  13: 30 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed: 185   Index: 182
+Mt.Ordeals-3rd station                                                        Seed: 185   Index: 182
+  Step   5: 31 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 185   Index: 187
+Mt.Ordeals Summit                                                             Seed: 185   Index: 229
+  Optional Steps: 0
+  Step   4: 32 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed: 185   Index: 246
+Mt.Ordeals Summit                                                             Seed: 185   Index: 246
+Paladin                                                                       Seed: 185   Index: 250
+Mt.Ordeals Summit                                                             Seed: 185   Index: 250
+  Optional Steps: 0
+  Step   2: 33 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  12: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 202   Index:  16
+  Step  22: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 202   Index:  58
+Mt.Ordeals                                                                    Seed: 202   Index:  88
+  Step  15: 36 / Skelton x3, Red Bone x2 (7.997s)
+  Step  21: 37 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 202   Index: 132
+  Step   3: 38 / Raven x1, Cocktric x3 (8.790s)
+Take Chocobo to Mysidia                                                       Seed: 202   Index: 145
+Overworld (Mysidia)                                                           Seed: 202   Index: 145
+Town of Baron Serpent Road                                                    Seed: 202   Index: 145
+Credit Warp Fight Search                                                      Seed: 202   Index: 149
+  Overworld (Baron)                                                           Seed: 202   Index: 149
+    Extra Steps: 50
+    Step   2: 39 / Imp x3 (7.174s)
+    Step  50: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step 143: 41 / FloatEye x2)
+   (Step 181: 42 / FloatEye x2)
+   (Step 235: 43 / FloatEye x2)
+   (Step 240: 44 / Imp x3, SwordRat x1)
+
+Encounter Time:      310.451s
+Other Time:          510.726s
+Total Time:          821.177s
+
+Base Total Time:     909.724s
+Time Saved:          88.548s
+
+Optional Steps:      9
+Extra Steps:         62
+Encounters:          40
+
+Base Encounters:     44
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/118.txt
+++ b/data/routes/cw/118.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	118
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50163835
+VARS	FFFFFFFF:18 E302600:6
+
+Overworld (Kaipo)                                                             Seed: 118   Index:   0
+Overworld (Kaipo)                                                             Seed: 118   Index:   1
+  Step  16: 1 / SandWorm x1 (6.973s)
+Kaipo                                                                         Seed: 118   Index:  37
+Overworld (Kaipo)                                                             Seed: 118   Index:  37
+  Step  12: 2 / Imp x4 (6.944s)
+  Step  22: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 118   Index:  69
+  Step  19: 4 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 118   Index: 101
+Watery Pass-South B1F                                                         Seed: 118   Index: 101
+Watery Pass-South B2F                                                         Seed: 118   Index: 121
+  Step  45: 5 / Pike x3 (7.152s)
+  Step  48: 6 / Pike x3 (7.152s)
+  Step  56: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 118   Index: 211
+Watery Pass-South B2F                                                         Seed: 118   Index: 215
+Watery Pass-South B3F                                                         Seed: 118   Index: 254
+Watery Pass-North B2F                                                         Seed: 135   Index:  32
+  Step  14: 8 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed: 135   Index:  53
+  Step  26: 9 / CaveToad x4 (7.163s)
+  Step  37: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  58: 11 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 135   Index: 113
+Waterfalls B1F                                                                Seed: 135   Index: 122
+Waterfalls B2F                                                                Seed: 135   Index: 123
+  Step  45: 12 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 135   Index: 168
+  Step  30: 13 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed: 135   Index: 205
+Waterfalls Lake                                                               Seed: 135   Index: 205
+Overworld (Kaipo)                                                             Seed: 135   Index: 206
+Overworld (Damcyan)                                                           Seed: 135   Index: 217
+Damcyan                                                                       Seed: 135   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 135   Index: 228
+Antlion B1F                                                                   Seed: 135   Index: 228
+  Step   9: 14 / Turtle x2 (7.487s)
+  Step  10: 15 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 152   Index:  10
+  Antlion B2F                                                                 Seed: 152   Index:  10
+    Step  15: 16 / Basilisk x1, Turtle x1 (7.110s)
+    Step  34: 17 / Basilisk x1, Imp x3 (6.775s)
+    Step  35: 18 / Turtle x2 (7.487s)
+    Step  73: 19 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 152   Index:  90
+Battle: Antlion                                                               Seed: 152   Index: 104
+Antlion's Nest                                                                Seed: 152   Index: 104
+  Step   1: 20 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed: 152   Index: 119
+  Antlion B2F                                                                 Seed: 152   Index: 119
+    Step  30: 21 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  54: 22 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 152   Index: 199
+Overworld (Damcyan)                                                           Seed: 152   Index: 237
+Overworld (Kaipo)                                                             Seed: 152   Index: 237
+Kaipo Revisited                                                               Seed: 152   Index: 237
+Overworld (Kaipo)                                                             Seed: 152   Index: 237
+Overworld (Damcyan)                                                           Seed: 152   Index: 237
+Mt.Hobs-West                                                                  Seed: 152   Index: 237
+  Step   6: 23 / Skelton x4 (8.683s)
+  Step  24: 24 / Gargoyle x1, Cocktric x2 (9.399s)
+  Step  30: 25 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 169   Index:  20
+Battle: MomBomb                                                               Seed: 169   Index:  35
+Mt.Hobs Summit                                                                Seed: 169   Index:  35
+Mt.Hobs-East                                                                  Seed: 169   Index:  41
+Overworld (Fabul)                                                             Seed: 169   Index:  87
+  Step   8: 26 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  84: 27 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 169   Index: 171
+  Optional Steps: 6
+Overworld (Fabul)                                                             Seed: 169   Index: 237
+Fabul Boat and Leviatan                                                       Seed: 169   Index: 244
+Overworld (Mysidia)                                                           Seed: 169   Index: 244
+Mysidia                                                                       Seed: 169   Index: 253
+Overworld (Mysidia)                                                           Seed: 169   Index: 253
+Overworld (Mt.Ordeals)                                                        Seed: 186   Index:   7
+  Step   2: 28 / Raven x1 (8.356s)
+  Step  14: 29 / Raven x1 (8.356s)
+  Step  33: 30 / Needler x2, SwordRat x2 (8.097s)
+  Step  34: 31 / Raven x1 (8.356s)
+  Step  56: 32 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 186   Index: 101
+Mt.Ordeals-3rd station                                                        Seed: 186   Index: 144
+  Step   1: 33 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 186   Index: 167
+Mt.Ordeals-3rd station                                                        Seed: 186   Index: 167
+  Step   5: 34 / Zombie x2, Ghoul x2 (7.616s)
+Mt.Ordeals-7th station                                                        Seed: 186   Index: 172
+  Step  15: 35 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 186   Index: 214
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 186   Index: 231
+Mt.Ordeals Summit                                                             Seed: 186   Index: 231
+  Step   2: 36 / Lilith x1 (8.568s)
+Paladin                                                                       Seed: 186   Index: 235
+Mt.Ordeals Summit                                                             Seed: 186   Index: 235
+  Optional Steps: 0
+  Step  17: 37 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed: 203   Index:   1
+  Step   5: 38 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+  Step  37: 39 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 203   Index:  43
+  Step  27: 40 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed: 203   Index:  73
+  Step  30: 41 / Red Bone x1, Skelton x3 (7.844s)
+  Step  36: 42 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 203   Index: 117
+Take Chocobo to Mysidia                                                       Seed: 203   Index: 130
+Overworld (Mysidia)                                                           Seed: 203   Index: 130
+Town of Baron Serpent Road                                                    Seed: 203   Index: 130
+Credit Warp Fight Search                                                      Seed: 203   Index: 134
+  Overworld (Baron)                                                           Seed: 203   Index: 134
+    Extra Steps: 18
+    Step   1: 43 / FloatEye x2 (7.230s)
+    Step  17: 44 / Imp x3, SwordRat x1 (7.227s)
+   (Step  65: 45 / FloatEye x1, Eagle x2)
+   (Step 158: 46 / FloatEye x1, Eagle x2)
+   (Step 196: 47 / FloatEye x1, Eagle x2)
+   (Step 222: 48 / Eagle x3)
+   (Step 250: 49 / Imp x3, SwordRat x1)
+
+Encounter Time:      344.197s
+Other Time:          490.492s
+Total Time:          834.689s
+
+Base Total Time:     837.169s
+Time Saved:          2.480s
+
+Optional Steps:      6
+Extra Steps:         18
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/119.txt
+++ b/data/routes/cw/119.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	119
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50145842
+VARS	FFFFFFFF:46 E302500:10 E302600:54 E307802:2 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 119   Index:   0
+Overworld (Kaipo)                                                             Seed: 119   Index:   1
+  Step  16: 1 / SandWorm x1 (6.973s)
+Kaipo                                                                         Seed: 119   Index:  37
+Overworld (Kaipo)                                                             Seed: 119   Index:  37
+  Step  12: 2 / Imp x4 (6.944s)
+  Step  22: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 119   Index:  69
+  Step  19: 4 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 119   Index: 101
+Watery Pass-South B1F                                                         Seed: 119   Index: 101
+Watery Pass-South B2F                                                         Seed: 119   Index: 121
+  Step  48: 5 / Pike x3 (7.152s)
+  Step  56: 6 / Pike x3 (7.152s)
+  Step  88: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 119   Index: 211
+Watery Pass-South B2F                                                         Seed: 119   Index: 215
+Watery Pass-South B3F                                                         Seed: 119   Index: 254
+Watery Pass-North B2F                                                         Seed: 136   Index:  32
+Watery Pass-North B1F                                                         Seed: 136   Index:  53
+  Step  18: 8 / Aligator x1, Pike x2 (7.368s)
+  Step  26: 9 / CaveToad x4 (7.163s)
+  Step  37: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  58: 11 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 136   Index: 113
+Waterfalls B1F                                                                Seed: 136   Index: 122
+Waterfalls B2F                                                                Seed: 136   Index: 123
+  Step  45: 12 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 136   Index: 168
+  Step  30: 13 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed: 136   Index: 205
+Waterfalls Lake                                                               Seed: 136   Index: 205
+Overworld (Kaipo)                                                             Seed: 136   Index: 206
+Overworld (Damcyan)                                                           Seed: 136   Index: 217
+Damcyan                                                                       Seed: 136   Index: 221
+  Optional Steps: 0
+  Extra Steps: 10
+Overworld (Damcyan)                                                           Seed: 136   Index: 238
+Antlion B1F                                                                   Seed: 136   Index: 238
+Antlion B2F Inward Direct                                                     Seed: 153   Index:  20
+  Antlion B2F                                                                 Seed: 153   Index:  20
+    Step   5: 14 / Weeper x2 (7.114s)
+    Step  24: 15 / Turtle x2 (7.487s)
+    Step  25: 16 / Basilisk x1, Turtle x1 (7.110s)
+    Step  63: 17 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 153   Index: 100
+  Step   5: 18 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed: 153   Index: 114
+Antlion's Nest                                                                Seed: 153   Index: 114
+Antlion B2F Outward Direct                                                    Seed: 153   Index: 129
+  Antlion B2F                                                                 Seed: 153   Index: 129
+    Extra Steps: 2
+    Step  20: 19 / Basilisk x1, Imp x3 (6.783s)
+    Step  44: 20 / Basilisk x1, Imp x3 (6.783s)
+    Step  82: 21 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 153   Index: 211
+Overworld (Damcyan)                                                           Seed: 153   Index: 249
+Overworld (Kaipo)                                                             Seed: 153   Index: 249
+Kaipo Revisited                                                               Seed: 153   Index: 249
+Overworld (Kaipo)                                                             Seed: 153   Index: 249
+Overworld (Damcyan)                                                           Seed: 153   Index: 249
+Mt.Hobs-West                                                                  Seed: 153   Index: 249
+  Step  12: 22 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 170   Index:  32
+  Step  10: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Battle: MomBomb                                                               Seed: 170   Index:  47
+Mt.Hobs Summit                                                                Seed: 170   Index:  47
+Mt.Hobs-East                                                                  Seed: 170   Index:  53
+  Step  42: 24 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 170   Index:  99
+  Step  72: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  77: 26 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 170   Index: 183
+  Optional Steps: 10
+  Extra Steps: 44
+Overworld (Fabul)                                                             Seed: 187   Index:  41
+Fabul Boat and Leviatan                                                       Seed: 187   Index:  48
+Overworld (Mysidia)                                                           Seed: 187   Index:  48
+Mysidia                                                                       Seed: 187   Index:  57
+Overworld (Mysidia)                                                           Seed: 187   Index:  57
+  Step   6: 27 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 187   Index:  67
+  Step  78: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 187   Index: 161
+  Step  11: 29 / Soul x2, Red Bone x2 (9.583s)
+  Step  30: 30 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 187   Index: 204
+Recruit Tellah                                                                Seed: 187   Index: 227
+Mt.Ordeals-3rd station                                                        Seed: 187   Index: 227
+Mt.Ordeals-7th station                                                        Seed: 187   Index: 232
+  Step   1: 31 / Lilith x1, Red Bone x2 (8.912s)
+  Step  20: 32 / Lilith x1, Red Bone x2 (8.912s)
+  Step  30: 33 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 204   Index:  18
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 204   Index:  36
+Mt.Ordeals Summit                                                             Seed: 204   Index:  36
+  Step   2: 34 / Soul x2, Ghoul x2, Revenant x2 (10.046s)
+Paladin                                                                       Seed: 204   Index:  40
+Mt.Ordeals Summit                                                             Seed: 204   Index:  40
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 204   Index:  63
+  Step   7: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 204   Index: 105
+  Step   4: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  30: 37 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 204   Index: 135
+  Step  16: 38 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 204   Index: 179
+Take Chocobo to Mysidia                                                       Seed: 204   Index: 192
+Overworld (Mysidia)                                                           Seed: 204   Index: 192
+Town of Baron Serpent Road                                                    Seed: 204   Index: 192
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 204   Index: 198
+  Overworld (Baron)                                                           Seed: 204   Index: 198
+    Extra Steps: 46
+    Step   1: 39 / Imp x3 (7.174s)
+    Step  46: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  94: 41 / FloatEye x2)
+   (Step 132: 42 / FloatEye x2)
+   (Step 158: 43 / FloatEye x2)
+   (Step 186: 44 / Eagle x3)
+   (Step 190: 45 / FloatEye x1, Eagle x2)
+   (Step 233: 46 / FloatEye x1, Eagle x2)
+   (Step 255: 47 / FloatEye x1, Eagle x2)
+
+Encounter Time:      313.548s
+Other Time:          520.842s
+Total Time:          834.390s
+
+Base Total Time:     1020.259s
+Time Saved:          185.869s
+
+Optional Steps:      12
+Extra Steps:         104
+Encounters:          40
+
+Base Encounters:     49
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/120.txt
+++ b/data/routes/cw/120.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	120
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50826703
+VARS	FFFFFFFF:6 C307800:1 E302500:143 E302600:7 E305400:56 E307100:2 E307B00:18 E309700:23
+
+Overworld (Kaipo)                                                             Seed: 120   Index:   0
+Overworld (Kaipo)                                                             Seed: 120   Index:   1
+  Step  16: 1 / SandWorm x1 (6.973s)
+  Step  22: 2 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 120   Index:  37
+Overworld (Kaipo)                                                             Seed: 120   Index:  37
+  Step  12: 3 / SandMoth x2, Larva x2 (7.049s)
+  Step  22: 4 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 120   Index:  69
+  Step  19: 5 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 120   Index: 101
+Watery Pass-South B1F                                                         Seed: 120   Index: 101
+Watery Pass-South B2F                                                         Seed: 120   Index: 121
+  Step  48: 6 / Pike x3 (7.152s)
+  Step  56: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  88: 8 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 120   Index: 211
+  Extra Steps: 56
+Watery Pass-South B2F                                                         Seed: 137   Index:  15
+Watery Pass-South B3F                                                         Seed: 137   Index:  54
+  Extra Steps: 2
+  Step  17: 9 / Zombie x4 (7.148s)
+  Step  25: 10 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 137   Index:  90
+  Step  21: 11 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 137   Index: 111
+  Step  57: 12 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 137   Index: 171
+Waterfalls B1F                                                                Seed: 137   Index: 180
+Waterfalls B2F                                                                Seed: 137   Index: 181
+  Step  17: 13 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 137   Index: 226
+  Step  12: 14 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 154   Index:   7
+Waterfalls Lake                                                               Seed: 154   Index:   7
+Overworld (Kaipo)                                                             Seed: 154   Index:   8
+Overworld (Damcyan)                                                           Seed: 154   Index:  19
+Damcyan                                                                       Seed: 154   Index:  23
+  Optional Steps: 1
+  Extra Steps: 142
+Overworld (Damcyan)                                                           Seed: 154   Index: 173
+Antlion B1F                                                                   Seed: 154   Index: 173
+  Step  38: 15 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 154   Index: 211
+  Antlion B2F                                                                 Seed: 154   Index: 211
+  Antlion B2F Treasure Room                                                   Seed: 154   Index: 244
+    Extra Steps: 18
+  Antlion B2F                                                                 Seed: 171   Index:   6
+    Step  36: 16 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed: 171   Index:  58
+Battle: Antlion                                                               Seed: 171   Index:  72
+Antlion's Nest                                                                Seed: 171   Index:  72
+Antlion B2F Outward Direct                                                    Seed: 171   Index:  87
+  Antlion B2F                                                                 Seed: 171   Index:  87
+    Step   8: 17 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 171   Index: 167
+  Step   4: 18 / Turtle x1, Imp x2 (7.009s)
+  Step   9: 19 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  22: 20 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 171   Index: 205
+Overworld (Kaipo)                                                             Seed: 171   Index: 205
+Kaipo Revisited                                                               Seed: 171   Index: 205
+Overworld (Kaipo)                                                             Seed: 171   Index: 205
+Overworld (Damcyan)                                                           Seed: 171   Index: 205
+Mt.Hobs-West                                                                  Seed: 171   Index: 205
+  Step  14: 21 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 171   Index: 244
+Battle: MomBomb                                                               Seed: 188   Index:   3
+Mt.Hobs Summit                                                                Seed: 188   Index:   3
+Mt.Hobs-East                                                                  Seed: 188   Index:   9
+  Step  31: 22 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 188   Index:  55
+  Step   8: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  49: 24 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 188   Index: 139
+  Optional Steps: 7
+Overworld (Fabul)                                                             Seed: 188   Index: 206
+Fabul Boat and Leviatan                                                       Seed: 188   Index: 213
+Overworld (Mysidia)                                                           Seed: 188   Index: 213
+Mysidia                                                                       Seed: 188   Index: 222
+Overworld (Mysidia)                                                           Seed: 188   Index: 222
+Overworld (Mt.Ordeals)                                                        Seed: 188   Index: 232
+  Step   1: 25 / Raven x1 (8.356s)
+  Step  20: 26 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  30: 27 / Raven x1 (8.356s)
+  Step  62: 28 / Raven x1 (8.356s)
+  Step  94: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 205   Index:  70
+  Step  39: 30 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 205   Index: 113
+  Step  21: 31 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed: 205   Index: 136
+Mt.Ordeals-3rd station                                                        Seed: 205   Index: 136
+Mt.Ordeals-7th station                                                        Seed: 205   Index: 141
+  Step  10: 32 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 205   Index: 183
+  Optional Steps: 0
+  Step  16: 33 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 205   Index: 200
+Mt.Ordeals Summit                                                             Seed: 205   Index: 200
+Paladin                                                                       Seed: 205   Index: 204
+Mt.Ordeals Summit                                                             Seed: 205   Index: 204
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 205   Index: 226
+  Step  18: 34 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed: 222   Index:  12
+  Step  24: 35 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 222   Index:  42
+  Step  32: 36 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 222   Index:  86
+Take Chocobo to Mysidia                                                       Seed: 222   Index:  99
+Overworld (Mysidia)                                                           Seed: 222   Index:  99
+Town of Baron Serpent Road                                                    Seed: 222   Index:  99
+  Extra Steps: 23
+Credit Warp Fight Search                                                      Seed: 222   Index: 126
+  Overworld (Baron)                                                           Seed: 222   Index: 126
+    Extra Steps: 6
+    Step   2: 37 / Imp x3 (7.174s)
+    Step   6: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  38: 39 / Imp x3)
+   (Step  49: 40 / Imp x3, SwordRat x1)
+   (Step 164: 41 / FloatEye x2)
+   (Step 196: 42 / FloatEye x2)
+   (Step 228: 43 / FloatEye x2)
+   (Step 243: 44 / Eagle x3)
+
+Encounter Time:      292.597s
+Other Time:          553.122s
+Total Time:          845.719s
+
+Base Total Time:     980.363s
+Time Saved:          134.644s
+
+Optional Steps:      8
+Extra Steps:         247
+Encounters:          38
+
+Base Encounters:     49
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/121.txt
+++ b/data/routes/cw/121.txt
@@ -1,0 +1,157 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	121
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49424773
+VARS	FFFFFFFF:4 C307801:1 E302500:15 E302600:8 E305400:56 E307200:2 E307803:4 E307900:8 E307B01:10 E307E00:2 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 121   Index:   0
+Overworld (Kaipo)                                                             Seed: 121   Index:   1
+  Step  22: 1 / SandWorm x1 (6.973s)
+Kaipo                                                                         Seed: 121   Index:  37
+Overworld (Kaipo)                                                             Seed: 121   Index:  37
+  Step  12: 2 / Imp x4 (6.944s)
+  Step  22: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 121   Index:  69
+  Step  19: 4 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 121   Index: 101
+Watery Pass-South B1F                                                         Seed: 121   Index: 101
+Watery Pass-South B2F                                                         Seed: 121   Index: 121
+  Step  34: 5 / Pike x3 (7.152s)
+  Step  48: 6 / Pike x3 (7.152s)
+  Step  56: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  88: 8 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 121   Index: 211
+  Extra Steps: 56
+Watery Pass-South B2F                                                         Seed: 138   Index:  15
+Watery Pass-South B3F                                                         Seed: 138   Index:  54
+  Step  17: 9 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 138   Index:  88
+  Extra Steps: 2
+  Step  23: 10 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 138   Index: 111
+  Step  57: 11 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 138   Index: 171
+Waterfalls B1F                                                                Seed: 138   Index: 180
+Waterfalls B2F                                                                Seed: 138   Index: 181
+  Step  17: 12 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 138   Index: 226
+  Step  12: 13 / Zombie x6 (7.489s)
+  Step  14: 14 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 155   Index:   7
+Waterfalls Lake                                                               Seed: 155   Index:   7
+Overworld (Kaipo)                                                             Seed: 155   Index:   8
+Overworld (Damcyan)                                                           Seed: 155   Index:  19
+Damcyan                                                                       Seed: 155   Index:  23
+  Optional Steps: 1
+  Extra Steps: 14
+Overworld (Damcyan)                                                           Seed: 155   Index:  45
+Antlion B1F                                                                   Seed: 155   Index:  45
+  Step  38: 15 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 155   Index:  83
+  Antlion B2F                                                                 Seed: 155   Index:  83
+    Step  22: 16 / Basilisk x1, Turtle x1 (7.110s)
+    Step  71: 17 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 155   Index: 163
+  Extra Steps: 8
+  Step  10: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+  Step  22: 19 / Basilisk x1, Imp x3 (6.775s)
+Battle: Antlion                                                               Seed: 155   Index: 185
+Antlion's Nest                                                                Seed: 155   Index: 185
+Antlion B2F Outward Charm Room Steps                                          Seed: 155   Index: 200
+  Antlion B2F                                                                 Seed: 155   Index: 200
+    Step  11: 20 / Basilisk x1, Imp x3 (6.783s)
+  Antlion B2F Treasure Room                                                   Seed: 155   Index: 251
+    Extra Steps: 10
+  Antlion B2F                                                                 Seed: 172   Index:   5
+    Extra Steps: 4
+    Step  37: 21 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 172   Index:  43
+Overworld (Damcyan)                                                           Seed: 172   Index:  81
+Overworld (Kaipo)                                                             Seed: 172   Index:  81
+Kaipo Revisited                                                               Seed: 172   Index:  81
+Overworld (Kaipo)                                                             Seed: 172   Index:  81
+Overworld (Damcyan)                                                           Seed: 172   Index:  81
+Mt.Hobs-West                                                                  Seed: 172   Index:  81
+  Extra Steps: 2
+  Step  14: 22 / Spirit x2 (8.028s)
+  Step  41: 23 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 172   Index: 122
+Battle: MomBomb                                                               Seed: 172   Index: 137
+Mt.Hobs Summit                                                                Seed: 172   Index: 137
+Mt.Hobs-East                                                                  Seed: 172   Index: 143
+  Step  28: 24 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  33: 25 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 172   Index: 189
+  Step  15: 26 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  30: 27 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 189   Index:  17
+  Optional Steps: 8
+Overworld (Fabul)                                                             Seed: 189   Index:  85
+Fabul Boat and Leviatan                                                       Seed: 189   Index:  92
+Overworld (Mysidia)                                                           Seed: 189   Index:  92
+Mysidia                                                                       Seed: 189   Index: 101
+Overworld (Mysidia)                                                           Seed: 189   Index: 101
+  Step   3: 28 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 189   Index: 111
+  Step  34: 29 / Raven x1 (8.356s)
+  Step  61: 30 / Needler x2, SwordRat x2 (8.097s)
+  Step  80: 31 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 189   Index: 205
+  Step  28: 32 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 189   Index: 248
+  Step  14: 33 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 206   Index:  15
+Mt.Ordeals-3rd station                                                        Seed: 206   Index:  15
+Mt.Ordeals-7th station                                                        Seed: 206   Index:  20
+  Step  18: 34 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 206   Index:  62
+  Optional Steps: 1
+  Step   8: 35 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed: 206   Index:  80
+Mt.Ordeals Summit                                                             Seed: 206   Index:  80
+Paladin                                                                       Seed: 206   Index:  84
+Mt.Ordeals Summit                                                             Seed: 206   Index:  84
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 206   Index: 107
+  Step  27: 36 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed: 206   Index: 149
+  Step   2: 37 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 206   Index: 179
+  Step  20: 38 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 206   Index: 223
+Take Chocobo to Mysidia                                                       Seed: 206   Index: 236
+Overworld (Mysidia)                                                           Seed: 206   Index: 236
+Town of Baron Serpent Road                                                    Seed: 206   Index: 236
+Credit Warp Fight Search                                                      Seed: 206   Index: 240
+  Overworld (Baron)                                                           Seed: 206   Index: 240
+    Extra Steps: 4
+    Step   2: 39 / Imp x3 (7.174s)
+    Step   4: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  52: 41 / FloatEye x2)
+   (Step  71: 42 / FloatEye x2)
+   (Step  90: 43 / FloatEye x2)
+   (Step 116: 44 / Eagle x3)
+   (Step 144: 45 / FloatEye x1, Eagle x2)
+   (Step 148: 46 / FloatEye x1, Eagle x2)
+   (Step 180: 47 / FloatEye x1, Eagle x2)
+
+Encounter Time:      309.204s
+Other Time:          513.188s
+Total Time:          822.392s
+
+Base Total Time:     966.649s
+Time Saved:          144.257s
+
+Optional Steps:      11
+Extra Steps:         100
+Encounters:          40
+
+Base Encounters:     49
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/122.txt
+++ b/data/routes/cw/122.txt
@@ -1,0 +1,156 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	122
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49592017
+VARS	FFFFFFFF:4 C307800:1 E302500:7 E302600:8 E307000:16 E307200:2 E307400:28 E307B00:12 E308000:32 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 122   Index:   0
+Overworld (Kaipo)                                                             Seed: 122   Index:   1
+  Step  22: 1 / SandWorm x1 (6.973s)
+Kaipo                                                                         Seed: 122   Index:  37
+Overworld (Kaipo)                                                             Seed: 122   Index:  37
+  Step  22: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 122   Index:  69
+  Step  17: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 122   Index: 101
+Watery Pass-South B1F                                                         Seed: 122   Index: 101
+Watery Pass-South B2F                                                         Seed: 122   Index: 121
+  Step  34: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  48: 5 / Pike x3 (7.152s)
+  Step  56: 6 / Pike x3 (7.152s)
+  Step  88: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 122   Index: 211
+Watery Pass-South B2F                                                         Seed: 122   Index: 215
+  Extra Steps: 16
+  Step  55: 8 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 139   Index:  14
+Watery Pass-North B2F                                                         Seed: 139   Index:  48
+  Extra Steps: 2
+  Step  23: 9 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 139   Index:  71
+  Step  40: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 139   Index: 131
+Waterfalls B1F                                                                Seed: 139   Index: 140
+  Extra Steps: 28
+Waterfalls B2F                                                                Seed: 139   Index: 169
+  Step  29: 11 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 139   Index: 214
+  Step  24: 12 / Aligator x1, Pike x2 (7.368s)
+  Step  26: 13 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed: 139   Index: 251
+Waterfalls Lake                                                               Seed: 139   Index: 251
+Overworld (Kaipo)                                                             Seed: 139   Index: 252
+Overworld (Damcyan)                                                           Seed: 156   Index:   7
+Damcyan                                                                       Seed: 156   Index:  11
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed: 156   Index:  25
+Antlion B1F                                                                   Seed: 156   Index:  25
+Antlion B2F Inward Charm Room Steps                                           Seed: 156   Index:  63
+  Antlion B2F                                                                 Seed: 156   Index:  63
+    Step  20: 14 / Weeper x2 (7.114s)
+  Antlion B2F Treasure Room                                                   Seed: 156   Index:  96
+    Extra Steps: 12
+  Antlion B2F                                                                 Seed: 156   Index: 108
+    Step  46: 15 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 156   Index: 160
+  Step  13: 16 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 156   Index: 174
+Antlion's Nest                                                                Seed: 156   Index: 174
+  Step  11: 17 / Basilisk x1, Imp x3 (6.783s)
+Antlion B2F Outward Direct                                                    Seed: 156   Index: 189
+  Antlion B2F                                                                 Seed: 156   Index: 189
+    Step  22: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  71: 19 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 173   Index:  13
+  Step  29: 20 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 173   Index:  51
+Overworld (Kaipo)                                                             Seed: 173   Index:  51
+Kaipo Revisited                                                               Seed: 173   Index:  51
+Overworld (Kaipo)                                                             Seed: 173   Index:  51
+Overworld (Damcyan)                                                           Seed: 173   Index:  51
+Mt.Hobs-West                                                                  Seed: 173   Index:  51
+Mt.Hobs Summit                                                                Seed: 173   Index:  90
+  Step   5: 21 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed: 173   Index: 105
+Mt.Hobs Summit                                                                Seed: 173   Index: 105
+Mt.Hobs-East                                                                  Seed: 173   Index: 111
+  Extra Steps: 32
+  Step  11: 22 / Gargoyle x2 (7.630s)
+  Step  54: 23 / Spirit x2, Skelton x2 (8.237s)
+  Step  60: 24 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  65: 25 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 173   Index: 189
+  Step  30: 26 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 190   Index:  17
+  Optional Steps: 8
+Overworld (Fabul)                                                             Seed: 190   Index:  85
+Fabul Boat and Leviatan                                                       Seed: 190   Index:  92
+Overworld (Mysidia)                                                           Seed: 190   Index:  92
+Mysidia                                                                       Seed: 190   Index: 101
+Overworld (Mysidia)                                                           Seed: 190   Index: 101
+  Step   3: 27 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 190   Index: 111
+  Step  34: 28 / Raven x1 (8.356s)
+  Step  61: 29 / Raven x1 (8.356s)
+  Step  80: 30 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed: 190   Index: 205
+  Step   9: 31 / Soul x2, Red Bone x2 (9.583s)
+  Step  28: 32 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 190   Index: 248
+  Step  14: 33 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 207   Index:  15
+Mt.Ordeals-3rd station                                                        Seed: 207   Index:  15
+Mt.Ordeals-7th station                                                        Seed: 207   Index:  20
+  Step  18: 34 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 207   Index:  62
+  Optional Steps: 1
+  Step   8: 35 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed: 207   Index:  80
+Mt.Ordeals Summit                                                             Seed: 207   Index:  80
+Paladin                                                                       Seed: 207   Index:  84
+Mt.Ordeals Summit                                                             Seed: 207   Index:  84
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 207   Index: 107
+  Step  27: 36 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed: 207   Index: 149
+  Step   2: 37 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 207   Index: 179
+  Step  28: 38 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 207   Index: 223
+Take Chocobo to Mysidia                                                       Seed: 207   Index: 236
+Overworld (Mysidia)                                                           Seed: 207   Index: 236
+Town of Baron Serpent Road                                                    Seed: 207   Index: 236
+Credit Warp Fight Search                                                      Seed: 207   Index: 240
+  Overworld (Baron)                                                           Seed: 207   Index: 240
+    Extra Steps: 4
+    Step   2: 39 / Imp x3 (7.174s)
+    Step   4: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  52: 41 / FloatEye x2)
+   (Step  71: 42 / FloatEye x2)
+   (Step 116: 43 / FloatEye x2)
+   (Step 144: 44 / Eagle x3)
+   (Step 148: 45 / FloatEye x1, Eagle x2)
+   (Step 180: 46 / FloatEye x1, Eagle x2)
+   (Step 244: 47 / FloatEye x1, Eagle x2)
+
+Encounter Time:      311.986s
+Other Time:          513.188s
+Total Time:          825.175s
+
+Base Total Time:     996.522s
+Time Saved:          171.347s
+
+Optional Steps:      11
+Extra Steps:         100
+Encounters:          40
+
+Base Encounters:     49
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/123.txt
+++ b/data/routes/cw/123.txt
@@ -1,0 +1,158 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	123
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49922967
+VARS	FFFFFFFF:4 C307800:1 C307801:1 E302500:7 E302600:9 E307200:18 E307400:28 E307B00:12 E307B01:20 E308700:1 E308701:6 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 123   Index:   0
+Overworld (Kaipo)                                                             Seed: 123   Index:   1
+  Step  22: 1 / SandWorm x1 (6.973s)
+Kaipo                                                                         Seed: 123   Index:  37
+Overworld (Kaipo)                                                             Seed: 123   Index:  37
+  Step  22: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 123   Index:  69
+  Step  11: 3 / Pike x3 (6.935s)
+  Step  17: 4 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 123   Index: 101
+Watery Pass-South B1F                                                         Seed: 123   Index: 101
+Watery Pass-South B2F                                                         Seed: 123   Index: 121
+  Step  34: 5 / Pike x3 (7.152s)
+  Step  48: 6 / Pike x3 (7.152s)
+  Step  56: 7 / Pike x3 (7.152s)
+  Step  88: 8 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 123   Index: 211
+Watery Pass-South B2F                                                         Seed: 123   Index: 215
+Watery Pass-South B3F                                                         Seed: 123   Index: 254
+  Step  16: 9 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 140   Index:  32
+  Extra Steps: 18
+  Step  39: 10 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 140   Index:  71
+  Step  39: 11 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 140   Index: 131
+Waterfalls B1F                                                                Seed: 140   Index: 140
+  Extra Steps: 28
+Waterfalls B2F                                                                Seed: 140   Index: 169
+  Step  29: 12 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 140   Index: 214
+  Step  24: 13 / Zombie x6 (7.489s)
+  Step  26: 14 / Mad Toad x4 (7.317s)
+Battle: Octomamm                                                              Seed: 140   Index: 251
+Waterfalls Lake                                                               Seed: 140   Index: 251
+Overworld (Kaipo)                                                             Seed: 140   Index: 252
+Overworld (Damcyan)                                                           Seed: 157   Index:   7
+Damcyan                                                                       Seed: 157   Index:  11
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed: 157   Index:  25
+Antlion B1F                                                                   Seed: 157   Index:  25
+Antlion B2F Inward Charm Room Steps                                           Seed: 157   Index:  63
+  Antlion B2F                                                                 Seed: 157   Index:  63
+  Antlion B2F Treasure Room                                                   Seed: 157   Index:  96
+    Extra Steps: 12
+  Antlion B2F                                                                 Seed: 157   Index: 108
+    Step  46: 15 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 157   Index: 160
+  Step  13: 16 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 157   Index: 174
+Antlion's Nest                                                                Seed: 157   Index: 174
+  Step  11: 17 / Turtle x2 (7.464s)
+Antlion B2F Outward Charm Room Steps                                          Seed: 157   Index: 189
+  Antlion B2F                                                                 Seed: 157   Index: 189
+    Step  22: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Antlion B2F Treasure Room                                                   Seed: 157   Index: 240
+    Extra Steps: 20
+  Antlion B2F                                                                 Seed: 174   Index:   4
+Antlion B1F                                                                   Seed: 174   Index:  38
+  Step   4: 19 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 174   Index:  76
+Overworld (Kaipo)                                                             Seed: 174   Index:  76
+Kaipo Revisited                                                               Seed: 174   Index:  76
+Overworld (Kaipo)                                                             Seed: 174   Index:  76
+Overworld (Damcyan)                                                           Seed: 174   Index:  76
+Mt.Hobs-West                                                                  Seed: 174   Index:  76
+  Step  19: 20 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 174   Index: 115
+  Step   7: 21 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed: 174   Index: 130
+Mt.Hobs Summit                                                                Seed: 174   Index: 130
+Mt.Hobs-East                                                                  Seed: 174   Index: 136
+  Step  29: 22 / Gargoyle x2 (7.630s)
+  Step  34: 23 / Spirit x2, Skelton x2 (8.237s)
+  Step  40: 24 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 174   Index: 182
+  Step  37: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 191   Index:  10
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed: 191   Index:  79
+Fabul Boat and Leviatan                                                       Seed: 191   Index:  86
+Overworld (Mysidia)                                                           Seed: 191   Index:  86
+Mysidia                                                                       Seed: 191   Index:  95
+Overworld (Mysidia)                                                           Seed: 191   Index:  95
+  Step   9: 26 / Imp Cap. x3, Needler x1 (7.932s)
+Overworld (Mt.Ordeals)                                                        Seed: 191   Index: 105
+  Step  40: 27 / Needler x2, SwordRat x2 (8.097s)
+  Step  67: 28 / Raven x1 (8.356s)
+  Step  79: 29 / Raven x1 (8.356s)
+  Step  86: 30 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed: 191   Index: 199
+  Step  15: 31 / Soul x2, Red Bone x2 (9.583s)
+  Step  34: 32 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 191   Index: 242
+  Step  20: 33 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 208   Index:   9
+Mt.Ordeals-3rd station                                                        Seed: 208   Index:   9
+Mt.Ordeals-7th station                                                        Seed: 208   Index:  14
+  Step  24: 34 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 208   Index:  56
+  Optional Steps: 1
+  Step  14: 35 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed: 208   Index:  74
+Mt.Ordeals Summit                                                             Seed: 208   Index:  74
+  Extra Steps: 6
+  Step  10: 36 / Soul x3, Ghoul x1, Revenant x1 (9.512s)
+Paladin                                                                       Seed: 208   Index:  84
+Mt.Ordeals Summit                                                             Seed: 208   Index:  84
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 208   Index: 107
+  Step  27: 37 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 208   Index: 149
+Mt.Ordeals                                                                    Seed: 208   Index: 179
+  Step  28: 38 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 208   Index: 223
+Take Chocobo to Mysidia                                                       Seed: 208   Index: 236
+Overworld (Mysidia)                                                           Seed: 208   Index: 236
+Town of Baron Serpent Road                                                    Seed: 208   Index: 236
+Credit Warp Fight Search                                                      Seed: 208   Index: 240
+  Overworld (Baron)                                                           Seed: 208   Index: 240
+    Extra Steps: 4
+    Step   2: 39 / FloatEye x2 (7.230s)
+    Step   4: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  19: 41 / FloatEye x2)
+   (Step  71: 42 / FloatEye x2)
+   (Step 116: 43 / FloatEye x2)
+   (Step 144: 44 / Eagle x3)
+   (Step 148: 45 / FloatEye x1, Eagle x2)
+   (Step 180: 46 / FloatEye x1, Eagle x2)
+   (Step 244: 47 / FloatEye x1, Eagle x2)
+
+Encounter Time:      314.498s
+Other Time:          516.183s
+Total Time:          830.681s
+
+Base Total Time:     961.424s
+Time Saved:          130.742s
+
+Optional Steps:      12
+Extra Steps:         94
+Encounters:          40
+
+Base Encounters:     49
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/124.txt
+++ b/data/routes/cw/124.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	124
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48626490
+VARS	FFFFFFFF:4 C307800:1 E302500:7 E302600:10 E307000:16 E307200:2 E307400:28 E307B00:42 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 124   Index:   0
+Overworld (Kaipo)                                                             Seed: 124   Index:   1
+  Step  22: 1 / SandWorm x1 (6.973s)
+Kaipo                                                                         Seed: 124   Index:  37
+Overworld (Kaipo)                                                             Seed: 124   Index:  37
+Watery Pass-South B1F                                                         Seed: 124   Index:  69
+  Step  11: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  17: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 124   Index: 101
+Watery Pass-South B1F                                                         Seed: 124   Index: 101
+  Step  11: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 124   Index: 121
+  Step  34: 5 / Pike x3 (7.152s)
+  Step  56: 6 / Pike x3 (7.152s)
+  Step  88: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 124   Index: 211
+Watery Pass-South B2F                                                         Seed: 124   Index: 215
+  Extra Steps: 16
+  Step  55: 8 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 141   Index:  14
+Watery Pass-North B2F                                                         Seed: 141   Index:  48
+  Extra Steps: 2
+  Step  23: 9 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 141   Index:  71
+  Step  39: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 141   Index: 131
+Waterfalls B1F                                                                Seed: 141   Index: 140
+  Extra Steps: 28
+Waterfalls B2F                                                                Seed: 141   Index: 169
+  Step  29: 11 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 141   Index: 214
+  Step  26: 12 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed: 141   Index: 251
+Waterfalls Lake                                                               Seed: 141   Index: 251
+Overworld (Kaipo)                                                             Seed: 141   Index: 252
+Overworld (Damcyan)                                                           Seed: 158   Index:   7
+Damcyan                                                                       Seed: 158   Index:  11
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed: 158   Index:  25
+Antlion B1F                                                                   Seed: 158   Index:  25
+Antlion B2F Inward Charm Room Steps                                           Seed: 158   Index:  63
+  Antlion B2F                                                                 Seed: 158   Index:  63
+  Antlion B2F Treasure Room                                                   Seed: 158   Index:  96
+    Extra Steps: 42
+  Antlion B2F                                                                 Seed: 158   Index: 138
+    Step  16: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  47: 14 / SandWorm x2 (6.841s)
+Antlion's Nest                                                                Seed: 158   Index: 190
+Battle: Antlion                                                               Seed: 158   Index: 204
+Antlion's Nest                                                                Seed: 158   Index: 204
+  Step   7: 15 / Turtle x2 (7.464s)
+Antlion B2F Outward Direct                                                    Seed: 158   Index: 219
+  Antlion B2F                                                                 Seed: 158   Index: 219
+    Step  29: 16 / Basilisk x1, Turtle x1 (7.124s)
+    Step  41: 17 / Turtle x2 (7.464s)
+    Step  79: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 175   Index:  43
+Overworld (Damcyan)                                                           Seed: 175   Index:  81
+Overworld (Kaipo)                                                             Seed: 175   Index:  81
+Kaipo Revisited                                                               Seed: 175   Index:  81
+Overworld (Kaipo)                                                             Seed: 175   Index:  81
+Overworld (Damcyan)                                                           Seed: 175   Index:  81
+Mt.Hobs-West                                                                  Seed: 175   Index:  81
+Mt.Hobs Summit                                                                Seed: 175   Index: 120
+  Step   2: 19 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed: 175   Index: 135
+Mt.Hobs Summit                                                                Seed: 175   Index: 135
+Mt.Hobs-East                                                                  Seed: 175   Index: 141
+  Step  24: 20 / Gargoyle x2 (7.630s)
+  Step  29: 21 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  35: 22 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 175   Index: 187
+  Step  15: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  32: 24 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 192   Index:  15
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 192   Index:  85
+Fabul Boat and Leviatan                                                       Seed: 192   Index:  92
+Overworld (Mysidia)                                                           Seed: 192   Index:  92
+Mysidia                                                                       Seed: 192   Index: 101
+Overworld (Mysidia)                                                           Seed: 192   Index: 101
+  Step   3: 25 / Raven x1 (8.356s)
+  Step   5: 26 / Imp Cap. x3, Needler x1 (7.932s)
+Overworld (Mt.Ordeals)                                                        Seed: 192   Index: 111
+  Step  61: 27 / Needler x2, SwordRat x2 (8.097s)
+  Step  73: 28 / Raven x1 (8.356s)
+  Step  80: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 192   Index: 205
+  Step   9: 30 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 192   Index: 248
+Recruit Tellah                                                                Seed: 209   Index:  15
+Mt.Ordeals-3rd station                                                        Seed: 209   Index:  15
+Mt.Ordeals-7th station                                                        Seed: 209   Index:  20
+  Step  18: 31 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 209   Index:  62
+  Optional Steps: 1
+  Step   8: 32 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed: 209   Index:  80
+Mt.Ordeals Summit                                                             Seed: 209   Index:  80
+  Step   4: 33 / Soul x2, Ghoul x2, Revenant x2 (10.046s)
+Paladin                                                                       Seed: 209   Index:  84
+Mt.Ordeals Summit                                                             Seed: 209   Index:  84
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 209   Index: 107
+  Step  27: 34 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  32: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 209   Index: 149
+Mt.Ordeals                                                                    Seed: 209   Index: 179
+  Step  28: 36 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 209   Index: 223
+Take Chocobo to Mysidia                                                       Seed: 209   Index: 236
+Overworld (Mysidia)                                                           Seed: 209   Index: 236
+Town of Baron Serpent Road                                                    Seed: 209   Index: 236
+Credit Warp Fight Search                                                      Seed: 209   Index: 240
+  Overworld (Baron)                                                           Seed: 209   Index: 240
+    Extra Steps: 4
+    Step   2: 37 / Imp x3 (7.174s)
+    Step   4: 38 / Imp x6 (7.090s)
+   (Step  19: 39 / FloatEye x2)
+   (Step  71: 40 / Imp x3, SwordRat x1)
+   (Step 116: 41 / FloatEye x2)
+   (Step 148: 42 / FloatEye x2)
+   (Step 180: 43 / FloatEye x2)
+   (Step 208: 44 / Eagle x3)
+   (Step 244: 45 / FloatEye x1, Eagle x2)
+
+Encounter Time:      296.453s
+Other Time:          512.656s
+Total Time:          809.109s
+
+Base Total Time:     953.330s
+Time Saved:          144.221s
+
+Optional Steps:      13
+Extra Steps:         98
+Encounters:          38
+
+Base Encounters:     48
+Encounters Saved:    10
+
+Number of Variables: 54

--- a/data/routes/cw/125.txt
+++ b/data/routes/cw/125.txt
@@ -1,0 +1,158 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	125
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48284929
+VARS	FFFFFFFF:8 C307800:1 C307801:1 E302500:1 E302600:18 E307000:16 E307200:2 E307400:12 E307B00:2 E307B01:4 E308700:1 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed: 125   Index:   0
+Overworld (Kaipo)                                                             Seed: 125   Index:   1
+  Step  22: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 125   Index:  37
+Overworld (Kaipo)                                                             Seed: 125   Index:  37
+Watery Pass-South B1F                                                         Seed: 125   Index:  69
+  Step  11: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  17: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 125   Index: 101
+Watery Pass-South B1F                                                         Seed: 125   Index: 101
+  Step  11: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 125   Index: 121
+  Step  34: 5 / Pike x3 (7.152s)
+  Step  39: 6 / Pike x3 (7.152s)
+  Step  88: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 125   Index: 211
+Watery Pass-South B2F                                                         Seed: 125   Index: 215
+  Extra Steps: 16
+  Step  55: 8 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 142   Index:  14
+Watery Pass-North B2F                                                         Seed: 142   Index:  48
+  Extra Steps: 2
+  Step  23: 9 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 142   Index:  71
+  Step  39: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 142   Index: 131
+Waterfalls B1F                                                                Seed: 142   Index: 140
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed: 142   Index: 153
+  Step  21: 11 / Aligator x2 (7.544s)
+  Step  45: 12 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 142   Index: 198
+Battle: Octomamm                                                              Seed: 142   Index: 235
+Waterfalls Lake                                                               Seed: 142   Index: 235
+Overworld (Kaipo)                                                             Seed: 142   Index: 236
+  Step   4: 13 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed: 142   Index: 247
+Damcyan                                                                       Seed: 142   Index: 251
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 159   Index:   3
+Antlion B1F                                                                   Seed: 159   Index:   3
+  Step  22: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 159   Index:  41
+  Antlion B2F                                                                 Seed: 159   Index:  41
+  Antlion B2F Treasure Room                                                   Seed: 159   Index:  74
+    Extra Steps: 2
+  Antlion B2F                                                                 Seed: 159   Index:  76
+    Step  32: 15 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 159   Index: 128
+  Step  10: 16 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 159   Index: 142
+Antlion's Nest                                                                Seed: 159   Index: 142
+  Step  12: 17 / Turtle x2 (7.464s)
+Antlion B2F Outward Charm Room Steps                                          Seed: 159   Index: 157
+  Antlion B2F                                                                 Seed: 159   Index: 157
+    Step  28: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Antlion B2F Treasure Room                                                   Seed: 159   Index: 208
+    Extra Steps: 4
+  Antlion B2F                                                                 Seed: 159   Index: 212
+Antlion B1F                                                                   Seed: 159   Index: 246
+  Step   2: 19 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  14: 20 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 176   Index:  28
+Overworld (Kaipo)                                                             Seed: 176   Index:  28
+Kaipo Revisited                                                               Seed: 176   Index:  28
+Overworld (Kaipo)                                                             Seed: 176   Index:  28
+Overworld (Damcyan)                                                           Seed: 176   Index:  28
+Mt.Hobs-West                                                                  Seed: 176   Index:  28
+  Step  14: 21 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 176   Index:  67
+Battle: MomBomb                                                               Seed: 176   Index:  82
+Mt.Hobs Summit                                                                Seed: 176   Index:  82
+Mt.Hobs-East                                                                  Seed: 176   Index:  88
+  Step  34: 22 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 176   Index: 134
+  Step  31: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  36: 24 / Cocktric x3 (8.241s)
+  Step  42: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  68: 26 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 176   Index: 218
+  Optional Steps: 10
+  Extra Steps: 8
+Overworld (Fabul)                                                             Seed: 193   Index:  40
+Fabul Boat and Leviatan                                                       Seed: 193   Index:  47
+Overworld (Mysidia)                                                           Seed: 193   Index:  47
+Mysidia                                                                       Seed: 193   Index:  56
+Overworld (Mysidia)                                                           Seed: 193   Index:  56
+Overworld (Mt.Ordeals)                                                        Seed: 193   Index:  66
+  Step  38: 27 / Needler x2, SwordRat x2 (8.097s)
+  Step  40: 28 / Raven x1 (8.356s)
+  Step  90: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 193   Index: 160
+  Step  24: 30 / Lilith x1, Red Bone x2 (9.259s)
+  Step  31: 31 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed: 193   Index: 203
+  Step  11: 32 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed: 193   Index: 226
+Mt.Ordeals-3rd station                                                        Seed: 193   Index: 226
+Mt.Ordeals-7th station                                                        Seed: 193   Index: 231
+Mt.Ordeals Summit                                                             Seed: 210   Index:  17
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 210   Index:  35
+Mt.Ordeals Summit                                                             Seed: 210   Index:  35
+Paladin                                                                       Seed: 210   Index:  39
+Mt.Ordeals Summit                                                             Seed: 210   Index:  39
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 210   Index:  62
+  Step   8: 33 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  22: 34 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed: 210   Index: 104
+  Step  30: 35 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 210   Index: 134
+  Step   5: 36 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 210   Index: 178
+Take Chocobo to Mysidia                                                       Seed: 210   Index: 191
+Overworld (Mysidia)                                                           Seed: 210   Index: 191
+Town of Baron Serpent Road                                                    Seed: 210   Index: 191
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed: 210   Index: 199
+  Overworld (Baron)                                                           Seed: 210   Index: 199
+    Extra Steps: 8
+    Step   1: 37 / Imp x3 (7.174s)
+    Step   8: 38 / Imp x6 (7.090s)
+   (Step  43: 39 / FloatEye x2)
+   (Step  45: 40 / Imp x3, SwordRat x1)
+   (Step  60: 41 / FloatEye x2)
+   (Step 112: 42 / FloatEye x2)
+   (Step 189: 43 / FloatEye x2)
+   (Step 221: 44 / Eagle x3)
+   (Step 247: 45 / FloatEye x1, Eagle x2)
+   (Step 249: 46 / FloatEye x1, Eagle x2)
+
+Encounter Time:      296.294s
+Other Time:          507.131s
+Total Time:          803.426s
+
+Base Total Time:     922.724s
+Time Saved:          119.298s
+
+Optional Steps:      13
+Extra Steps:         56
+Encounters:          38
+
+Base Encounters:     48
+Encounters Saved:    10
+
+Number of Variables: 54

--- a/data/routes/cw/126.txt
+++ b/data/routes/cw/126.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	126
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48670178
+VARS	FFFFFFFF:8 E000301:14 E000501:8 E302500:1 E302600:10 E307200:18 E307400:12 E308700:1 E308702:1 E309700:6
+
+Overworld (Kaipo)                                                             Seed: 126   Index:   0
+Overworld (Kaipo)                                                             Seed: 126   Index:   1
+  Step  22: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 126   Index:  37
+Overworld (Kaipo)                                                             Seed: 126   Index:  37
+Watery Pass-South B1F                                                         Seed: 126   Index:  69
+  Step  11: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  17: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 126   Index: 101
+Watery Pass-South B1F                                                         Seed: 126   Index: 101
+  Step  11: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 126   Index: 121
+  Step  34: 5 / Pike x3 (7.152s)
+  Step  39: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 126   Index: 211
+Watery Pass-South B2F                                                         Seed: 126   Index: 215
+Watery Pass-South B3F                                                         Seed: 126   Index: 254
+  Step  16: 7 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 143   Index:  32
+  Extra Steps: 18
+  Step  39: 8 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed: 143   Index:  71
+  Step  36: 9 / CaveToad x4 (7.163s)
+  Step  39: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 143   Index: 131
+Waterfalls B1F                                                                Seed: 143   Index: 140
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed: 143   Index: 153
+  Step  21: 11 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed: 143   Index: 198
+Battle: Octomamm                                                              Seed: 143   Index: 235
+Waterfalls Lake                                                               Seed: 143   Index: 235
+Overworld (Kaipo)                                                             Seed: 143   Index: 236
+  Step   4: 12 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed: 143   Index: 247
+Damcyan                                                                       Seed: 143   Index: 251
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 160   Index:   3
+  Extra Steps: 14
+  Step  13: 13 / SandWorm x1, Sandpede x1 (7.162s)
+Antlion B1F                                                                   Seed: 160   Index:  17
+Antlion B2F Inward Direct                                                     Seed: 160   Index:  55
+  Antlion B2F                                                                 Seed: 160   Index:  55
+    Step  20: 14 / SandWorm x2 (6.841s)
+    Step  53: 15 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 160   Index: 135
+  Step   3: 16 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 160   Index: 149
+Antlion's Nest                                                                Seed: 160   Index: 149
+  Step   5: 17 / Turtle x2 (7.464s)
+Antlion B2F Outward Direct                                                    Seed: 160   Index: 164
+  Antlion B2F                                                                 Seed: 160   Index: 164
+    Step  21: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  47: 19 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 160   Index: 244
+  Step   4: 20 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  16: 21 / Cream x4 (7.523s)
+  Step  21: 22 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 177   Index:  26
+Overworld (Kaipo)                                                             Seed: 177   Index:  26
+Kaipo Revisited                                                               Seed: 177   Index:  26
+Overworld (Kaipo)                                                             Seed: 177   Index:  26
+Overworld (Damcyan)                                                           Seed: 177   Index:  26
+Mt.Hobs-West                                                                  Seed: 177   Index:  26
+  Step  16: 23 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 177   Index:  65
+Battle: MomBomb                                                               Seed: 177   Index:  80
+Mt.Hobs Summit                                                                Seed: 177   Index:  80
+Mt.Hobs-East                                                                  Seed: 177   Index:  86
+  Step  36: 24 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 177   Index: 132
+  Step  33: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  38: 26 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  44: 27 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  70: 28 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 177   Index: 216
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 194   Index:  30
+Fabul Boat and Leviatan                                                       Seed: 194   Index:  37
+Overworld (Mysidia)                                                           Seed: 194   Index:  37
+Mysidia                                                                       Seed: 194   Index:  46
+Overworld (Mysidia)                                                           Seed: 194   Index:  46
+  Extra Steps: 8
+Overworld (Mt.Ordeals)                                                        Seed: 194   Index:  64
+  Step  40: 29 / Raven x1 (8.356s)
+  Step  42: 30 / Raven x1, Cocktric x3 (9.100s)
+  Step  92: 31 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 194   Index: 158
+  Step  26: 32 / Skelton x3, Red Bone x2 (8.244s)
+  Step  33: 33 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 194   Index: 201
+  Step  13: 34 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed: 194   Index: 224
+Mt.Ordeals-3rd station                                                        Seed: 194   Index: 224
+Mt.Ordeals-7th station                                                        Seed: 194   Index: 229
+Mt.Ordeals Summit                                                             Seed: 211   Index:  15
+  Optional Steps: 1
+  Step   7: 35 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed: 211   Index:  33
+Mt.Ordeals Summit                                                             Seed: 211   Index:  33
+Paladin                                                                       Seed: 211   Index:  37
+Mt.Ordeals Summit                                                             Seed: 211   Index:  37
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 211   Index:  60
+  Step  24: 36 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-3rd station                                                        Seed: 211   Index: 102
+Mt.Ordeals                                                                    Seed: 211   Index: 132
+  Step   2: 37 / Spirit x2, Skelton x2 (8.065s)
+  Step   7: 38 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 211   Index: 176
+Take Chocobo to Mysidia                                                       Seed: 211   Index: 189
+Overworld (Mysidia)                                                           Seed: 211   Index: 189
+Town of Baron Serpent Road                                                    Seed: 211   Index: 189
+  Extra Steps: 6
+Credit Warp Fight Search                                                      Seed: 211   Index: 199
+  Overworld (Baron)                                                           Seed: 211   Index: 199
+    Extra Steps: 8
+    Step   1: 39 / FloatEye x2 (7.230s)
+    Step   8: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  43: 41 / FloatEye x2)
+   (Step  60: 42 / FloatEye x2)
+   (Step 112: 43 / FloatEye x2)
+   (Step 188: 44 / Eagle x3)
+   (Step 221: 45 / FloatEye x1, Eagle x2)
+   (Step 247: 46 / FloatEye x1, Eagle x2)
+   (Step 249: 47 / FloatEye x1, Eagle x2)
+
+Encounter Time:      309.227s
+Other Time:          500.609s
+Total Time:          809.836s
+
+Base Total Time:     955.140s
+Time Saved:          145.304s
+
+Optional Steps:      13
+Extra Steps:         66
+Encounters:          40
+
+Base Encounters:     48
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/127.txt
+++ b/data/routes/cw/127.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	127
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48655697
+VARS	FFFFFFFF:8 E302500:1 E302600:10 E307400:30 E307900:4 E308501:10 E308700:1 E308702:1 E309700:14
+
+Overworld (Kaipo)                                                             Seed: 127   Index:   0
+Overworld (Kaipo)                                                             Seed: 127   Index:   1
+  Step  22: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 127   Index:  37
+Overworld (Kaipo)                                                             Seed: 127   Index:  37
+Watery Pass-South B1F                                                         Seed: 127   Index:  69
+  Step  11: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  17: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 127   Index: 101
+Watery Pass-South B1F                                                         Seed: 127   Index: 101
+  Step  11: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 127   Index: 121
+  Step  34: 5 / Pike x3 (7.152s)
+  Step  39: 6 / CaveToad x3 (7.014s)
+  Step  87: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 127   Index: 211
+Watery Pass-South B2F                                                         Seed: 127   Index: 215
+Watery Pass-South B3F                                                         Seed: 127   Index: 254
+Watery Pass-North B2F                                                         Seed: 144   Index:  32
+Watery Pass-North B1F                                                         Seed: 144   Index:  53
+  Step  54: 8 / Aligator x1, Pike x2 (7.368s)
+  Step  57: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 144   Index: 113
+Waterfalls B1F                                                                Seed: 144   Index: 122
+  Extra Steps: 30
+Waterfalls B2F                                                                Seed: 144   Index: 153
+  Step  21: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 144   Index: 198
+  Step  18: 11 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed: 144   Index: 235
+Waterfalls Lake                                                               Seed: 144   Index: 235
+Overworld (Kaipo)                                                             Seed: 144   Index: 236
+  Step   4: 12 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed: 144   Index: 247
+Damcyan                                                                       Seed: 144   Index: 251
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 161   Index:   3
+Antlion B1F                                                                   Seed: 161   Index:   3
+  Step  13: 13 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed: 161   Index:  41
+  Antlion B2F                                                                 Seed: 161   Index:  41
+    Step  34: 14 / SandWorm x2 (6.841s)
+    Step  67: 15 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 161   Index: 121
+  Extra Steps: 4
+  Step  17: 16 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 161   Index: 139
+Antlion's Nest                                                                Seed: 161   Index: 139
+  Step  15: 17 / Turtle x2 (7.464s)
+Antlion B2F Outward Direct                                                    Seed: 161   Index: 154
+  Antlion B2F                                                                 Seed: 161   Index: 154
+    Step  31: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  42: 19 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 161   Index: 234
+  Step  14: 20 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  26: 21 / Cream x4 (7.523s)
+  Step  31: 22 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 178   Index:  16
+Overworld (Kaipo)                                                             Seed: 178   Index:  16
+Kaipo Revisited                                                               Seed: 178   Index:  16
+Overworld (Kaipo)                                                             Seed: 178   Index:  16
+Overworld (Damcyan)                                                           Seed: 178   Index:  16
+Mt.Hobs-West                                                                  Seed: 178   Index:  16
+  Step  25: 23 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 178   Index:  55
+Battle: MomBomb                                                               Seed: 178   Index:  70
+Mt.Hobs Summit                                                                Seed: 178   Index:  70
+Mt.Hobs-East                                                                  Seed: 178   Index:  76
+  Step  46: 24 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 178   Index: 122
+  Step  43: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  48: 26 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  80: 27 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 178   Index: 206
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 195   Index:  20
+Fabul Boat and Leviatan                                                       Seed: 195   Index:  27
+Overworld (Mysidia)                                                           Seed: 195   Index:  27
+Mysidia                                                                       Seed: 195   Index:  36
+Overworld (Mysidia)                                                           Seed: 195   Index:  36
+Overworld (Mt.Ordeals)                                                        Seed: 195   Index:  46
+  Step  58: 28 / Needler x2, SwordRat x2 (8.097s)
+  Step  60: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 195   Index: 140
+  Step  16: 30 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed: 195   Index: 183
+  Step   1: 31 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed: 195   Index: 206
+Mt.Ordeals-3rd station                                                        Seed: 195   Index: 206
+  Extra Steps: 10
+  Step   8: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  15: 33 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 195   Index: 221
+Mt.Ordeals Summit                                                             Seed: 212   Index:   7
+  Optional Steps: 1
+  Step  15: 34 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 212   Index:  25
+Mt.Ordeals Summit                                                             Seed: 212   Index:  25
+Paladin                                                                       Seed: 212   Index:  29
+Mt.Ordeals Summit                                                             Seed: 212   Index:  29
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 212   Index:  52
+  Step  32: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 212   Index:  94
+  Step   7: 36 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals                                                                    Seed: 212   Index: 124
+  Step  10: 37 / Spirit x2, Skelton x2 (8.065s)
+  Step  15: 38 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 212   Index: 168
+Take Chocobo to Mysidia                                                       Seed: 212   Index: 181
+Overworld (Mysidia)                                                           Seed: 212   Index: 181
+Town of Baron Serpent Road                                                    Seed: 212   Index: 181
+  Extra Steps: 14
+Credit Warp Fight Search                                                      Seed: 212   Index: 199
+  Overworld (Baron)                                                           Seed: 212   Index: 199
+    Extra Steps: 8
+    Step   1: 39 / FloatEye x2 (7.230s)
+    Step   8: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  43: 41 / FloatEye x2)
+   (Step  60: 42 / FloatEye x2)
+   (Step 112: 43 / FloatEye x2)
+   (Step 188: 44 / Eagle x3)
+   (Step 194: 45 / FloatEye x1, Eagle x2)
+   (Step 247: 46 / FloatEye x1, Eagle x2)
+   (Step 249: 47 / FloatEye x1, Eagle x2)
+
+Encounter Time:      308.986s
+Other Time:          500.609s
+Total Time:          809.595s
+
+Base Total Time:     994.273s
+Time Saved:          184.678s
+
+Optional Steps:      13
+Extra Steps:         66
+Encounters:          40
+
+Base Encounters:     48
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/128.txt
+++ b/data/routes/cw/128.txt
@@ -1,0 +1,145 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	128
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48035365
+VARS	FFFFFFFF:8 E302500:1 E302600:2
+
+Overworld (Kaipo)                                                             Seed: 128   Index:   0
+Overworld (Kaipo)                                                             Seed: 128   Index:   1
+Kaipo                                                                         Seed: 128   Index:  37
+Overworld (Kaipo)                                                             Seed: 128   Index:  37
+  Step   9: 1 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 128   Index:  69
+  Step  11: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  17: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 128   Index: 101
+Watery Pass-South B1F                                                         Seed: 128   Index: 101
+  Step  11: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 128   Index: 121
+  Step  39: 5 / Pike x3 (7.152s)
+  Step  87: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 128   Index: 211
+Watery Pass-South B2F                                                         Seed: 128   Index: 215
+Watery Pass-South B3F                                                         Seed: 128   Index: 254
+Watery Pass-North B2F                                                         Seed: 145   Index:  32
+Watery Pass-North B1F                                                         Seed: 145   Index:  53
+  Step  54: 7 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  57: 8 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed: 145   Index: 113
+Waterfalls B1F                                                                Seed: 145   Index: 122
+Waterfalls B2F                                                                Seed: 145   Index: 123
+  Step  19: 9 / Aligator x2 (7.544s)
+  Step  29: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 145   Index: 168
+  Step   6: 11 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed: 145   Index: 205
+Waterfalls Lake                                                               Seed: 145   Index: 205
+Overworld (Kaipo)                                                             Seed: 145   Index: 206
+  Step  10: 12 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed: 145   Index: 217
+Damcyan                                                                       Seed: 145   Index: 221
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 145   Index: 229
+Antlion B1F                                                                   Seed: 145   Index: 229
+  Step  11: 13 / Cream x4 (7.552s)
+  Step  14: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+  Step  38: 15 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 162   Index:  11
+  Antlion B2F                                                                 Seed: 162   Index:  11
+    Step   5: 16 / Basilisk x1, Turtle x1 (7.110s)
+    Step  64: 17 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 162   Index:  91
+Battle: Antlion                                                               Seed: 162   Index: 105
+Antlion's Nest                                                                Seed: 162   Index: 105
+  Step   3: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed: 162   Index: 120
+  Antlion B2F                                                                 Seed: 162   Index: 120
+    Step  18: 19 / Basilisk x1, Imp x3 (6.783s)
+    Step  65: 20 / Basilisk x1, Imp x3 (6.783s)
+    Step  76: 21 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 162   Index: 200
+Overworld (Damcyan)                                                           Seed: 162   Index: 238
+Overworld (Kaipo)                                                             Seed: 162   Index: 238
+Kaipo Revisited                                                               Seed: 162   Index: 238
+Overworld (Kaipo)                                                             Seed: 162   Index: 238
+Overworld (Damcyan)                                                           Seed: 162   Index: 238
+Mt.Hobs-West                                                                  Seed: 162   Index: 238
+  Step  10: 22 / Spirit x2 (8.028s)
+  Step  27: 23 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 179   Index:  21
+Battle: MomBomb                                                               Seed: 179   Index:  36
+Mt.Hobs Summit                                                                Seed: 179   Index:  36
+  Step   5: 24 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed: 179   Index:  42
+Overworld (Fabul)                                                             Seed: 179   Index:  88
+  Step  34: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  77: 26 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  82: 27 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 179   Index: 172
+  Optional Steps: 2
+Overworld (Fabul)                                                             Seed: 179   Index: 234
+Fabul Boat and Leviatan                                                       Seed: 179   Index: 241
+Overworld (Mysidia)                                                           Seed: 179   Index: 241
+Mysidia                                                                       Seed: 179   Index: 250
+Overworld (Mysidia)                                                           Seed: 179   Index: 250
+Overworld (Mt.Ordeals)                                                        Seed: 196   Index:   4
+  Step  14: 28 / Needler x2, SwordRat x2 (8.097s)
+  Step  15: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 196   Index:  98
+  Step   5: 30 / Lilith x1, Red Bone x2 (9.259s)
+  Step   8: 31 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed: 196   Index: 141
+  Step  15: 32 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed: 196   Index: 164
+Mt.Ordeals-3rd station                                                        Seed: 196   Index: 164
+Mt.Ordeals-7th station                                                        Seed: 196   Index: 169
+  Step  15: 33 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed: 196   Index: 211
+  Optional Steps: 0
+  Step   3: 34 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  10: 35 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed: 196   Index: 228
+Mt.Ordeals Summit                                                             Seed: 196   Index: 228
+Paladin                                                                       Seed: 196   Index: 232
+Mt.Ordeals Summit                                                             Seed: 196   Index: 232
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 196   Index: 254
+  Step  24: 36 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-3rd station                                                        Seed: 213   Index:  40
+Mt.Ordeals                                                                    Seed: 213   Index:  70
+  Step  14: 37 / Spirit x2, Skelton x2 (8.065s)
+  Step  31: 38 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 213   Index: 114
+Take Chocobo to Mysidia                                                       Seed: 213   Index: 127
+Overworld (Mysidia)                                                           Seed: 213   Index: 127
+Town of Baron Serpent Road                                                    Seed: 213   Index: 127
+Credit Warp Fight Search                                                      Seed: 213   Index: 131
+  Overworld (Baron)                                                           Seed: 213   Index: 131
+    Extra Steps: 8
+    Step   2: 39 / FloatEye x2 (7.230s)
+    Step   8: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  69: 41 / FloatEye x2)
+   (Step  76: 42 / FloatEye x2)
+   (Step 128: 43 / FloatEye x1, Eagle x2)
+   (Step 256: 44 / Eagle x3)
+
+Encounter Time:      314.105s
+Other Time:          485.168s
+Total Time:          799.273s
+
+Base Total Time:     1024.900s
+Time Saved:          225.627s
+
+Optional Steps:      3
+Extra Steps:         8
+Encounters:          40
+
+Base Encounters:     48
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/129.txt
+++ b/data/routes/cw/129.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	129
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48637923
+VARS	FFFFFFFF:2 E000600:2 E302500:15 E302600:10 E307400:30 E307802:4 E308700:1 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed: 129   Index:   0
+Overworld (Kaipo)                                                             Seed: 129   Index:   1
+Kaipo                                                                         Seed: 129   Index:  37
+Overworld (Kaipo)                                                             Seed: 129   Index:  37
+  Step   9: 1 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 129   Index:  69
+  Step  11: 2 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 129   Index: 101
+Watery Pass-South B1F                                                         Seed: 129   Index: 101
+  Step  11: 3 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 129   Index: 121
+  Step  39: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  87: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 129   Index: 211
+Watery Pass-South B2F                                                         Seed: 129   Index: 215
+  Step  22: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 129   Index: 254
+Watery Pass-North B2F                                                         Seed: 146   Index:  32
+  Step  13: 7 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 146   Index:  53
+  Step  54: 8 / Aligator x1, Pike x2 (7.368s)
+  Step  57: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 146   Index: 113
+Waterfalls B1F                                                                Seed: 146   Index: 122
+  Extra Steps: 30
+Waterfalls B2F                                                                Seed: 146   Index: 153
+  Step  21: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 146   Index: 198
+  Step  18: 11 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed: 146   Index: 235
+Waterfalls Lake                                                               Seed: 146   Index: 235
+Overworld (Kaipo)                                                             Seed: 146   Index: 236
+  Step   7: 12 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed: 146   Index: 247
+Damcyan                                                                       Seed: 146   Index: 251
+  Optional Steps: 1
+  Extra Steps: 14
+Overworld (Damcyan)                                                           Seed: 163   Index:  17
+Antlion B1F                                                                   Seed: 163   Index:  17
+Antlion B2F Inward Direct                                                     Seed: 163   Index:  55
+  Antlion B2F                                                                 Seed: 163   Index:  55
+    Step  20: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  53: 14 / SandWorm x2 (6.841s)
+Antlion's Nest                                                                Seed: 163   Index: 135
+  Step   3: 15 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed: 163   Index: 149
+Antlion's Nest                                                                Seed: 163   Index: 149
+Antlion B2F Outward Direct                                                    Seed: 163   Index: 164
+  Antlion B2F                                                                 Seed: 163   Index: 164
+    Extra Steps: 4
+    Step  32: 16 / Weeper x2 (7.132s)
+    Step  40: 17 / Turtle x2 (7.464s)
+    Step  84: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 163   Index: 248
+  Step  17: 19 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  29: 20 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 180   Index:  30
+Overworld (Kaipo)                                                             Seed: 180   Index:  30
+Kaipo Revisited                                                               Seed: 180   Index:  30
+Overworld (Kaipo)                                                             Seed: 180   Index:  30
+Overworld (Damcyan)                                                           Seed: 180   Index:  30
+Mt.Hobs-West                                                                  Seed: 180   Index:  30
+  Step  11: 21 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 180   Index:  69
+Battle: MomBomb                                                               Seed: 180   Index:  84
+Mt.Hobs Summit                                                                Seed: 180   Index:  84
+Mt.Hobs-East                                                                  Seed: 180   Index:  90
+Overworld (Fabul)                                                             Seed: 180   Index: 136
+  Step  29: 22 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  34: 23 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  51: 24 / Cocktric x3 (8.241s)
+  Step  66: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 180   Index: 220
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 197   Index:  34
+Fabul Boat and Leviatan                                                       Seed: 197   Index:  41
+Overworld (Mysidia)                                                           Seed: 197   Index:  41
+Mysidia                                                                       Seed: 197   Index:  50
+Overworld (Mysidia)                                                           Seed: 197   Index:  50
+Overworld (Mt.Ordeals)                                                        Seed: 197   Index:  60
+  Extra Steps: 2
+  Step  43: 26 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  44: 27 / Needler x2, SwordRat x2 (8.097s)
+  Step  46: 28 / Needler x2, SwordRat x2 (8.097s)
+  Step  75: 29 / Raven x1 (8.356s)
+  Step  96: 30 / Raven x1, Cocktric x3 (9.100s)
+Mt.Ordeals                                                                    Seed: 197   Index: 156
+  Step  28: 31 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed: 197   Index: 199
+  Step  15: 32 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+  Step  22: 33 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed: 197   Index: 222
+Mt.Ordeals-3rd station                                                        Seed: 197   Index: 222
+Mt.Ordeals-7th station                                                        Seed: 197   Index: 227
+Mt.Ordeals Summit                                                             Seed: 214   Index:  13
+  Optional Steps: 1
+  Step   9: 34 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 214   Index:  31
+Mt.Ordeals Summit                                                             Seed: 214   Index:  31
+Paladin                                                                       Seed: 214   Index:  35
+Mt.Ordeals Summit                                                             Seed: 214   Index:  35
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 214   Index:  58
+  Step  26: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 214   Index: 100
+  Step   1: 36 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals                                                                    Seed: 214   Index: 130
+  Step   3: 37 / Spirit x2, Skelton x2 (8.065s)
+  Step   9: 38 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 214   Index: 174
+Take Chocobo to Mysidia                                                       Seed: 214   Index: 187
+Overworld (Mysidia)                                                           Seed: 214   Index: 187
+Town of Baron Serpent Road                                                    Seed: 214   Index: 187
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed: 214   Index: 199
+  Overworld (Baron)                                                           Seed: 214   Index: 199
+    Extra Steps: 2
+    Step   1: 39 / FloatEye x2 (7.230s)
+    Step   2: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  60: 41 / FloatEye x2)
+   (Step 188: 42 / FloatEye x2)
+   (Step 194: 43 / FloatEye x1, Eagle x2)
+   (Step 207: 44 / Eagle x3)
+   (Step 220: 45 / FloatEye x1, Eagle x2)
+   (Step 247: 46 / FloatEye x1, Eagle x2)
+   (Step 249: 47 / Imp x3, SwordRat x1)
+
+Encounter Time:      311.885s
+Other Time:          497.414s
+Total Time:          809.299s
+
+Base Total Time:     988.099s
+Time Saved:          178.800s
+
+Optional Steps:      13
+Extra Steps:         60
+Encounters:          40
+
+Base Encounters:     47
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/130.txt
+++ b/data/routes/cw/130.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	130
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48480369
+VARS	FFFFFFFF:2 E000202:2 E000600:10 E302500:13 E302600:10 E307400:26 E308700:1 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed: 130   Index:   0
+Overworld (Kaipo)                                                             Seed: 130   Index:   1
+Kaipo                                                                         Seed: 130   Index:  37
+Overworld (Kaipo)                                                             Seed: 130   Index:  37
+  Step   9: 1 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 130   Index:  69
+  Step  21: 2 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 130   Index: 101
+Watery Pass-South B1F                                                         Seed: 130   Index: 101
+  Step  11: 3 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 130   Index: 121
+  Step  39: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  87: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 130   Index: 211
+Watery Pass-South B2F                                                         Seed: 130   Index: 215
+  Step  22: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 130   Index: 254
+Watery Pass-North B2F                                                         Seed: 147   Index:  32
+  Step  13: 7 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 147   Index:  53
+  Step  54: 8 / Aligator x1, Pike x2 (7.368s)
+  Step  57: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 147   Index: 113
+Waterfalls B1F                                                                Seed: 147   Index: 122
+  Extra Steps: 26
+Waterfalls B2F                                                                Seed: 147   Index: 149
+  Step  25: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 147   Index: 194
+  Step  22: 11 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed: 147   Index: 231
+Waterfalls Lake                                                               Seed: 147   Index: 231
+Overworld (Kaipo)                                                             Seed: 147   Index: 232
+  Step  11: 12 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed: 147   Index: 243
+Damcyan                                                                       Seed: 147   Index: 247
+  Optional Steps: 1
+  Extra Steps: 12
+Overworld (Damcyan)                                                           Seed: 164   Index:  11
+Antlion B1F                                                                   Seed: 164   Index:  11
+  Step   5: 13 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed: 164   Index:  49
+  Antlion B2F                                                                 Seed: 164   Index:  49
+    Step  26: 14 / SandWorm x2 (6.841s)
+Antlion's Nest                                                                Seed: 164   Index: 129
+  Step   9: 15 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed: 164   Index: 143
+Antlion's Nest                                                                Seed: 164   Index: 143
+Antlion B2F Outward Direct                                                    Seed: 164   Index: 158
+  Antlion B2F                                                                 Seed: 164   Index: 158
+    Step  31: 16 / Weeper x2 (7.132s)
+    Step  38: 17 / Turtle x2 (7.464s)
+    Step  46: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 164   Index: 238
+  Step  10: 19 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  27: 20 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 181   Index:  20
+Overworld (Kaipo)                                                             Seed: 181   Index:  20
+  Extra Steps: 2
+  Step   1: 21 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed: 181   Index:  22
+Overworld (Kaipo)                                                             Seed: 181   Index:  22
+Overworld (Damcyan)                                                           Seed: 181   Index:  22
+Mt.Hobs-West                                                                  Seed: 181   Index:  22
+  Step  19: 22 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 181   Index:  61
+Battle: MomBomb                                                               Seed: 181   Index:  76
+Mt.Hobs Summit                                                                Seed: 181   Index:  76
+Mt.Hobs-East                                                                  Seed: 181   Index:  82
+Overworld (Fabul)                                                             Seed: 181   Index: 128
+  Step  37: 23 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  42: 24 / Cocktric x3 (8.241s)
+  Step  59: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  74: 26 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 181   Index: 212
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 198   Index:  26
+Fabul Boat and Leviatan                                                       Seed: 198   Index:  33
+Overworld (Mysidia)                                                           Seed: 198   Index:  33
+Mysidia                                                                       Seed: 198   Index:  42
+Overworld (Mysidia)                                                           Seed: 198   Index:  42
+Overworld (Mt.Ordeals)                                                        Seed: 198   Index:  52
+  Extra Steps: 10
+  Step  51: 27 / Needler x2, SwordRat x2 (8.097s)
+  Step  54: 28 / Needler x2, SwordRat x2 (8.097s)
+  Step  57: 29 / Raven x1 (8.356s)
+  Step  83: 30 / Raven x1, Cocktric x3 (9.100s)
+  Step 104: 31 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 198   Index: 156
+  Step  28: 32 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 198   Index: 199
+  Step  22: 33 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed: 198   Index: 222
+Mt.Ordeals-3rd station                                                        Seed: 198   Index: 222
+Mt.Ordeals-7th station                                                        Seed: 198   Index: 227
+Mt.Ordeals Summit                                                             Seed: 215   Index:  13
+  Optional Steps: 1
+  Step   9: 34 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 215   Index:  31
+Mt.Ordeals Summit                                                             Seed: 215   Index:  31
+Paladin                                                                       Seed: 215   Index:  35
+Mt.Ordeals Summit                                                             Seed: 215   Index:  35
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 215   Index:  58
+  Step  26: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 215   Index: 100
+  Step   1: 36 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals                                                                    Seed: 215   Index: 130
+  Step   3: 37 / Spirit x2, Skelton x2 (8.065s)
+  Step   9: 38 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 215   Index: 174
+Take Chocobo to Mysidia                                                       Seed: 215   Index: 187
+Overworld (Mysidia)                                                           Seed: 215   Index: 187
+Town of Baron Serpent Road                                                    Seed: 215   Index: 187
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed: 215   Index: 199
+  Overworld (Baron)                                                           Seed: 215   Index: 199
+    Extra Steps: 2
+    Step   1: 39 / FloatEye x2 (7.230s)
+    Step   2: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step 188: 41 / FloatEye x2)
+   (Step 194: 42 / FloatEye x2)
+   (Step 207: 43 / FloatEye x1, Eagle x2)
+   (Step 220: 44 / Eagle x3)
+   (Step 247: 45 / FloatEye x1, Eagle x2)
+   (Step 249: 46 / FloatEye x1, Eagle x2)
+
+Encounter Time:      309.263s
+Other Time:          497.414s
+Total Time:          806.678s
+
+Base Total Time:     889.930s
+Time Saved:          83.252s
+
+Optional Steps:      13
+Extra Steps:         60
+Encounters:          40
+
+Base Encounters:     47
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/131.txt
+++ b/data/routes/cw/131.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	131
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48004099
+VARS	FFFFFFFF:8 C307800:1 E302600:52 E307400:150 E307900:6 E307B00:12 E308700:1 E308702:1 E309700:30
+
+Overworld (Kaipo)                                                             Seed: 131   Index:   0
+Overworld (Kaipo)                                                             Seed: 131   Index:   1
+Kaipo                                                                         Seed: 131   Index:  37
+Overworld (Kaipo)                                                             Seed: 131   Index:  37
+  Step   9: 1 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 131   Index:  69
+  Step  10: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  21: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 131   Index: 101
+Watery Pass-South B1F                                                         Seed: 131   Index: 101
+Watery Pass-South B2F                                                         Seed: 131   Index: 121
+  Step  39: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  87: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 131   Index: 211
+Watery Pass-South B2F                                                         Seed: 131   Index: 215
+  Step  22: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 131   Index: 254
+Watery Pass-North B2F                                                         Seed: 148   Index:  32
+  Step  12: 7 / CaveToad x3 (7.014s)
+  Step  13: 8 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed: 148   Index:  53
+  Step  54: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 148   Index: 113
+Waterfalls B1F                                                                Seed: 148   Index: 122
+  Extra Steps: 150
+Waterfalls B2F                                                                Seed: 165   Index:  17
+Waterfalls Lake                                                               Seed: 165   Index:  62
+  Step  13: 10 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 165   Index:  99
+Waterfalls Lake                                                               Seed: 165   Index:  99
+Overworld (Kaipo)                                                             Seed: 165   Index: 100
+Overworld (Damcyan)                                                           Seed: 165   Index: 111
+Damcyan                                                                       Seed: 165   Index: 115
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 165   Index: 122
+Antlion B1F                                                                   Seed: 165   Index: 122
+  Step  16: 11 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 165   Index: 160
+  Antlion B2F                                                                 Seed: 165   Index: 160
+    Step  29: 12 / Turtle x2 (7.487s)
+  Antlion B2F Treasure Room                                                   Seed: 165   Index: 193
+    Extra Steps: 12
+  Antlion B2F                                                                 Seed: 165   Index: 205
+Antlion's Nest                                                                Seed: 182   Index:   1
+  Extra Steps: 6
+  Step   8: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+  Step  20: 14 / SandWorm x1, Sandpede x1 (6.829s)
+Battle: Antlion                                                               Seed: 182   Index:  21
+Antlion's Nest                                                                Seed: 182   Index:  21
+Antlion B2F Outward Direct                                                    Seed: 182   Index:  36
+  Antlion B2F                                                                 Seed: 182   Index:  36
+    Step   5: 15 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 182   Index: 116
+  Step  29: 16 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 182   Index: 154
+Overworld (Kaipo)                                                             Seed: 182   Index: 154
+Kaipo Revisited                                                               Seed: 182   Index: 154
+Overworld (Kaipo)                                                             Seed: 182   Index: 154
+Overworld (Damcyan)                                                           Seed: 182   Index: 154
+Mt.Hobs-West                                                                  Seed: 182   Index: 154
+  Step  33: 17 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed: 182   Index: 193
+  Step   9: 18 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed: 182   Index: 208
+Mt.Hobs Summit                                                                Seed: 182   Index: 208
+Mt.Hobs-East                                                                  Seed: 182   Index: 214
+  Step  20: 19 / Gargoyle x2 (7.630s)
+  Step  38: 20 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 199   Index:   4
+  Step  15: 21 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 199   Index:  88
+  Optional Steps: 10
+  Extra Steps: 42
+Overworld (Fabul)                                                             Seed: 199   Index: 200
+Fabul Boat and Leviatan                                                       Seed: 199   Index: 207
+Overworld (Mysidia)                                                           Seed: 199   Index: 207
+Mysidia                                                                       Seed: 199   Index: 216
+Overworld (Mysidia)                                                           Seed: 199   Index: 216
+  Step   5: 22 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Overworld (Mt.Ordeals)                                                        Seed: 199   Index: 226
+  Step  52: 23 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 216   Index:  64
+  Step  37: 24 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 216   Index: 107
+Recruit Tellah                                                                Seed: 216   Index: 130
+Mt.Ordeals-3rd station                                                        Seed: 216   Index: 130
+  Step   3: 25 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed: 216   Index: 135
+  Step   4: 26 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  40: 27 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 216   Index: 177
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 216   Index: 195
+Mt.Ordeals Summit                                                             Seed: 216   Index: 195
+  Step   2: 28 / Lilith x1 (8.568s)
+Paladin                                                                       Seed: 216   Index: 199
+Mt.Ordeals Summit                                                             Seed: 216   Index: 199
+  Optional Steps: 1
+  Step   1: 29 / Lilith x1, Red Bone x2 (8.437s)
+  Step   2: 30 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-7th station                                                        Seed: 216   Index: 222
+Mt.Ordeals-3rd station                                                        Seed: 233   Index:   8
+Mt.Ordeals                                                                    Seed: 233   Index:  38
+Overworld (Mt.Ordeals)                                                        Seed: 233   Index:  82
+Take Chocobo to Mysidia                                                       Seed: 233   Index:  95
+Overworld (Mysidia)                                                           Seed: 233   Index:  95
+Town of Baron Serpent Road                                                    Seed: 233   Index:  95
+  Extra Steps: 30
+Credit Warp Fight Search                                                      Seed: 233   Index: 129
+  Overworld (Baron)                                                           Seed: 233   Index: 129
+    Extra Steps: 8
+    Step   2: 31 / Eagle x3 (7.417s)
+    Step   8: 32 / Imp x4 (7.223s)
+   (Step  21: 33 / Eagle x3)
+   (Step  34: 34 / Imp x3, SwordRat x1)
+   (Step  61: 35 / Imp x3)
+   (Step  98: 36 / Imp x6)
+   (Step 125: 37 / FloatEye x2)
+   (Step 127: 38 / Imp x3)
+   (Step 253: 39 / FloatEye x2)
+   (Step 256: 40 / Imp x3, SwordRat x1)
+
+Encounter Time:      245.098s
+Other Time:          553.655s
+Total Time:          798.753s
+
+Base Total Time:     987.023s
+Time Saved:          188.271s
+
+Optional Steps:      12
+Extra Steps:         248
+Encounters:          32
+
+Base Encounters:     47
+Encounters Saved:    15
+
+Number of Variables: 54

--- a/data/routes/cw/132.txt
+++ b/data/routes/cw/132.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	132
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48757022
+VARS	FFFFFFFF:6 E000600:6 E302500:19 E302600:10 E305400:22 E307400:4 E308401:2 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 132   Index:   0
+Overworld (Kaipo)                                                             Seed: 132   Index:   1
+Kaipo                                                                         Seed: 132   Index:  37
+Overworld (Kaipo)                                                             Seed: 132   Index:  37
+  Step   9: 1 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 132   Index:  69
+  Step  10: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  21: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 132   Index: 101
+Watery Pass-South B1F                                                         Seed: 132   Index: 101
+  Step  10: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 132   Index: 121
+  Step  87: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 132   Index: 211
+  Extra Steps: 22
+Watery Pass-South B2F                                                         Seed: 132   Index: 237
+Watery Pass-South B3F                                                         Seed: 149   Index:  20
+  Step  24: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  25: 7 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 149   Index:  54
+Watery Pass-North B1F                                                         Seed: 149   Index:  75
+  Step   8: 8 / Aligator x1, Pike x2 (7.368s)
+  Step  32: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 149   Index: 135
+Waterfalls B1F                                                                Seed: 149   Index: 144
+  Extra Steps: 4
+Waterfalls B2F                                                                Seed: 149   Index: 149
+  Step  25: 10 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 149   Index: 194
+  Step  22: 11 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed: 149   Index: 231
+Waterfalls Lake                                                               Seed: 149   Index: 231
+Overworld (Kaipo)                                                             Seed: 149   Index: 232
+  Step  11: 12 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed: 149   Index: 243
+Damcyan                                                                       Seed: 149   Index: 247
+  Optional Steps: 1
+  Extra Steps: 18
+Overworld (Damcyan)                                                           Seed: 166   Index:  17
+Antlion B1F                                                                   Seed: 166   Index:  17
+Antlion B2F Inward Direct                                                     Seed: 166   Index:  55
+  Antlion B2F                                                                 Seed: 166   Index:  55
+    Step  20: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 166   Index: 135
+Battle: Antlion                                                               Seed: 166   Index: 149
+Antlion's Nest                                                                Seed: 166   Index: 149
+Antlion B2F Outward Direct                                                    Seed: 166   Index: 164
+  Antlion B2F                                                                 Seed: 166   Index: 164
+    Step   7: 14 / SandWorm x1, Sandpede x1 (6.848s)
+    Step  25: 15 / Turtle x2 (7.464s)
+    Step  32: 16 / Weeper x2 (7.132s)
+    Step  40: 17 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 166   Index: 244
+  Step  21: 18 / Cream x4 (7.523s)
+  Step  33: 19 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 183   Index:  26
+Overworld (Kaipo)                                                             Seed: 183   Index:  26
+Kaipo Revisited                                                               Seed: 183   Index:  26
+Overworld (Kaipo)                                                             Seed: 183   Index:  26
+Overworld (Damcyan)                                                           Seed: 183   Index:  26
+Mt.Hobs-West                                                                  Seed: 183   Index:  26
+  Step  15: 20 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 183   Index:  65
+Battle: MomBomb                                                               Seed: 183   Index:  80
+Mt.Hobs Summit                                                                Seed: 183   Index:  80
+Mt.Hobs-East                                                                  Seed: 183   Index:  86
+Overworld (Fabul)                                                             Seed: 183   Index: 132
+  Step  13: 21 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  38: 22 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  40: 23 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  55: 24 / Cocktric x3 (8.241s)
+  Step  70: 25 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 183   Index: 216
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 200   Index:  30
+Fabul Boat and Leviatan                                                       Seed: 200   Index:  37
+Overworld (Mysidia)                                                           Seed: 200   Index:  37
+Mysidia                                                                       Seed: 200   Index:  46
+Overworld (Mysidia)                                                           Seed: 200   Index:  46
+Overworld (Mt.Ordeals)                                                        Seed: 200   Index:  56
+  Extra Steps: 6
+  Step  47: 26 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  50: 27 / Needler x2, SwordRat x2 (8.097s)
+  Step  53: 28 / Needler x2, SwordRat x2 (8.097s)
+  Step  79: 29 / Raven x1 (8.356s)
+  Step  95: 30 / Raven x1, Cocktric x3 (9.100s)
+  Step 100: 31 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 200   Index: 156
+  Step  43: 32 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 200   Index: 199
+  Step  22: 33 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed: 200   Index: 222
+Mt.Ordeals-3rd station                                                        Seed: 200   Index: 222
+Mt.Ordeals-7th station                                                        Seed: 200   Index: 227
+Mt.Ordeals Summit                                                             Seed: 217   Index:  13
+  Optional Steps: 1
+  Step   9: 34 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed: 217   Index:  31
+Mt.Ordeals Summit                                                             Seed: 217   Index:  31
+Paladin                                                                       Seed: 217   Index:  35
+Mt.Ordeals Summit                                                             Seed: 217   Index:  35
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 217   Index:  58
+  Step  16: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 217   Index: 100
+  Step   1: 36 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals                                                                    Seed: 217   Index: 130
+  Extra Steps: 2
+  Step   3: 37 / Red Bone x1, Skelton x3 (7.844s)
+  Step  45: 38 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 217   Index: 176
+Take Chocobo to Mysidia                                                       Seed: 217   Index: 189
+Overworld (Mysidia)                                                           Seed: 217   Index: 189
+Town of Baron Serpent Road                                                    Seed: 217   Index: 189
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 217   Index: 195
+  Overworld (Baron)                                                           Seed: 217   Index: 195
+    Extra Steps: 6
+    Step   2: 39 / FloatEye x2 (7.230s)
+    Step   6: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  95: 41 / FloatEye x2)
+   (Step 192: 42 / FloatEye x1, Eagle x2)
+   (Step 198: 43 / FloatEye x1, Eagle x2)
+   (Step 211: 44 / Eagle x3)
+   (Step 224: 45 / FloatEye x1, Eagle x2)
+
+Encounter Time:      312.802s
+Other Time:          498.479s
+Total Time:          811.281s
+
+Base Total Time:     989.580s
+Time Saved:          178.299s
+
+Optional Steps:      13
+Extra Steps:         60
+Encounters:          40
+
+Base Encounters:     47
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/133.txt
+++ b/data/routes/cw/133.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	133
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48751970
+VARS	FFFFFFFF:6 E000200:4 E000600:2 E302500:17 E302600:10 E305400:24 E308401:6 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 133   Index:   0
+Overworld (Kaipo)                                                             Seed: 133   Index:   1
+Kaipo                                                                         Seed: 133   Index:  37
+Overworld (Kaipo)                                                             Seed: 133   Index:  37
+  Step   9: 1 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 133   Index:  69
+  Step  10: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  21: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 133   Index: 101
+Watery Pass-South B1F                                                         Seed: 133   Index: 101
+  Step  10: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 133   Index: 121
+  Step  87: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 133   Index: 211
+  Extra Steps: 24
+Watery Pass-South B2F                                                         Seed: 133   Index: 239
+Watery Pass-South B3F                                                         Seed: 150   Index:  22
+  Step  22: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  23: 7 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 150   Index:  56
+Watery Pass-North B1F                                                         Seed: 150   Index:  77
+  Step   6: 8 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  30: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 150   Index: 137
+  Extra Steps: 4
+  Step  12: 10 / Sandpede x1, Sand Man x2 (7.188s)
+Waterfalls B1F                                                                Seed: 150   Index: 150
+Waterfalls B2F                                                                Seed: 150   Index: 151
+  Step  22: 11 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed: 150   Index: 196
+  Step  20: 12 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed: 150   Index: 233
+Waterfalls Lake                                                               Seed: 150   Index: 233
+Overworld (Kaipo)                                                             Seed: 150   Index: 234
+  Step   9: 13 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed: 150   Index: 245
+Damcyan                                                                       Seed: 150   Index: 249
+  Optional Steps: 1
+  Extra Steps: 16
+Overworld (Damcyan)                                                           Seed: 167   Index:  17
+Antlion B1F                                                                   Seed: 167   Index:  17
+Antlion B2F Inward Direct                                                     Seed: 167   Index:  55
+  Antlion B2F                                                                 Seed: 167   Index:  55
+    Step  40: 14 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 167   Index: 135
+Battle: Antlion                                                               Seed: 167   Index: 149
+Antlion's Nest                                                                Seed: 167   Index: 149
+Antlion B2F Outward Direct                                                    Seed: 167   Index: 164
+  Antlion B2F                                                                 Seed: 167   Index: 164
+    Step   7: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  25: 16 / Weeper x2 (7.132s)
+    Step  32: 17 / Turtle x2 (7.464s)
+    Step  40: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 167   Index: 244
+  Step  21: 19 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  33: 20 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 184   Index:  26
+Overworld (Kaipo)                                                             Seed: 184   Index:  26
+Kaipo Revisited                                                               Seed: 184   Index:  26
+Overworld (Kaipo)                                                             Seed: 184   Index:  26
+Overworld (Damcyan)                                                           Seed: 184   Index:  26
+Mt.Hobs-West                                                                  Seed: 184   Index:  26
+  Step  15: 21 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 184   Index:  65
+Battle: MomBomb                                                               Seed: 184   Index:  80
+Mt.Hobs Summit                                                                Seed: 184   Index:  80
+Mt.Hobs-East                                                                  Seed: 184   Index:  86
+Overworld (Fabul)                                                             Seed: 184   Index: 132
+  Step  13: 22 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  40: 23 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  55: 24 / Cocktric x3 (8.241s)
+  Step  70: 25 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 184   Index: 216
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 201   Index:  30
+Fabul Boat and Leviatan                                                       Seed: 201   Index:  37
+Overworld (Mysidia)                                                           Seed: 201   Index:  37
+Mysidia                                                                       Seed: 201   Index:  46
+Overworld (Mysidia)                                                           Seed: 201   Index:  46
+Overworld (Mt.Ordeals)                                                        Seed: 201   Index:  56
+  Extra Steps: 2
+  Step  47: 26 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  50: 27 / Needler x2, SwordRat x2 (8.097s)
+  Step  53: 28 / Needler x2, SwordRat x2 (8.097s)
+  Step  79: 29 / Needler x2, SwordRat x2 (8.097s)
+  Step  95: 30 / Raven x1, Cocktric x3 (9.100s)
+Mt.Ordeals                                                                    Seed: 201   Index: 152
+Mt.Ordeals-3rd station                                                        Seed: 201   Index: 195
+  Step   4: 31 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed: 201   Index: 218
+Mt.Ordeals-3rd station                                                        Seed: 201   Index: 218
+  Step   3: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed: 201   Index: 223
+Mt.Ordeals Summit                                                             Seed: 218   Index:   9
+  Optional Steps: 1
+  Step  13: 33 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed: 218   Index:  27
+Mt.Ordeals Summit                                                             Seed: 218   Index:  27
+Paladin                                                                       Seed: 218   Index:  31
+Mt.Ordeals Summit                                                             Seed: 218   Index:  31
+  Optional Steps: 1
+  Step   5: 34 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed: 218   Index:  54
+  Step  20: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 218   Index:  96
+  Step   5: 36 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 218   Index: 126
+  Extra Steps: 6
+  Step   7: 37 / Red Bone x1, Skelton x3 (7.844s)
+  Step  49: 38 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed: 218   Index: 176
+Take Chocobo to Mysidia                                                       Seed: 218   Index: 189
+Overworld (Mysidia)                                                           Seed: 218   Index: 189
+Town of Baron Serpent Road                                                    Seed: 218   Index: 189
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 218   Index: 195
+  Overworld (Baron)                                                           Seed: 218   Index: 195
+    Extra Steps: 6
+    Step   2: 39 / FloatEye x2 (7.230s)
+    Step   6: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  95: 41 / FloatEye x2)
+   (Step 127: 42 / FloatEye x1, Eagle x2)
+   (Step 198: 43 / FloatEye x1, Eagle x2)
+   (Step 211: 44 / Eagle x3)
+   (Step 224: 45 / FloatEye x1, Eagle x2)
+
+Encounter Time:      312.718s
+Other Time:          498.479s
+Total Time:          811.197s
+
+Base Total Time:     937.575s
+Time Saved:          126.378s
+
+Optional Steps:      13
+Extra Steps:         60
+Encounters:          40
+
+Base Encounters:     47
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/134.txt
+++ b/data/routes/cw/134.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	134
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	51453673
+VARS	FFFFFFFF:4 C307800:1 C307801:1 E302500:89 E302600:5 E305400:86 E307400:58 E307B00:22 E307B01:88 E309700:22
+
+Overworld (Kaipo)                                                             Seed: 134   Index:   0
+Overworld (Kaipo)                                                             Seed: 134   Index:   1
+Kaipo                                                                         Seed: 134   Index:  37
+Overworld (Kaipo)                                                             Seed: 134   Index:  37
+  Step   9: 1 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 134   Index:  69
+  Step  10: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  21: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 134   Index: 101
+Watery Pass-South B1F                                                         Seed: 134   Index: 101
+  Step  10: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 134   Index: 121
+  Step  47: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 134   Index: 211
+  Extra Steps: 86
+Watery Pass-South B2F                                                         Seed: 151   Index:  45
+  Step  38: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 151   Index:  84
+  Step  21: 7 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 151   Index: 118
+Watery Pass-North B1F                                                         Seed: 151   Index: 139
+  Step  10: 8 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  34: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 151   Index: 199
+Waterfalls B1F                                                                Seed: 151   Index: 208
+  Extra Steps: 58
+Waterfalls B2F                                                                Seed: 168   Index:  11
+Waterfalls Lake                                                               Seed: 168   Index:  56
+Battle: Octomamm                                                              Seed: 168   Index:  93
+Waterfalls Lake                                                               Seed: 168   Index:  93
+Overworld (Kaipo)                                                             Seed: 168   Index:  94
+  Step   1: 10 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed: 168   Index: 105
+Damcyan                                                                       Seed: 168   Index: 109
+  Optional Steps: 1
+  Extra Steps: 88
+Overworld (Damcyan)                                                           Seed: 168   Index: 205
+Antlion B1F                                                                   Seed: 168   Index: 205
+Antlion B2F Inward Charm Room Steps                                           Seed: 168   Index: 243
+  Antlion B2F                                                                 Seed: 168   Index: 243
+  Antlion B2F Treasure Room                                                   Seed: 185   Index:  20
+    Extra Steps: 22
+  Antlion B2F                                                                 Seed: 185   Index:  42
+    Step  21: 11 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed: 185   Index:  94
+Battle: Antlion                                                               Seed: 185   Index: 108
+Antlion's Nest                                                                Seed: 185   Index: 108
+Antlion B2F Outward Charm Room Steps                                          Seed: 185   Index: 123
+  Antlion B2F                                                                 Seed: 185   Index: 123
+    Step  22: 12 / Turtle x2 (7.464s)
+    Step  49: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Antlion B2F Treasure Room                                                   Seed: 185   Index: 174
+    Extra Steps: 88
+  Antlion B2F                                                                 Seed: 202   Index:   6
+    Step  32: 14 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed: 202   Index:  40
+Overworld (Damcyan)                                                           Seed: 202   Index:  78
+Overworld (Kaipo)                                                             Seed: 202   Index:  78
+Kaipo Revisited                                                               Seed: 202   Index:  78
+Overworld (Kaipo)                                                             Seed: 202   Index:  78
+Overworld (Damcyan)                                                           Seed: 202   Index:  78
+Mt.Hobs-West                                                                  Seed: 202   Index:  78
+  Step  25: 15 / Bomb x3 (8.832s)
+  Step  31: 16 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 202   Index: 117
+Battle: MomBomb                                                               Seed: 202   Index: 132
+Mt.Hobs Summit                                                                Seed: 202   Index: 132
+  Step   3: 17 / GrayBomb x2, Bomb x2 (8.430s)
+Mt.Hobs-East                                                                  Seed: 202   Index: 138
+  Step  13: 18 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 202   Index: 184
+  Step  15: 19 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  37: 20 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 219   Index:  12
+  Optional Steps: 5
+Overworld (Fabul)                                                             Seed: 219   Index:  77
+Fabul Boat and Leviatan                                                       Seed: 219   Index:  84
+Overworld (Mysidia)                                                           Seed: 219   Index:  84
+Mysidia                                                                       Seed: 219   Index:  93
+Overworld (Mysidia)                                                           Seed: 219   Index:  93
+  Step   8: 21 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 219   Index: 103
+  Step  25: 22 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  30: 23 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  72: 24 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  94: 25 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed: 219   Index: 197
+  Step   4: 26 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed: 219   Index: 240
+Recruit Tellah                                                                Seed: 236   Index:   7
+Mt.Ordeals-3rd station                                                        Seed: 236   Index:   7
+Mt.Ordeals-7th station                                                        Seed: 236   Index:  12
+  Step  22: 27 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 236   Index:  54
+  Optional Steps: 0
+  Step  12: 28 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed: 236   Index:  71
+Mt.Ordeals Summit                                                             Seed: 236   Index:  71
+Paladin                                                                       Seed: 236   Index:  75
+Mt.Ordeals Summit                                                             Seed: 236   Index:  75
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 236   Index:  97
+  Step   1: 29 / Lilith x1 (8.563s)
+  Step  40: 30 / Lilith x2 (9.169s)
+Mt.Ordeals-3rd station                                                        Seed: 236   Index: 139
+  Step  11: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  24: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 236   Index: 169
+Overworld (Mt.Ordeals)                                                        Seed: 236   Index: 213
+Take Chocobo to Mysidia                                                       Seed: 236   Index: 226
+Overworld (Mysidia)                                                           Seed: 236   Index: 226
+Town of Baron Serpent Road                                                    Seed: 236   Index: 226
+  Extra Steps: 22
+Credit Warp Fight Search                                                      Seed: 236   Index: 252
+  Overworld (Baron)                                                           Seed: 236   Index: 252
+    Extra Steps: 4
+    Step   2: 33 / Eagle x3 (7.417s)
+    Step   4: 34 / Imp x3, SwordRat x1 (7.227s)
+   (Step  41: 35 / Imp x3)
+   (Step 101: 36 / Imp x3)
+   (Step 124: 37 / FloatEye x2)
+   (Step 184: 38 / Imp x3)
+   (Step 197: 39 / FloatEye x2)
+   (Step 229: 40 / Eagle x3)
+
+Encounter Time:      267.021s
+Other Time:          589.130s
+Total Time:          856.151s
+
+Base Total Time:     934.277s
+Time Saved:          78.126s
+
+Optional Steps:      6
+Extra Steps:         368
+Encounters:          34
+
+Base Encounters:     47
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/135.txt
+++ b/data/routes/cw/135.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	135
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50030245
+VARS	FFFFFFFF:6 E302500:1 E302600:4 E307000:48 E307200:4 E307701:6 E309700:4
+
+Overworld (Kaipo)                                                             Seed: 135   Index:   0
+Overworld (Kaipo)                                                             Seed: 135   Index:   1
+Kaipo                                                                         Seed: 135   Index:  37
+Overworld (Kaipo)                                                             Seed: 135   Index:  37
+  Step   9: 1 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 135   Index:  69
+  Step  10: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  21: 3 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 135   Index: 101
+Watery Pass-South B1F                                                         Seed: 135   Index: 101
+  Step  10: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 135   Index: 121
+  Step  47: 5 / CaveToad x3 (7.014s)
+  Step  77: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 135   Index: 211
+Watery Pass-South B2F                                                         Seed: 135   Index: 215
+  Extra Steps: 48
+  Step  22: 7 / Pike x3 (7.152s)
+  Step  23: 8 / Zombie x4 (7.148s)
+  Step  66: 9 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  85: 10 / CaveToad x3 (7.014s)
+  Step  86: 11 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 152   Index:  46
+Watery Pass-North B2F                                                         Seed: 152   Index:  80
+  Extra Steps: 4
+  Step   3: 12 / Pike x2, EvilShel x2 (7.149s)
+  Step  25: 13 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 152   Index: 105
+  Step  44: 14 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 152   Index: 165
+  Step   8: 15 / Imp x4 (7.049s)
+Waterfalls B1F                                                                Seed: 152   Index: 174
+Waterfalls B2F                                                                Seed: 152   Index: 175
+Waterfalls Lake                                                               Seed: 152   Index: 220
+  Step  23: 16 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 169   Index:   1
+Waterfalls Lake                                                               Seed: 169   Index:   1
+Overworld (Kaipo)                                                             Seed: 169   Index:   2
+  Step   3: 17 / Sandpede x1, Sand Man x2 (7.221s)
+  Step   9: 18 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed: 169   Index:  13
+Damcyan                                                                       Seed: 169   Index:  17
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 169   Index:  25
+Antlion B1F                                                                   Seed: 169   Index:  25
+Antlion B2F Inward Direct                                                     Seed: 169   Index:  63
+  Antlion B2F                                                                 Seed: 169   Index:  63
+    Step  32: 19 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 169   Index: 143
+Battle: Antlion                                                               Seed: 169   Index: 157
+Antlion's Nest                                                                Seed: 169   Index: 157
+  Step  14: 20 / Basilisk x1, Imp x3 (6.783s)
+Antlion B2F Outward Direct                                                    Seed: 169   Index: 172
+  Antlion B2F                                                                 Seed: 169   Index: 172
+    Step   4: 21 / Basilisk x1, Turtle x1 (7.124s)
+    Step  17: 22 / Turtle x2 (7.464s)
+    Step  32: 23 / Basilisk x1, Imp x3 (6.783s)
+    Step  47: 24 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 169   Index: 252
+  Extra Steps: 6
+  Step  25: 25 / Turtle x2 (7.464s)
+  Step  44: 26 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 186   Index:  40
+Overworld (Kaipo)                                                             Seed: 186   Index:  40
+Kaipo Revisited                                                               Seed: 186   Index:  40
+Overworld (Kaipo)                                                             Seed: 186   Index:  40
+Overworld (Damcyan)                                                           Seed: 186   Index:  40
+Mt.Hobs-West                                                                  Seed: 186   Index:  40
+  Step  23: 27 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 186   Index:  79
+Battle: MomBomb                                                               Seed: 186   Index:  94
+Mt.Hobs Summit                                                                Seed: 186   Index:  94
+Mt.Hobs-East                                                                  Seed: 186   Index: 100
+  Step  45: 28 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 186   Index: 146
+  Step  26: 29 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  41: 30 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 186   Index: 230
+  Optional Steps: 4
+Overworld (Fabul)                                                             Seed: 203   Index:  38
+Fabul Boat and Leviatan                                                       Seed: 203   Index:  45
+Overworld (Mysidia)                                                           Seed: 203   Index:  45
+Mysidia                                                                       Seed: 203   Index:  54
+Overworld (Mysidia)                                                           Seed: 203   Index:  54
+Overworld (Mt.Ordeals)                                                        Seed: 203   Index:  64
+  Step   6: 31 / Needler x2, SwordRat x2 (8.097s)
+  Step  39: 32 / Needler x2, SwordRat x2 (8.097s)
+  Step  45: 33 / Raven x1 (8.356s)
+  Step  71: 34 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  87: 35 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 203   Index: 158
+  Step  41: 36 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 203   Index: 201
+Recruit Tellah                                                                Seed: 203   Index: 224
+Mt.Ordeals-3rd station                                                        Seed: 203   Index: 224
+Mt.Ordeals-7th station                                                        Seed: 203   Index: 229
+Mt.Ordeals Summit                                                             Seed: 220   Index:  15
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 220   Index:  32
+Mt.Ordeals Summit                                                             Seed: 220   Index:  32
+  Step   4: 37 / Revenant x1, Ghoul x3 (8.611s)
+Paladin                                                                       Seed: 220   Index:  36
+Mt.Ordeals Summit                                                             Seed: 220   Index:  36
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 220   Index:  58
+  Step  16: 38 / Ghoul x2, Soul x2 (8.971s)
+  Step  42: 39 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 220   Index: 100
+  Step  28: 40 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed: 220   Index: 130
+  Step   3: 41 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 220   Index: 174
+  Step   1: 42 / Imp Cap. x3, Needler x1 (7.897s)
+Take Chocobo to Mysidia                                                       Seed: 220   Index: 187
+Overworld (Mysidia)                                                           Seed: 220   Index: 187
+Town of Baron Serpent Road                                                    Seed: 220   Index: 187
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed: 220   Index: 195
+  Overworld (Baron)                                                           Seed: 220   Index: 195
+    Extra Steps: 6
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step   6: 44 / Imp x4 (7.223s)
+   (Step  95: 45 / FloatEye x1, Eagle x2)
+   (Step 127: 46 / FloatEye x1, Eagle x2)
+   (Step 159: 47 / Imp x3, SwordRat x1)
+   (Step 174: 48 / Imp x4)
+   (Step 211: 49 / Eagle x3)
+
+Encounter Time:      331.858s
+Other Time:          500.609s
+Total Time:          832.466s
+
+Base Total Time:     855.876s
+Time Saved:          23.410s
+
+Optional Steps:      5
+Extra Steps:         68
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/136.txt
+++ b/data/routes/cw/136.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	136
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50704450
+VARS	FFFFFFFF:24 E302600:7 E308400:6 E308700:1 E308702:1 E309700:30
+
+Overworld (Kaipo)                                                             Seed: 136   Index:   0
+Overworld (Kaipo)                                                             Seed: 136   Index:   1
+Kaipo                                                                         Seed: 136   Index:  37
+Overworld (Kaipo)                                                             Seed: 136   Index:  37
+Watery Pass-South B1F                                                         Seed: 136   Index:  69
+  Step   2: 1 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  10: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  21: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 136   Index: 101
+Watery Pass-South B1F                                                         Seed: 136   Index: 101
+  Step  10: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 136   Index: 121
+  Step  47: 5 / CaveToad x3 (7.014s)
+  Step  77: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 136   Index: 211
+Watery Pass-South B2F                                                         Seed: 136   Index: 215
+  Step  23: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 136   Index: 254
+  Step  27: 8 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed: 153   Index:  32
+  Step  12: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  13: 10 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 153   Index:  53
+  Step  30: 11 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  52: 12 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 153   Index: 113
+Waterfalls B1F                                                                Seed: 153   Index: 122
+Waterfalls B2F                                                                Seed: 153   Index: 123
+  Step  26: 13 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 153   Index: 168
+  Step   5: 14 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 153   Index: 205
+Waterfalls Lake                                                               Seed: 153   Index: 205
+Overworld (Kaipo)                                                             Seed: 153   Index: 206
+  Step   5: 15 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed: 153   Index: 217
+Damcyan                                                                       Seed: 153   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 153   Index: 228
+Antlion B1F                                                                   Seed: 153   Index: 228
+  Step  33: 16 / Turtle x2 (7.487s)
+Antlion B2F Inward Direct                                                     Seed: 170   Index:  10
+  Antlion B2F                                                                 Seed: 170   Index:  10
+    Step  32: 17 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 170   Index:  90
+  Step   5: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 170   Index: 104
+Antlion's Nest                                                                Seed: 170   Index: 104
+Antlion B2F Outward Direct                                                    Seed: 170   Index: 119
+  Antlion B2F                                                                 Seed: 170   Index: 119
+    Step  52: 19 / Basilisk x1, Imp x3 (6.783s)
+    Step  57: 20 / Basilisk x1, Imp x3 (6.783s)
+    Step  70: 21 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed: 170   Index: 199
+  Step   5: 22 / Turtle x1, Imp x2 (7.009s)
+  Step  20: 23 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 170   Index: 237
+Overworld (Kaipo)                                                             Seed: 170   Index: 237
+Kaipo Revisited                                                               Seed: 170   Index: 237
+Overworld (Kaipo)                                                             Seed: 170   Index: 237
+Overworld (Damcyan)                                                           Seed: 170   Index: 237
+Mt.Hobs-West                                                                  Seed: 170   Index: 237
+Mt.Hobs Summit                                                                Seed: 187   Index:  20
+  Step   1: 24 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed: 187   Index:  35
+Mt.Hobs Summit                                                                Seed: 187   Index:  35
+  Step   5: 25 / Spirit x2, Skelton x2 (8.237s)
+Mt.Hobs-East                                                                  Seed: 187   Index:  41
+  Step  22: 26 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 187   Index:  87
+  Step  58: 27 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 187   Index: 171
+  Optional Steps: 7
+Overworld (Fabul)                                                             Seed: 187   Index: 238
+Fabul Boat and Leviatan                                                       Seed: 187   Index: 245
+Overworld (Mysidia)                                                           Seed: 187   Index: 245
+  Step   7: 28 / Needler x2, SwordRat x2 (8.011s)
+Mysidia                                                                       Seed: 187   Index: 254
+Overworld (Mysidia)                                                           Seed: 187   Index: 254
+  Step   8: 29 / Needler x2, SwordRat x2 (8.097s)
+Overworld (Mt.Ordeals)                                                        Seed: 204   Index:   8
+  Step  30: 30 / Raven x1 (8.356s)
+  Step  62: 31 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed: 204   Index: 102
+  Extra Steps: 6
+  Step   7: 32 / Lilith x1, Red Bone x2 (9.259s)
+  Step  33: 33 / Soul x2, Red Bone x2 (9.583s)
+  Step  49: 34 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 204   Index: 151
+Recruit Tellah                                                                Seed: 204   Index: 174
+Mt.Ordeals-3rd station                                                        Seed: 204   Index: 174
+Mt.Ordeals-7th station                                                        Seed: 204   Index: 179
+  Step  20: 35 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 204   Index: 221
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 204   Index: 239
+Mt.Ordeals Summit                                                             Seed: 204   Index: 239
+Paladin                                                                       Seed: 204   Index: 243
+Mt.Ordeals Summit                                                             Seed: 204   Index: 243
+  Optional Steps: 1
+  Step   1: 36 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed: 221   Index:  10
+  Step  26: 37 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 221   Index:  52
+  Step  22: 38 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 221   Index:  82
+  Step  18: 39 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 221   Index: 126
+  Step   2: 40 / Raven x1 (8.065s)
+  Step   6: 41 / Imp Cap. x3, Needler x1 (7.897s)
+  Step   7: 42 / Imp Cap. x3, Needler x1 (7.897s)
+Take Chocobo to Mysidia                                                       Seed: 221   Index: 139
+Overworld (Mysidia)                                                           Seed: 221   Index: 139
+Town of Baron Serpent Road                                                    Seed: 221   Index: 139
+  Extra Steps: 30
+Credit Warp Fight Search                                                      Seed: 221   Index: 173
+  Overworld (Baron)                                                           Seed: 221   Index: 173
+    Extra Steps: 24
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  24: 44 / Imp x4 (7.223s)
+   (Step 117: 45 / FloatEye x1, Eagle x2)
+   (Step 149: 46 / FloatEye x1, Eagle x2)
+   (Step 181: 47 / Imp x3, SwordRat x1)
+   (Step 196: 48 / Imp x4)
+   (Step 245: 49 / Eagle x3)
+
+Encounter Time:      340.414s
+Other Time:          503.271s
+Total Time:          843.685s
+
+Base Total Time:     908.441s
+Time Saved:          64.756s
+
+Optional Steps:      9
+Extra Steps:         60
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/137.txt
+++ b/data/routes/cw/137.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	137
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50129571
+VARS	FFFFFFFF:12 E302600:7 E308400:6 E308700:1 E308702:1 E309700:20
+
+Overworld (Kaipo)                                                             Seed: 137   Index:   0
+Overworld (Kaipo)                                                             Seed: 137   Index:   1
+  Step  13: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 137   Index:  37
+Overworld (Kaipo)                                                             Seed: 137   Index:  37
+Watery Pass-South B1F                                                         Seed: 137   Index:  69
+  Step   2: 2 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  10: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 137   Index: 101
+Watery Pass-South B1F                                                         Seed: 137   Index: 101
+  Step  10: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 137   Index: 121
+  Step  47: 5 / CaveToad x3 (7.014s)
+  Step  77: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 137   Index: 211
+Watery Pass-South B2F                                                         Seed: 137   Index: 215
+  Step  23: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 137   Index: 254
+  Step  27: 8 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed: 154   Index:  32
+  Step  12: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B1F                                                         Seed: 154   Index:  53
+  Step  30: 10 / Jelly x4 (7.324s)
+  Step  52: 11 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 154   Index: 113
+Waterfalls B1F                                                                Seed: 154   Index: 122
+Waterfalls B2F                                                                Seed: 154   Index: 123
+  Step  26: 12 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  31: 13 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 154   Index: 168
+  Step   5: 14 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 154   Index: 205
+Waterfalls Lake                                                               Seed: 154   Index: 205
+Overworld (Kaipo)                                                             Seed: 154   Index: 206
+  Step   5: 15 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed: 154   Index: 217
+Damcyan                                                                       Seed: 154   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 154   Index: 228
+Antlion B1F                                                                   Seed: 154   Index: 228
+  Step  32: 16 / Turtle x2 (7.487s)
+  Step  33: 17 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 171   Index:  10
+  Antlion B2F                                                                 Seed: 171   Index:  10
+    Step  32: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 171   Index:  90
+  Step   5: 19 / Basilisk x1, Imp x3 (6.775s)
+Battle: Antlion                                                               Seed: 171   Index: 104
+Antlion's Nest                                                                Seed: 171   Index: 104
+Antlion B2F Outward Direct                                                    Seed: 171   Index: 119
+  Antlion B2F                                                                 Seed: 171   Index: 119
+    Step  52: 20 / Basilisk x1, Imp x3 (6.783s)
+    Step  57: 21 / Basilisk x1, Turtle x1 (7.124s)
+    Step  70: 22 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 171   Index: 199
+  Step  20: 23 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 171   Index: 237
+Overworld (Kaipo)                                                             Seed: 171   Index: 237
+Kaipo Revisited                                                               Seed: 171   Index: 237
+Overworld (Kaipo)                                                             Seed: 171   Index: 237
+Overworld (Damcyan)                                                           Seed: 171   Index: 237
+Mt.Hobs-West                                                                  Seed: 171   Index: 237
+Mt.Hobs Summit                                                                Seed: 188   Index:  20
+Battle: MomBomb                                                               Seed: 188   Index:  35
+Mt.Hobs Summit                                                                Seed: 188   Index:  35
+  Step   5: 24 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed: 188   Index:  41
+  Step  22: 25 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 188   Index:  87
+  Step  17: 26 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  58: 27 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 188   Index: 171
+  Optional Steps: 7
+Overworld (Fabul)                                                             Seed: 188   Index: 238
+Fabul Boat and Leviatan                                                       Seed: 188   Index: 245
+Overworld (Mysidia)                                                           Seed: 188   Index: 245
+  Step   7: 28 / Needler x2, SwordRat x2 (8.011s)
+Mysidia                                                                       Seed: 188   Index: 254
+Overworld (Mysidia)                                                           Seed: 188   Index: 254
+  Step   8: 29 / Needler x2, SwordRat x2 (8.097s)
+Overworld (Mt.Ordeals)                                                        Seed: 205   Index:   8
+  Step  30: 30 / Raven x1 (8.356s)
+  Step  62: 31 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed: 205   Index: 102
+  Extra Steps: 6
+  Step   7: 32 / Lilith x1, Red Bone x2 (9.259s)
+  Step  32: 33 / Soul x2, Red Bone x2 (9.583s)
+  Step  49: 34 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 205   Index: 151
+Recruit Tellah                                                                Seed: 205   Index: 174
+Mt.Ordeals-3rd station                                                        Seed: 205   Index: 174
+Mt.Ordeals-7th station                                                        Seed: 205   Index: 179
+  Step  20: 35 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 205   Index: 221
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 205   Index: 239
+Mt.Ordeals Summit                                                             Seed: 205   Index: 239
+Paladin                                                                       Seed: 205   Index: 243
+Mt.Ordeals Summit                                                             Seed: 205   Index: 243
+  Optional Steps: 1
+  Step   1: 36 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed: 222   Index:  10
+  Step  26: 37 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 222   Index:  52
+  Step  22: 38 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 222   Index:  82
+  Step  18: 39 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 222   Index: 126
+  Step   2: 40 / Raven x1 (8.065s)
+  Step   6: 41 / Imp Cap. x3, Needler x1 (7.897s)
+  Step   7: 42 / Imp Cap. x3, Needler x1 (7.897s)
+Take Chocobo to Mysidia                                                       Seed: 222   Index: 139
+Overworld (Mysidia)                                                           Seed: 222   Index: 139
+Town of Baron Serpent Road                                                    Seed: 222   Index: 139
+  Extra Steps: 20
+Credit Warp Fight Search                                                      Seed: 222   Index: 163
+  Overworld (Baron)                                                           Seed: 222   Index: 163
+    Extra Steps: 12
+    Step   1: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  12: 44 / Imp x4 (7.223s)
+   (Step 127: 45 / FloatEye x1, Eagle x2)
+   (Step 159: 46 / FloatEye x1, Eagle x2)
+   (Step 191: 47 / Imp x3, SwordRat x1)
+   (Step 206: 48 / Imp x4)
+   (Step 255: 49 / Eagle x3)
+
+Encounter Time:      339.900s
+Other Time:          494.219s
+Total Time:          834.119s
+
+Base Total Time:     907.927s
+Time Saved:          73.808s
+
+Optional Steps:      9
+Extra Steps:         38
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/138.txt
+++ b/data/routes/cw/138.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	138
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50765905
+VARS	FFFFFFFF:34 E302500:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 138   Index:   0
+Overworld (Kaipo)                                                             Seed: 138   Index:   1
+  Step  13: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 138   Index:  37
+Overworld (Kaipo)                                                             Seed: 138   Index:  37
+Watery Pass-South B1F                                                         Seed: 138   Index:  69
+  Step   2: 2 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 138   Index: 101
+Watery Pass-South B1F                                                         Seed: 138   Index: 101
+  Step  10: 3 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 138   Index: 121
+  Step  47: 4 / Pike x3 (7.152s)
+  Step  77: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 138   Index: 211
+Watery Pass-South B2F                                                         Seed: 138   Index: 215
+  Step  23: 6 / CaveToad x3 (7.014s)
+  Step  25: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 138   Index: 254
+  Step  27: 8 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed: 155   Index:  32
+  Step  12: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B1F                                                         Seed: 155   Index:  53
+  Step  30: 10 / Jelly x4 (7.324s)
+  Step  52: 11 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 155   Index: 113
+Waterfalls B1F                                                                Seed: 155   Index: 122
+Waterfalls B2F                                                                Seed: 155   Index: 123
+  Step  31: 12 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 155   Index: 168
+  Step   5: 13 / Aligator x2 (7.544s)
+  Step  17: 14 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 155   Index: 205
+Waterfalls Lake                                                               Seed: 155   Index: 205
+Overworld (Kaipo)                                                             Seed: 155   Index: 206
+  Step   5: 15 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed: 155   Index: 217
+Damcyan                                                                       Seed: 155   Index: 221
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 155   Index: 229
+Antlion B1F                                                                   Seed: 155   Index: 229
+  Step  31: 16 / Turtle x2 (7.487s)
+  Step  32: 17 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 172   Index:  11
+  Antlion B2F                                                                 Seed: 172   Index:  11
+    Step  31: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 172   Index:  91
+  Step   4: 19 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed: 172   Index: 105
+Antlion's Nest                                                                Seed: 172   Index: 105
+Antlion B2F Outward Direct                                                    Seed: 172   Index: 120
+  Antlion B2F                                                                 Seed: 172   Index: 120
+    Step   2: 20 / Basilisk x1, Imp x3 (6.783s)
+    Step  51: 21 / Basilisk x1, Turtle x1 (7.124s)
+    Step  56: 22 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 172   Index: 200
+  Step  19: 23 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 172   Index: 238
+Overworld (Kaipo)                                                             Seed: 172   Index: 238
+Kaipo Revisited                                                               Seed: 172   Index: 238
+Overworld (Kaipo)                                                             Seed: 172   Index: 238
+Overworld (Damcyan)                                                           Seed: 172   Index: 238
+Mt.Hobs-West                                                                  Seed: 172   Index: 238
+  Step  36: 24 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 189   Index:  21
+Battle: MomBomb                                                               Seed: 189   Index:  36
+Mt.Hobs Summit                                                                Seed: 189   Index:  36
+  Step   4: 25 / Spirit x2, Skelton x2 (8.237s)
+Mt.Hobs-East                                                                  Seed: 189   Index:  42
+  Step  21: 26 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 189   Index:  88
+  Step  16: 27 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  57: 28 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  84: 29 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 189   Index: 172
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 189   Index: 232
+  Step   1: 30 / Imp Cap. x3, Needler x1 (7.956s)
+Fabul Boat and Leviatan                                                       Seed: 189   Index: 239
+Overworld (Mysidia)                                                           Seed: 189   Index: 239
+Mysidia                                                                       Seed: 189   Index: 248
+Overworld (Mysidia)                                                           Seed: 189   Index: 248
+Overworld (Mt.Ordeals)                                                        Seed: 206   Index:   2
+  Step   4: 31 / Needler x2, SwordRat x2 (8.097s)
+  Step  36: 32 / Raven x1, Cocktric x3 (9.100s)
+  Step  68: 33 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 206   Index:  96
+  Step  38: 34 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 206   Index: 139
+  Step  12: 35 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed: 206   Index: 162
+Mt.Ordeals-3rd station                                                        Seed: 206   Index: 162
+Mt.Ordeals-7th station                                                        Seed: 206   Index: 167
+  Step  32: 36 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 206   Index: 209
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 206   Index: 226
+Mt.Ordeals Summit                                                             Seed: 206   Index: 226
+Paladin                                                                       Seed: 206   Index: 230
+Mt.Ordeals Summit                                                             Seed: 206   Index: 230
+  Optional Steps: 1
+  Step  12: 37 / Revenant x1, Ghoul x3 (8.489s)
+  Step  14: 38 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed: 206   Index: 253
+  Step  39: 39 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 223   Index:  39
+  Step  16: 40 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed: 223   Index:  69
+  Step   5: 41 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+  Step  31: 42 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 223   Index: 113
+Take Chocobo to Mysidia                                                       Seed: 223   Index: 126
+Overworld (Mysidia)                                                           Seed: 223   Index: 126
+Town of Baron Serpent Road                                                    Seed: 223   Index: 126
+Credit Warp Fight Search                                                      Seed: 223   Index: 130
+  Overworld (Baron)                                                           Seed: 223   Index: 130
+    Extra Steps: 34
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  34: 44 / Imp x4 (7.223s)
+   (Step 160: 45 / FloatEye x1, Eagle x2)
+   (Step 192: 46 / Imp x3, SwordRat x1)
+   (Step 224: 47 / Imp x3, SwordRat x1)
+   (Step 239: 48 / Imp x4)
+
+Encounter Time:      345.696s
+Other Time:          499.012s
+Total Time:          844.707s
+
+Base Total Time:     914.990s
+Time Saved:          70.282s
+
+Optional Steps:      2
+Extra Steps:         34
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/139.txt
+++ b/data/routes/cw/139.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	139
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50772321
+VARS	FFFFFFFF:34 E302500:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 139   Index:   0
+Overworld (Kaipo)                                                             Seed: 139   Index:   1
+  Step  13: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 139   Index:  37
+Overworld (Kaipo)                                                             Seed: 139   Index:  37
+Watery Pass-South B1F                                                         Seed: 139   Index:  69
+  Step   2: 2 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 139   Index: 101
+Watery Pass-South B1F                                                         Seed: 139   Index: 101
+Watery Pass-South B2F                                                         Seed: 139   Index: 121
+  Step  31: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  47: 4 / Pike x3 (7.152s)
+  Step  77: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 139   Index: 211
+Watery Pass-South B2F                                                         Seed: 139   Index: 215
+  Step  23: 6 / CaveToad x3 (7.014s)
+  Step  25: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 139   Index: 254
+  Step  27: 8 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed: 156   Index:  32
+Watery Pass-North B1F                                                         Seed: 156   Index:  53
+  Step  30: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  52: 10 / Jelly x4 (7.324s)
+  Step  55: 11 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 156   Index: 113
+Waterfalls B1F                                                                Seed: 156   Index: 122
+Waterfalls B2F                                                                Seed: 156   Index: 123
+  Step  31: 12 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 156   Index: 168
+  Step   5: 13 / Aligator x2 (7.544s)
+  Step  17: 14 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 156   Index: 205
+Waterfalls Lake                                                               Seed: 156   Index: 205
+Overworld (Kaipo)                                                             Seed: 156   Index: 206
+  Step   5: 15 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed: 156   Index: 217
+Damcyan                                                                       Seed: 156   Index: 221
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 156   Index: 229
+Antlion B1F                                                                   Seed: 156   Index: 229
+  Step  31: 16 / Turtle x2 (7.487s)
+Antlion B2F Inward Direct                                                     Seed: 173   Index:  11
+  Antlion B2F                                                                 Seed: 173   Index:  11
+    Step  31: 17 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 173   Index:  91
+  Step   4: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 173   Index: 105
+Antlion's Nest                                                                Seed: 173   Index: 105
+Antlion B2F Outward Direct                                                    Seed: 173   Index: 120
+  Antlion B2F                                                                 Seed: 173   Index: 120
+    Step   2: 19 / Turtle x2 (7.464s)
+    Step  45: 20 / Basilisk x1, Imp x3 (6.783s)
+    Step  51: 21 / Basilisk x1, Turtle x1 (7.124s)
+    Step  56: 22 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 173   Index: 200
+  Step  19: 23 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 173   Index: 238
+Overworld (Kaipo)                                                             Seed: 173   Index: 238
+Kaipo Revisited                                                               Seed: 173   Index: 238
+Overworld (Kaipo)                                                             Seed: 173   Index: 238
+Overworld (Damcyan)                                                           Seed: 173   Index: 238
+Mt.Hobs-West                                                                  Seed: 173   Index: 238
+  Step  36: 24 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 190   Index:  21
+Battle: MomBomb                                                               Seed: 190   Index:  36
+Mt.Hobs Summit                                                                Seed: 190   Index:  36
+  Step   4: 25 / Spirit x2, Skelton x2 (8.237s)
+Mt.Hobs-East                                                                  Seed: 190   Index:  42
+  Step  21: 26 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 190   Index:  88
+  Step  16: 27 / SwordRat x3, Needler x3 (7.663s)
+  Step  57: 28 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  84: 29 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 190   Index: 172
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 190   Index: 232
+  Step   1: 30 / Imp Cap. x3, Needler x1 (7.956s)
+Fabul Boat and Leviatan                                                       Seed: 190   Index: 239
+Overworld (Mysidia)                                                           Seed: 190   Index: 239
+Mysidia                                                                       Seed: 190   Index: 248
+Overworld (Mysidia)                                                           Seed: 190   Index: 248
+Overworld (Mt.Ordeals)                                                        Seed: 207   Index:   2
+  Step   4: 31 / Needler x2, SwordRat x2 (8.097s)
+  Step  36: 32 / Raven x1, Cocktric x3 (9.100s)
+  Step  68: 33 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 207   Index:  96
+  Step  38: 34 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 207   Index: 139
+  Step  12: 35 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed: 207   Index: 162
+Mt.Ordeals-3rd station                                                        Seed: 207   Index: 162
+Mt.Ordeals-7th station                                                        Seed: 207   Index: 167
+  Step  40: 36 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 207   Index: 209
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 207   Index: 226
+Mt.Ordeals Summit                                                             Seed: 207   Index: 226
+Paladin                                                                       Seed: 207   Index: 230
+Mt.Ordeals Summit                                                             Seed: 207   Index: 230
+  Optional Steps: 1
+  Step  12: 37 / Revenant x1, Ghoul x3 (8.489s)
+  Step  14: 38 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed: 207   Index: 253
+  Step  39: 39 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 224   Index:  39
+  Step  16: 40 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed: 224   Index:  69
+  Step   5: 41 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+  Step  31: 42 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 224   Index: 113
+Take Chocobo to Mysidia                                                       Seed: 224   Index: 126
+Overworld (Mysidia)                                                           Seed: 224   Index: 126
+Town of Baron Serpent Road                                                    Seed: 224   Index: 126
+Credit Warp Fight Search                                                      Seed: 224   Index: 130
+  Overworld (Baron)                                                           Seed: 224   Index: 130
+    Extra Steps: 34
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  34: 44 / Imp x4 (7.223s)
+   (Step  98: 45 / Imp x3, SwordRat x1)
+   (Step 183: 46 / Imp x3, SwordRat x1)
+   (Step 192: 47 / Imp x3, SwordRat x1)
+   (Step 224: 48 / Imp x4)
+   (Step 239: 49 / Eagle x3)
+
+Encounter Time:      345.803s
+Other Time:          499.012s
+Total Time:          844.814s
+
+Base Total Time:     880.934s
+Time Saved:          36.120s
+
+Optional Steps:      2
+Extra Steps:         34
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/140.txt
+++ b/data/routes/cw/140.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	140
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50646964
+VARS	FFFFFFFF:34 E302500:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 140   Index:   0
+Overworld (Kaipo)                                                             Seed: 140   Index:   1
+  Step  13: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 140   Index:  37
+Overworld (Kaipo)                                                             Seed: 140   Index:  37
+Watery Pass-South B1F                                                         Seed: 140   Index:  69
+  Step   2: 2 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 140   Index: 101
+Watery Pass-South B1F                                                         Seed: 140   Index: 101
+  Step   9: 3 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 140   Index: 121
+  Step  31: 4 / Pike x3 (7.152s)
+  Step  47: 5 / CaveToad x3 (7.014s)
+  Step  77: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 140   Index: 211
+Watery Pass-South B2F                                                         Seed: 140   Index: 215
+  Step  25: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 140   Index: 254
+  Step  27: 8 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed: 157   Index:  32
+Watery Pass-North B1F                                                         Seed: 157   Index:  53
+  Step  52: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  55: 10 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 157   Index: 113
+Waterfalls B1F                                                                Seed: 157   Index: 122
+Waterfalls B2F                                                                Seed: 157   Index: 123
+  Step  31: 11 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed: 157   Index: 168
+  Step   5: 12 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  17: 13 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed: 157   Index: 205
+Waterfalls Lake                                                               Seed: 157   Index: 205
+Overworld (Kaipo)                                                             Seed: 157   Index: 206
+  Step   5: 14 / SandMoth x2, Larva x2 (7.188s)
+Overworld (Damcyan)                                                           Seed: 157   Index: 217
+Damcyan                                                                       Seed: 157   Index: 221
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 157   Index: 229
+Antlion B1F                                                                   Seed: 157   Index: 229
+  Step  19: 15 / Cream x4 (7.552s)
+  Step  31: 16 / Turtle x2 (7.487s)
+Antlion B2F Inward Direct                                                     Seed: 174   Index:  11
+  Antlion B2F                                                                 Seed: 174   Index:  11
+    Step  31: 17 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 174   Index:  91
+  Step   4: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 174   Index: 105
+Antlion's Nest                                                                Seed: 174   Index: 105
+Antlion B2F Outward Direct                                                    Seed: 174   Index: 120
+  Antlion B2F                                                                 Seed: 174   Index: 120
+    Step   2: 19 / Turtle x2 (7.464s)
+    Step  45: 20 / Turtle x2 (7.464s)
+    Step  50: 21 / Basilisk x1, Turtle x1 (7.124s)
+    Step  56: 22 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 174   Index: 200
+  Step  19: 23 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 174   Index: 238
+Overworld (Kaipo)                                                             Seed: 174   Index: 238
+Kaipo Revisited                                                               Seed: 174   Index: 238
+Overworld (Kaipo)                                                             Seed: 174   Index: 238
+Overworld (Damcyan)                                                           Seed: 174   Index: 238
+Mt.Hobs-West                                                                  Seed: 174   Index: 238
+  Step  36: 24 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 191   Index:  21
+Battle: MomBomb                                                               Seed: 191   Index:  36
+Mt.Hobs Summit                                                                Seed: 191   Index:  36
+  Step   4: 25 / Spirit x2, Skelton x2 (8.237s)
+Mt.Hobs-East                                                                  Seed: 191   Index:  42
+  Step  21: 26 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 191   Index:  88
+  Step  16: 27 / SwordRat x3, Needler x3 (7.663s)
+  Step  57: 28 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  84: 29 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 191   Index: 172
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 191   Index: 232
+  Step   1: 30 / Imp Cap. x3, Needler x1 (7.956s)
+Fabul Boat and Leviatan                                                       Seed: 191   Index: 239
+Overworld (Mysidia)                                                           Seed: 191   Index: 239
+Mysidia                                                                       Seed: 191   Index: 248
+Overworld (Mysidia)                                                           Seed: 191   Index: 248
+Overworld (Mt.Ordeals)                                                        Seed: 208   Index:   2
+  Step   4: 31 / Needler x2, SwordRat x2 (8.097s)
+  Step  36: 32 / Raven x1, Cocktric x3 (9.100s)
+  Step  68: 33 / Raven x1 (8.356s)
+  Step  82: 34 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed: 208   Index:  96
+  Step  38: 35 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 208   Index: 139
+Recruit Tellah                                                                Seed: 208   Index: 162
+Mt.Ordeals-3rd station                                                        Seed: 208   Index: 162
+Mt.Ordeals-7th station                                                        Seed: 208   Index: 167
+  Step  40: 36 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 208   Index: 209
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 208   Index: 226
+Mt.Ordeals Summit                                                             Seed: 208   Index: 226
+Paladin                                                                       Seed: 208   Index: 230
+Mt.Ordeals Summit                                                             Seed: 208   Index: 230
+  Optional Steps: 1
+  Step  12: 37 / Revenant x1, Ghoul x3 (8.489s)
+  Step  14: 38 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed: 208   Index: 253
+  Step   6: 39 / Revenant x1, Ghoul x3 (8.489s)
+  Step  39: 40 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 225   Index:  39
+  Step  16: 41 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 225   Index:  69
+  Step  31: 42 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 225   Index: 113
+Take Chocobo to Mysidia                                                       Seed: 225   Index: 126
+Overworld (Mysidia)                                                           Seed: 225   Index: 126
+Town of Baron Serpent Road                                                    Seed: 225   Index: 126
+Credit Warp Fight Search                                                      Seed: 225   Index: 130
+  Overworld (Baron)                                                           Seed: 225   Index: 130
+    Extra Steps: 34
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  34: 44 / Imp x4 (7.223s)
+   (Step  98: 45 / Imp x3, SwordRat x1)
+   (Step 183: 46 / Imp x3, SwordRat x1)
+   (Step 224: 47 / Imp x3, SwordRat x1)
+   (Step 239: 48 / Imp x3, SwordRat x1)
+
+Encounter Time:      343.717s
+Other Time:          499.012s
+Total Time:          842.728s
+
+Base Total Time:     879.050s
+Time Saved:          36.322s
+
+Optional Steps:      2
+Extra Steps:         34
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/141.txt
+++ b/data/routes/cw/141.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	141
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50539322
+VARS	FFFFFFFF:34 E302500:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 141   Index:   0
+Overworld (Kaipo)                                                             Seed: 141   Index:   1
+  Step  13: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 141   Index:  37
+Overworld (Kaipo)                                                             Seed: 141   Index:  37
+Watery Pass-South B1F                                                         Seed: 141   Index:  69
+  Step   2: 2 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 141   Index: 101
+Watery Pass-South B1F                                                         Seed: 141   Index: 101
+  Step   9: 3 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 141   Index: 121
+  Step  21: 4 / Pike x3 (7.152s)
+  Step  31: 5 / CaveToad x3 (7.014s)
+  Step  77: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 141   Index: 211
+Watery Pass-South B2F                                                         Seed: 141   Index: 215
+  Step  25: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 141   Index: 254
+  Step  27: 8 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed: 158   Index:  32
+Watery Pass-North B1F                                                         Seed: 158   Index:  53
+  Step  52: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  55: 10 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 158   Index: 113
+Waterfalls B1F                                                                Seed: 158   Index: 122
+Waterfalls B2F                                                                Seed: 158   Index: 123
+  Step  15: 11 / Aligator x1, WaterBug x2 (7.292s)
+  Step  31: 12 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 158   Index: 168
+  Step  17: 13 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed: 158   Index: 205
+Waterfalls Lake                                                               Seed: 158   Index: 205
+Overworld (Kaipo)                                                             Seed: 158   Index: 206
+  Step   5: 14 / SandMoth x2, Larva x2 (7.188s)
+Overworld (Damcyan)                                                           Seed: 158   Index: 217
+Damcyan                                                                       Seed: 158   Index: 221
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 158   Index: 229
+Antlion B1F                                                                   Seed: 158   Index: 229
+  Step  19: 15 / Cream x4 (7.552s)
+  Step  31: 16 / Turtle x2 (7.487s)
+Antlion B2F Inward Direct                                                     Seed: 175   Index:  11
+  Antlion B2F                                                                 Seed: 175   Index:  11
+    Step  31: 17 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 175   Index:  91
+Battle: Antlion                                                               Seed: 175   Index: 105
+Antlion's Nest                                                                Seed: 175   Index: 105
+Antlion B2F Outward Direct                                                    Seed: 175   Index: 120
+  Antlion B2F                                                                 Seed: 175   Index: 120
+    Step   2: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  45: 19 / Turtle x2 (7.464s)
+    Step  50: 20 / Turtle x2 (7.464s)
+    Step  56: 21 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed: 175   Index: 200
+  Step   2: 22 / Turtle x1, Imp x2 (7.009s)
+  Step  19: 23 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 175   Index: 238
+Overworld (Kaipo)                                                             Seed: 175   Index: 238
+Kaipo Revisited                                                               Seed: 175   Index: 238
+Overworld (Kaipo)                                                             Seed: 175   Index: 238
+Overworld (Damcyan)                                                           Seed: 175   Index: 238
+Mt.Hobs-West                                                                  Seed: 175   Index: 238
+  Step  36: 24 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 192   Index:  21
+Battle: MomBomb                                                               Seed: 192   Index:  36
+Mt.Hobs Summit                                                                Seed: 192   Index:  36
+  Step   4: 25 / Spirit x2, Skelton x2 (8.237s)
+Mt.Hobs-East                                                                  Seed: 192   Index:  42
+  Step  21: 26 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 192   Index:  88
+  Step  16: 27 / SwordRat x3, Needler x3 (7.663s)
+  Step  18: 28 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  84: 29 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 192   Index: 172
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 192   Index: 232
+  Step   1: 30 / Imp Cap. x3, Needler x1 (7.956s)
+Fabul Boat and Leviatan                                                       Seed: 192   Index: 239
+Overworld (Mysidia)                                                           Seed: 192   Index: 239
+Mysidia                                                                       Seed: 192   Index: 248
+Overworld (Mysidia)                                                           Seed: 192   Index: 248
+Overworld (Mt.Ordeals)                                                        Seed: 209   Index:   2
+  Step   4: 31 / Needler x2, SwordRat x2 (8.097s)
+  Step  36: 32 / Raven x1, Cocktric x3 (9.100s)
+  Step  68: 33 / Raven x1 (8.356s)
+  Step  82: 34 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 209   Index:  96
+  Step  38: 35 / Red Bone x1, Skelton x3 (8.067s)
+  Step  43: 36 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 209   Index: 139
+Recruit Tellah                                                                Seed: 209   Index: 162
+Mt.Ordeals-3rd station                                                        Seed: 209   Index: 162
+Mt.Ordeals-7th station                                                        Seed: 209   Index: 167
+  Step  40: 37 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 209   Index: 209
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 209   Index: 226
+Mt.Ordeals Summit                                                             Seed: 209   Index: 226
+Paladin                                                                       Seed: 209   Index: 230
+Mt.Ordeals Summit                                                             Seed: 209   Index: 230
+  Optional Steps: 1
+  Step  12: 38 / Ghoul x2, Soul x2 (8.971s)
+  Step  14: 39 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed: 209   Index: 253
+  Step   6: 40 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed: 226   Index:  39
+  Step  16: 41 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 226   Index:  69
+  Step  31: 42 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 226   Index: 113
+Take Chocobo to Mysidia                                                       Seed: 226   Index: 126
+Overworld (Mysidia)                                                           Seed: 226   Index: 126
+Town of Baron Serpent Road                                                    Seed: 226   Index: 126
+Credit Warp Fight Search                                                      Seed: 226   Index: 130
+  Overworld (Baron)                                                           Seed: 226   Index: 130
+    Extra Steps: 34
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step  34: 44 / Imp x4 (7.223s)
+   (Step  62: 45 / Imp x3, SwordRat x1)
+   (Step  98: 46 / Imp x3, SwordRat x1)
+   (Step 183: 47 / Imp x3, SwordRat x1)
+   (Step 191: 48 / Imp x3, SwordRat x1)
+   (Step 239: 49 / Imp x4)
+
+Encounter Time:      341.926s
+Other Time:          499.012s
+Total Time:          840.937s
+
+Base Total Time:     860.712s
+Time Saved:          19.775s
+
+Optional Steps:      2
+Extra Steps:         34
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/142.txt
+++ b/data/routes/cw/142.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	142
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50359558
+VARS	FFFFFFFF:4 E000502:28 E302600:10 E308700:1 E308702:1 E309700:20
+
+Overworld (Kaipo)                                                             Seed: 142   Index:   0
+Overworld (Kaipo)                                                             Seed: 142   Index:   1
+  Step  13: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 142   Index:  37
+Overworld (Kaipo)                                                             Seed: 142   Index:  37
+Watery Pass-South B1F                                                         Seed: 142   Index:  69
+  Step   2: 2 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 142   Index: 101
+Watery Pass-South B1F                                                         Seed: 142   Index: 101
+  Step   9: 3 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 142   Index: 121
+  Step  21: 4 / Pike x3 (7.152s)
+  Step  31: 5 / CaveToad x3 (7.014s)
+  Step  53: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 142   Index: 211
+Watery Pass-South B2F                                                         Seed: 142   Index: 215
+  Step  25: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 142   Index: 254
+Watery Pass-North B2F                                                         Seed: 159   Index:  32
+Watery Pass-North B1F                                                         Seed: 159   Index:  53
+  Step  22: 8 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  55: 9 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 159   Index: 113
+Waterfalls B1F                                                                Seed: 159   Index: 122
+Waterfalls B2F                                                                Seed: 159   Index: 123
+  Step  15: 10 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  31: 11 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed: 159   Index: 168
+  Step  17: 12 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed: 159   Index: 205
+Waterfalls Lake                                                               Seed: 159   Index: 205
+Overworld (Kaipo)                                                             Seed: 159   Index: 206
+  Step   5: 13 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 159   Index: 217
+Damcyan                                                                       Seed: 159   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 159   Index: 228
+Antlion B1F                                                                   Seed: 159   Index: 228
+  Step  20: 14 / Imp x3 (6.649s)
+  Step  32: 15 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed: 176   Index:  10
+  Antlion B2F                                                                 Seed: 176   Index:  10
+    Step  32: 16 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 176   Index:  90
+Battle: Antlion                                                               Seed: 176   Index: 104
+Antlion's Nest                                                                Seed: 176   Index: 104
+Antlion B2F Outward Direct                                                    Seed: 176   Index: 119
+  Antlion B2F                                                                 Seed: 176   Index: 119
+    Step   3: 17 / Turtle x2 (7.464s)
+    Step  46: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  51: 19 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 176   Index: 199
+  Step   3: 20 / Turtle x1, Imp x2 (7.009s)
+  Step  20: 21 / Basilisk x1, Imp x3 (6.783s)
+  Step  35: 22 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 176   Index: 237
+Overworld (Kaipo)                                                             Seed: 176   Index: 237
+Kaipo Revisited                                                               Seed: 176   Index: 237
+Overworld (Kaipo)                                                             Seed: 176   Index: 237
+Overworld (Damcyan)                                                           Seed: 176   Index: 237
+Mt.Hobs-West                                                                  Seed: 176   Index: 237
+  Step  37: 23 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 193   Index:  20
+Battle: MomBomb                                                               Seed: 193   Index:  35
+Mt.Hobs Summit                                                                Seed: 193   Index:  35
+  Step   5: 24 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed: 193   Index:  41
+Overworld (Fabul)                                                             Seed: 193   Index:  87
+  Step  17: 25 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  19: 26 / Cocktric x3 (8.241s)
+  Step  69: 27 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed: 193   Index: 171
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 193   Index: 241
+Fabul Boat and Leviatan                                                       Seed: 193   Index: 248
+Overworld (Mysidia)                                                           Seed: 193   Index: 248
+Mysidia                                                                       Seed: 210   Index:   1
+Overworld (Mysidia)                                                           Seed: 210   Index:   1
+Overworld (Mt.Ordeals)                                                        Seed: 210   Index:  11
+  Step  27: 28 / Raven x1, Cocktric x3 (9.100s)
+  Step  59: 29 / Needler x2, SwordRat x2 (8.097s)
+  Step  73: 30 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 210   Index: 105
+  Step  29: 31 / Skelton x3, Red Bone x2 (8.244s)
+  Step  34: 32 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed: 210   Index: 148
+Recruit Tellah                                                                Seed: 210   Index: 171
+Mt.Ordeals-3rd station                                                        Seed: 210   Index: 171
+Mt.Ordeals-7th station                                                        Seed: 210   Index: 176
+  Step  24: 33 / Lilith x1, Red Bone x2 (8.912s)
+  Step  31: 34 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed: 210   Index: 218
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 210   Index: 236
+Mt.Ordeals Summit                                                             Seed: 210   Index: 236
+Paladin                                                                       Seed: 210   Index: 240
+Mt.Ordeals Summit                                                             Seed: 210   Index: 240
+  Optional Steps: 1
+  Step   2: 35 / Revenant x1, Ghoul x3 (8.489s)
+  Step   4: 36 / Ghoul x2, Soul x2 (8.971s)
+  Step  19: 37 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed: 227   Index:   7
+Mt.Ordeals-3rd station                                                        Seed: 227   Index:  49
+  Step   6: 38 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 227   Index:  79
+  Step  21: 39 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 227   Index: 123
+  Step   5: 40 / Raven x1 (8.065s)
+  Step   9: 41 / Imp Cap. x3, Needler x1 (7.897s)
+Take Chocobo to Mysidia                                                       Seed: 227   Index: 136
+Overworld (Mysidia)                                                           Seed: 227   Index: 136
+  Extra Steps: 28
+  Step  28: 42 / Imp Cap. x3, Needler x1 (7.897s)
+Town of Baron Serpent Road                                                    Seed: 227   Index: 164
+  Extra Steps: 20
+Credit Warp Fight Search                                                      Seed: 227   Index: 188
+  Overworld (Baron)                                                           Seed: 227   Index: 188
+    Extra Steps: 4
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step   4: 44 / Imp x4 (7.223s)
+   (Step  40: 45 / Imp x3, SwordRat x1)
+   (Step 125: 46 / Imp x3, SwordRat x1)
+   (Step 133: 47 / Imp x3, SwordRat x1)
+   (Step 194: 48 / Imp x3, SwordRat x1)
+   (Step 230: 49 / Imp x4)
+   (Step 247: 50 / Imp x3, SwordRat x1)
+
+Encounter Time:      342.129s
+Other Time:          495.817s
+Total Time:          837.946s
+
+Base Total Time:     857.357s
+Time Saved:          19.411s
+
+Optional Steps:      12
+Extra Steps:         52
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/143.txt
+++ b/data/routes/cw/143.txt
@@ -1,0 +1,157 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	143
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50243884
+VARS	FFFFFFFF:4 E000200:10 E000202:2 E302500:1 E302600:9 E307000:18 E307200:4 E307701:4 E308700:1 E308702:1 E309700:10
+
+Overworld (Kaipo)                                                             Seed: 143   Index:   0
+Overworld (Kaipo)                                                             Seed: 143   Index:   1
+  Step  13: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 143   Index:  37
+Overworld (Kaipo)                                                             Seed: 143   Index:  37
+Watery Pass-South B1F                                                         Seed: 143   Index:  69
+Recruit Tellah                                                                Seed: 143   Index: 101
+Watery Pass-South B1F                                                         Seed: 143   Index: 101
+  Step   6: 2 / Pike x3 (7.152s)
+  Step   9: 3 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 143   Index: 121
+  Step  21: 4 / Pike x3 (7.152s)
+  Step  31: 5 / CaveToad x3 (7.014s)
+  Step  53: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 143   Index: 211
+Watery Pass-South B2F                                                         Seed: 143   Index: 215
+  Extra Steps: 18
+  Step  25: 7 / Pike x3 (7.152s)
+  Step  57: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 160   Index:  16
+Watery Pass-North B2F                                                         Seed: 160   Index:  50
+  Extra Steps: 4
+  Step  25: 9 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed: 160   Index:  75
+  Step  33: 10 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 160   Index: 135
+  Extra Steps: 10
+  Step   3: 11 / SandMoth x2, Larva x2 (7.163s)
+  Step  19: 12 / Sandpede x1, Sand Man x2 (7.188s)
+Waterfalls B1F                                                                Seed: 160   Index: 154
+Waterfalls B2F                                                                Seed: 160   Index: 155
+  Step  30: 13 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed: 160   Index: 200
+  Step  11: 14 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 160   Index: 237
+Waterfalls Lake                                                               Seed: 160   Index: 237
+Overworld (Kaipo)                                                             Seed: 160   Index: 238
+  Step  10: 15 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed: 160   Index: 249
+Damcyan                                                                       Seed: 160   Index: 253
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 177   Index:   5
+Antlion B1F                                                                   Seed: 177   Index:   5
+  Step   4: 16 / Turtle x2 (7.487s)
+  Step  37: 17 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 177   Index:  43
+  Antlion B2F                                                                 Seed: 177   Index:  43
+    Step  79: 18 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed: 177   Index: 123
+Battle: Antlion                                                               Seed: 177   Index: 137
+Antlion's Nest                                                                Seed: 177   Index: 137
+Antlion B2F Outward Direct                                                    Seed: 177   Index: 152
+  Antlion B2F                                                                 Seed: 177   Index: 152
+    Step  13: 19 / Turtle x2 (7.464s)
+    Step  18: 20 / Turtle x2 (7.464s)
+    Step  50: 21 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed: 177   Index: 232
+  Extra Steps: 4
+  Step   2: 22 / Turtle x1, Imp x2 (7.009s)
+  Step  42: 23 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 194   Index:  18
+Overworld (Kaipo)                                                             Seed: 194   Index:  18
+  Extra Steps: 2
+  Step   1: 24 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed: 194   Index:  20
+Overworld (Kaipo)                                                             Seed: 194   Index:  20
+Overworld (Damcyan)                                                           Seed: 194   Index:  20
+Mt.Hobs-West                                                                  Seed: 194   Index:  20
+Mt.Hobs Summit                                                                Seed: 194   Index:  59
+Battle: MomBomb                                                               Seed: 194   Index:  74
+Mt.Hobs Summit                                                                Seed: 194   Index:  74
+Mt.Hobs-East                                                                  Seed: 194   Index:  80
+  Step  24: 25 / Turtle x2 (7.432s)
+  Step  26: 26 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 194   Index: 126
+  Step  30: 27 / SwordRat x3, Needler x3 (7.663s)
+  Step  58: 28 / SwordRat x3, Needler x3 (7.663s)
+  Step  65: 29 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 194   Index: 210
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed: 211   Index:  23
+Fabul Boat and Leviatan                                                       Seed: 211   Index:  30
+Overworld (Mysidia)                                                           Seed: 211   Index:  30
+Mysidia                                                                       Seed: 211   Index:  39
+Overworld (Mysidia)                                                           Seed: 211   Index:  39
+Overworld (Mt.Ordeals)                                                        Seed: 211   Index:  49
+  Step  21: 30 / Raven x1 (8.356s)
+  Step  35: 31 / Needler x2, SwordRat x2 (8.097s)
+  Step  85: 32 / Raven x1, Cocktric x3 (9.100s)
+  Step  90: 33 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 211   Index: 143
+Mt.Ordeals-3rd station                                                        Seed: 211   Index: 186
+  Step  14: 34 / Revenant x1, Ghoul x3 (8.911s)
+  Step  21: 35 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed: 211   Index: 209
+Mt.Ordeals-3rd station                                                        Seed: 211   Index: 209
+Mt.Ordeals-7th station                                                        Seed: 211   Index: 214
+  Step  28: 36 / Ghoul x2, Soul x2 (9.197s)
+  Step  30: 37 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 228   Index:   0
+  Optional Steps: 1
+  Step   3: 38 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed: 228   Index:  18
+Mt.Ordeals Summit                                                             Seed: 228   Index:  18
+Paladin                                                                       Seed: 228   Index:  22
+Mt.Ordeals Summit                                                             Seed: 228   Index:  22
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 228   Index:  45
+  Step  10: 39 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 228   Index:  87
+Mt.Ordeals                                                                    Seed: 228   Index: 117
+  Step  14: 40 / Soul x2, Red Bone x2 (8.881s)
+  Step  15: 41 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 228   Index: 161
+  Step   3: 42 / Imp Cap. x3, Needler x1 (7.897s)
+Take Chocobo to Mysidia                                                       Seed: 228   Index: 174
+Overworld (Mysidia)                                                           Seed: 228   Index: 174
+Town of Baron Serpent Road                                                    Seed: 228   Index: 174
+  Extra Steps: 10
+Credit Warp Fight Search                                                      Seed: 228   Index: 188
+  Overworld (Baron)                                                           Seed: 228   Index: 188
+    Extra Steps: 4
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step   4: 44 / Imp x4 (7.223s)
+   (Step  40: 45 / Imp x3, SwordRat x1)
+   (Step 125: 46 / Imp x3, SwordRat x1)
+   (Step 133: 47 / Imp x3, SwordRat x1)
+   (Step 194: 48 / Imp x3, SwordRat x1)
+   (Step 197: 49 / Imp x4)
+   (Step 247: 50 / Eagle x3)
+
+Encounter Time:      340.204s
+Other Time:          495.817s
+Total Time:          836.021s
+
+Base Total Time:     856.754s
+Time Saved:          20.733s
+
+Optional Steps:      12
+Extra Steps:         52
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/144.txt
+++ b/data/routes/cw/144.txt
@@ -1,0 +1,158 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	144
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50152125
+VARS	FFFFFFFF:4 E000202:2 E302500:1 E302600:9 E307000:18 E307200:4 E307400:10 E307701:4 E308700:1 E308702:1 E309700:10
+
+Overworld (Kaipo)                                                             Seed: 144   Index:   0
+Overworld (Kaipo)                                                             Seed: 144   Index:   1
+  Step  13: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 144   Index:  37
+Overworld (Kaipo)                                                             Seed: 144   Index:  37
+Watery Pass-South B1F                                                         Seed: 144   Index:  69
+Recruit Tellah                                                                Seed: 144   Index: 101
+Watery Pass-South B1F                                                         Seed: 144   Index: 101
+  Step   6: 2 / Pike x3 (7.152s)
+  Step   9: 3 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 144   Index: 121
+  Step  21: 4 / Pike x3 (7.152s)
+  Step  31: 5 / CaveToad x3 (7.014s)
+  Step  53: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 144   Index: 211
+Watery Pass-South B2F                                                         Seed: 144   Index: 215
+  Extra Steps: 18
+  Step   1: 7 / CaveToad x3 (7.014s)
+  Step  25: 8 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  57: 9 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 161   Index:  16
+Watery Pass-North B2F                                                         Seed: 161   Index:  50
+  Extra Steps: 4
+  Step  25: 10 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 161   Index:  75
+  Step  33: 11 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed: 161   Index: 135
+  Step   3: 12 / Sandpede x1, Sand Man x2 (7.188s)
+Waterfalls B1F                                                                Seed: 161   Index: 144
+  Extra Steps: 10
+Waterfalls B2F                                                                Seed: 161   Index: 155
+  Step  30: 13 / Aligator x2 (7.544s)
+  Step  41: 14 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 161   Index: 200
+Battle: Octomamm                                                              Seed: 161   Index: 237
+Waterfalls Lake                                                               Seed: 161   Index: 237
+Overworld (Kaipo)                                                             Seed: 161   Index: 238
+  Step  10: 15 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed: 161   Index: 249
+Damcyan                                                                       Seed: 161   Index: 253
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 178   Index:   5
+Antlion B1F                                                                   Seed: 178   Index:   5
+  Step   4: 16 / Turtle x2 (7.487s)
+  Step  36: 17 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 178   Index:  43
+  Antlion B2F                                                                 Seed: 178   Index:  43
+    Step  79: 18 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed: 178   Index: 123
+Battle: Antlion                                                               Seed: 178   Index: 137
+Antlion's Nest                                                                Seed: 178   Index: 137
+Antlion B2F Outward Direct                                                    Seed: 178   Index: 152
+  Antlion B2F                                                                 Seed: 178   Index: 152
+    Step  13: 19 / Turtle x2 (7.464s)
+    Step  18: 20 / Turtle x2 (7.464s)
+    Step  50: 21 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed: 178   Index: 232
+  Extra Steps: 4
+  Step   2: 22 / Turtle x1, Imp x2 (7.009s)
+  Step  42: 23 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 195   Index:  18
+Overworld (Kaipo)                                                             Seed: 195   Index:  18
+  Extra Steps: 2
+  Step   1: 24 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed: 195   Index:  20
+Overworld (Kaipo)                                                             Seed: 195   Index:  20
+Overworld (Damcyan)                                                           Seed: 195   Index:  20
+Mt.Hobs-West                                                                  Seed: 195   Index:  20
+Mt.Hobs Summit                                                                Seed: 195   Index:  59
+Battle: MomBomb                                                               Seed: 195   Index:  74
+Mt.Hobs Summit                                                                Seed: 195   Index:  74
+Mt.Hobs-East                                                                  Seed: 195   Index:  80
+  Step  24: 25 / Turtle x2 (7.432s)
+  Step  26: 26 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 195   Index: 126
+  Step  30: 27 / SwordRat x3, Needler x3 (7.663s)
+  Step  58: 28 / SwordRat x3, Needler x3 (7.663s)
+  Step  65: 29 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 195   Index: 210
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed: 212   Index:  23
+Fabul Boat and Leviatan                                                       Seed: 212   Index:  30
+Overworld (Mysidia)                                                           Seed: 212   Index:  30
+Mysidia                                                                       Seed: 212   Index:  39
+Overworld (Mysidia)                                                           Seed: 212   Index:  39
+Overworld (Mt.Ordeals)                                                        Seed: 212   Index:  49
+  Step  21: 30 / Raven x1 (8.356s)
+  Step  35: 31 / Needler x2, SwordRat x2 (8.097s)
+  Step  52: 32 / Raven x1, Cocktric x3 (9.100s)
+  Step  85: 33 / Raven x1 (8.356s)
+  Step  90: 34 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 212   Index: 143
+Mt.Ordeals-3rd station                                                        Seed: 212   Index: 186
+  Step  14: 35 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+  Step  21: 36 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed: 212   Index: 209
+Mt.Ordeals-3rd station                                                        Seed: 212   Index: 209
+Mt.Ordeals-7th station                                                        Seed: 212   Index: 214
+  Step  28: 37 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 229   Index:   0
+  Optional Steps: 1
+  Step   3: 38 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed: 229   Index:  18
+Mt.Ordeals Summit                                                             Seed: 229   Index:  18
+Paladin                                                                       Seed: 229   Index:  22
+Mt.Ordeals Summit                                                             Seed: 229   Index:  22
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 229   Index:  45
+  Step  10: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 229   Index:  87
+Mt.Ordeals                                                                    Seed: 229   Index: 117
+  Step  14: 40 / Soul x2, Red Bone x2 (8.881s)
+  Step  20: 41 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 229   Index: 161
+  Step   3: 42 / Imp Cap. x3, Needler x1 (7.897s)
+Take Chocobo to Mysidia                                                       Seed: 229   Index: 174
+Overworld (Mysidia)                                                           Seed: 229   Index: 174
+Town of Baron Serpent Road                                                    Seed: 229   Index: 174
+  Extra Steps: 10
+Credit Warp Fight Search                                                      Seed: 229   Index: 188
+  Overworld (Baron)                                                           Seed: 229   Index: 188
+    Extra Steps: 4
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step   4: 44 / Imp x4 (7.223s)
+   (Step  40: 45 / Imp x3, SwordRat x1)
+   (Step 125: 46 / Imp x3, SwordRat x1)
+   (Step 133: 47 / Imp x3, SwordRat x1)
+   (Step 194: 48 / Imp x3, SwordRat x1)
+   (Step 197: 49 / Imp x4)
+   (Step 229: 50 / Eagle x3)
+   (Step 247: 51 / Eagle x3)
+
+Encounter Time:      338.678s
+Other Time:          495.817s
+Total Time:          834.494s
+
+Base Total Time:     858.340s
+Time Saved:          23.846s
+
+Optional Steps:      12
+Extra Steps:         52
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/145.txt
+++ b/data/routes/cw/145.txt
@@ -1,0 +1,146 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	145
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48879806
+VARS	FFFFFFFF:4 C307800:1 E000500:18 E302600:68 E305400:58 E307400:16 E307B00:86 E308501:2
+
+Overworld (Kaipo)                                                             Seed: 145   Index:   0
+Overworld (Kaipo)                                                             Seed: 145   Index:   1
+Kaipo                                                                         Seed: 145   Index:  37
+Overworld (Kaipo)                                                             Seed: 145   Index:  37
+Watery Pass-South B1F                                                         Seed: 145   Index:  69
+Recruit Tellah                                                                Seed: 145   Index: 101
+Watery Pass-South B1F                                                         Seed: 145   Index: 101
+  Step   6: 1 / EvilShel x3, WaterBug x1 (7.081s)
+  Step   9: 2 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 145   Index: 121
+  Step  21: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  31: 4 / Pike x3 (7.152s)
+  Step  53: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 145   Index: 211
+  Extra Steps: 58
+Watery Pass-South B2F                                                         Seed: 162   Index:  17
+Watery Pass-South B3F                                                         Seed: 162   Index:  56
+  Step  19: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed: 162   Index:  90
+  Step  18: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 162   Index: 111
+  Step  27: 8 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 162   Index: 171
+Waterfalls B1F                                                                Seed: 162   Index: 180
+  Extra Steps: 16
+Waterfalls B2F                                                                Seed: 162   Index: 197
+Waterfalls Lake                                                               Seed: 162   Index: 242
+  Step   6: 9 / Aligator x1, WaterBug x2 (7.292s)
+  Step  23: 10 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed: 179   Index:  23
+Waterfalls Lake                                                               Seed: 179   Index:  23
+Overworld (Kaipo)                                                             Seed: 179   Index:  24
+Overworld (Damcyan)                                                           Seed: 179   Index:  35
+Damcyan                                                                       Seed: 179   Index:  39
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 179   Index:  46
+Antlion B1F                                                                   Seed: 179   Index:  46
+Antlion B2F Inward Charm Room Steps                                           Seed: 179   Index:  84
+  Antlion B2F                                                                 Seed: 179   Index:  84
+  Antlion B2F Treasure Room                                                   Seed: 179   Index: 117
+    Extra Steps: 86
+  Antlion B2F                                                                 Seed: 179   Index: 203
+    Step  31: 11 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 179   Index: 255
+Battle: Antlion                                                               Seed: 196   Index:  13
+Antlion's Nest                                                                Seed: 196   Index:  13
+  Step   5: 12 / Turtle x2 (7.464s)
+  Step   6: 13 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B2F Outward Direct                                                    Seed: 196   Index:  28
+  Antlion B2F                                                                 Seed: 196   Index:  28
+    Step  75: 14 / Cream x4 (7.523s)
+    Step  78: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 196   Index: 108
+Overworld (Damcyan)                                                           Seed: 196   Index: 146
+Overworld (Kaipo)                                                             Seed: 196   Index: 146
+Kaipo Revisited                                                               Seed: 196   Index: 146
+Overworld (Kaipo)                                                             Seed: 196   Index: 146
+Overworld (Damcyan)                                                           Seed: 196   Index: 146
+Mt.Hobs-West                                                                  Seed: 196   Index: 146
+  Step  10: 16 / GrayBomb x2, Bomb x2 (10.938s)
+  Step  38: 17 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 196   Index: 185
+Battle: MomBomb                                                               Seed: 196   Index: 200
+Mt.Hobs Summit                                                                Seed: 196   Index: 200
+Mt.Hobs-East                                                                  Seed: 196   Index: 206
+  Step   8: 18 / Red Bone x1, Skelton x3 (8.007s)
+  Step  15: 19 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 196   Index: 252
+  Step  26: 20 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 213   Index:  80
+  Optional Steps: 10
+  Extra Steps: 58
+Overworld (Fabul)                                                             Seed: 213   Index: 208
+Fabul Boat and Leviatan                                                       Seed: 213   Index: 215
+Overworld (Mysidia)                                                           Seed: 213   Index: 215
+  Extra Steps: 18
+  Step  27: 21 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 213   Index: 242
+Overworld (Mysidia)                                                           Seed: 213   Index: 242
+Overworld (Mt.Ordeals)                                                        Seed: 213   Index: 252
+  Step   7: 22 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  59: 23 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 230   Index:  90
+  Step  41: 24 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed: 230   Index: 133
+  Step   4: 25 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed: 230   Index: 156
+Mt.Ordeals-3rd station                                                        Seed: 230   Index: 156
+  Extra Steps: 2
+  Step   7: 26 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 230   Index: 163
+  Step  27: 27 / Soul x3, Ghoul x1, Revenant x1 (9.933s)
+  Step  29: 28 / Soul x3, Ghoul x1, Revenant x1 (9.933s)
+Mt.Ordeals Summit                                                             Seed: 230   Index: 205
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 230   Index: 222
+Mt.Ordeals Summit                                                             Seed: 230   Index: 222
+Paladin                                                                       Seed: 230   Index: 226
+Mt.Ordeals Summit                                                             Seed: 230   Index: 226
+  Optional Steps: 0
+  Step   2: 29 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed: 230   Index: 248
+Mt.Ordeals-3rd station                                                        Seed: 247   Index:  34
+  Step  23: 30 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed: 247   Index:  64
+  Step   1: 31 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 247   Index: 108
+Take Chocobo to Mysidia                                                       Seed: 247   Index: 121
+Overworld (Mysidia)                                                           Seed: 247   Index: 121
+Town of Baron Serpent Road                                                    Seed: 247   Index: 121
+Credit Warp Fight Search                                                      Seed: 247   Index: 125
+  Overworld (Baron)                                                           Seed: 247   Index: 125
+    Extra Steps: 4
+    Step   1: 32 / Imp x6 (7.090s)
+    Step   4: 33 / Imp x4 (7.223s)
+   (Step  36: 34 / Eagle x3)
+   (Step  54: 35 / FloatEye x2)
+   (Step  68: 36 / Imp x3)
+   (Step 212: 37 / FloatEye x2)
+
+Encounter Time:      262.331s
+Other Time:          550.993s
+Total Time:          813.324s
+
+Base Total Time:     854.630s
+Time Saved:          41.306s
+
+Optional Steps:      10
+Extra Steps:         242
+Encounters:          33
+
+Base Encounters:     44
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/146.txt
+++ b/data/routes/cw/146.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	146
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50061709
+VARS	FFFFFFFF:4 E000500:2 E000601:6 E302600:10 E305400:2 E308000:18 E308700:1 E308702:1 E309700:20
+
+Overworld (Kaipo)                                                             Seed: 146   Index:   0
+Overworld (Kaipo)                                                             Seed: 146   Index:   1
+Kaipo                                                                         Seed: 146   Index:  37
+Overworld (Kaipo)                                                             Seed: 146   Index:  37
+  Step   8: 1 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 146   Index:  69
+Recruit Tellah                                                                Seed: 146   Index: 101
+Watery Pass-South B1F                                                         Seed: 146   Index: 101
+  Step   6: 2 / Pike x3 (7.152s)
+  Step   9: 3 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 146   Index: 121
+  Step  21: 4 / Pike x3 (7.152s)
+  Step  53: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 146   Index: 211
+  Extra Steps: 2
+Watery Pass-South B2F                                                         Seed: 146   Index: 217
+  Step  26: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 163   Index:   0
+  Step  11: 7 / Pike x2, EvilShel x2 (7.149s)
+  Step  16: 8 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed: 163   Index:  34
+Watery Pass-North B1F                                                         Seed: 163   Index:  55
+  Step  20: 9 / Aligator x1, Pike x2 (7.368s)
+  Step  53: 10 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 163   Index: 115
+Waterfalls B1F                                                                Seed: 163   Index: 124
+Waterfalls B2F                                                                Seed: 163   Index: 125
+  Step  13: 11 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed: 163   Index: 170
+  Step  26: 12 / Zombie x6 (7.489s)
+  Step  34: 13 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed: 163   Index: 207
+Waterfalls Lake                                                               Seed: 163   Index: 207
+Overworld (Kaipo)                                                             Seed: 163   Index: 208
+Overworld (Damcyan)                                                           Seed: 163   Index: 219
+Damcyan                                                                       Seed: 163   Index: 223
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 163   Index: 230
+Antlion B1F                                                                   Seed: 163   Index: 230
+  Step  18: 14 / Imp x3 (6.649s)
+  Step  35: 15 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed: 180   Index:  12
+  Antlion B2F                                                                 Seed: 180   Index:  12
+    Step   9: 16 / SandWorm x2 (6.841s)
+    Step  29: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 180   Index:  92
+Battle: Antlion                                                               Seed: 180   Index: 106
+Antlion's Nest                                                                Seed: 180   Index: 106
+Antlion B2F Outward Direct                                                    Seed: 180   Index: 121
+  Antlion B2F                                                                 Seed: 180   Index: 121
+    Step  44: 18 / Basilisk x1, Turtle x1 (7.124s)
+    Step  49: 19 / Turtle x2 (7.464s)
+    Step  66: 20 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 180   Index: 201
+  Step   1: 21 / Basilisk x1, Imp x3 (6.783s)
+  Step  33: 22 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 180   Index: 239
+Overworld (Kaipo)                                                             Seed: 180   Index: 239
+Kaipo Revisited                                                               Seed: 180   Index: 239
+Overworld (Kaipo)                                                             Seed: 180   Index: 239
+Overworld (Damcyan)                                                           Seed: 180   Index: 239
+Mt.Hobs-West                                                                  Seed: 180   Index: 239
+  Step  36: 23 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 197   Index:  22
+Battle: MomBomb                                                               Seed: 197   Index:  37
+Mt.Hobs Summit                                                                Seed: 197   Index:  37
+Mt.Hobs-East                                                                  Seed: 197   Index:  43
+  Extra Steps: 18
+  Step  60: 24 / Red Bone x1, Skelton x3 (8.007s)
+  Step  63: 25 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 197   Index: 107
+  Step  28: 26 / Cocktric x3 (8.241s)
+  Step  49: 27 / SwordRat x3, Needler x3 (7.663s)
+  Step  77: 28 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed: 197   Index: 191
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 214   Index:   5
+Fabul Boat and Leviatan                                                       Seed: 214   Index:  12
+Overworld (Mysidia)                                                           Seed: 214   Index:  12
+  Extra Steps: 2
+  Step  10: 29 / Needler x2, SwordRat x2 (8.011s)
+Mysidia                                                                       Seed: 214   Index:  23
+Overworld (Mysidia)                                                           Seed: 214   Index:  23
+Overworld (Mt.Ordeals)                                                        Seed: 214   Index:  33
+  Step  51: 30 / Raven x1 (8.356s)
+  Step  68: 31 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed: 214   Index: 127
+  Step   6: 32 / Spirit x2, Skelton x2 (8.285s)
+  Step  12: 33 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 214   Index: 170
+Recruit Tellah                                                                Seed: 214   Index: 193
+Mt.Ordeals-3rd station                                                        Seed: 214   Index: 193
+Mt.Ordeals-7th station                                                        Seed: 214   Index: 198
+  Step   2: 34 / Lilith x1, Red Bone x2 (8.912s)
+  Step   3: 35 / Revenant x1, Ghoul x3 (8.914s)
+  Step   9: 36 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 214   Index: 240
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 231   Index:   2
+Mt.Ordeals Summit                                                             Seed: 231   Index:   2
+  Step   1: 37 / Revenant x1, Ghoul x3 (8.611s)
+Paladin                                                                       Seed: 231   Index:   6
+Mt.Ordeals Summit                                                             Seed: 231   Index:   6
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 231   Index:  29
+Mt.Ordeals-3rd station                                                        Seed: 231   Index:  71
+Mt.Ordeals                                                                    Seed: 231   Index: 101
+  Step  30: 38 / Spirit x2, Skelton x2 (8.065s)
+  Step  36: 39 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 231   Index: 145
+  Extra Steps: 6
+  Step   5: 40 / Raven x1 (8.065s)
+  Step  18: 41 / Imp Cap. x3, Needler x1 (7.897s)
+  Step  19: 42 / Imp Cap. x3, Needler x1 (7.897s)
+Take Chocobo to Mysidia                                                       Seed: 231   Index: 164
+Overworld (Mysidia)                                                           Seed: 231   Index: 164
+Town of Baron Serpent Road                                                    Seed: 231   Index: 164
+  Extra Steps: 20
+Credit Warp Fight Search                                                      Seed: 231   Index: 188
+  Overworld (Baron)                                                           Seed: 231   Index: 188
+    Extra Steps: 4
+    Step   2: 43 / FloatEye x1, Eagle x2 (7.365s)
+    Step   4: 44 / Imp x4 (7.223s)
+   (Step 133: 45 / Imp x3, SwordRat x1)
+   (Step 194: 46 / Imp x3, SwordRat x1)
+   (Step 197: 47 / Imp x3, SwordRat x1)
+   (Step 229: 48 / Imp x3, SwordRat x1)
+   (Step 247: 49 / Imp x4)
+
+Encounter Time:      337.173s
+Other Time:          495.817s
+Total Time:          832.990s
+
+Base Total Time:     853.650s
+Time Saved:          20.660s
+
+Optional Steps:      12
+Extra Steps:         52
+Encounters:          44
+
+Base Encounters:     44
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/147.txt
+++ b/data/routes/cw/147.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	147
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48746488
+VARS	FFFFFFFF:4 C307801:1 E000501:8 E302600:20 E305400:58 E307400:116 E307803:12 E307B01:22 E308400:8 E308501:4
+
+Overworld (Kaipo)                                                             Seed: 147   Index:   0
+Overworld (Kaipo)                                                             Seed: 147   Index:   1
+Kaipo                                                                         Seed: 147   Index:  37
+Overworld (Kaipo)                                                             Seed: 147   Index:  37
+  Step   8: 1 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 147   Index:  69
+Recruit Tellah                                                                Seed: 147   Index: 101
+Watery Pass-South B1F                                                         Seed: 147   Index: 101
+  Step   6: 2 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 147   Index: 121
+  Step  21: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  28: 4 / Pike x3 (7.152s)
+  Step  53: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 147   Index: 211
+  Extra Steps: 58
+Watery Pass-South B2F                                                         Seed: 164   Index:  17
+Watery Pass-South B3F                                                         Seed: 164   Index:  56
+  Step  19: 6 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 164   Index:  90
+Watery Pass-North B1F                                                         Seed: 164   Index: 111
+  Step  27: 7 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 164   Index: 171
+Waterfalls B1F                                                                Seed: 164   Index: 180
+  Extra Steps: 116
+Waterfalls B2F                                                                Seed: 181   Index:  41
+Waterfalls Lake                                                               Seed: 181   Index:  86
+Battle: Octomamm                                                              Seed: 181   Index: 123
+Waterfalls Lake                                                               Seed: 181   Index: 123
+Overworld (Kaipo)                                                             Seed: 181   Index: 124
+Overworld (Damcyan)                                                           Seed: 181   Index: 135
+Damcyan                                                                       Seed: 181   Index: 139
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 181   Index: 146
+Antlion B1F                                                                   Seed: 181   Index: 146
+  Step  24: 8 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 181   Index: 184
+  Antlion B2F                                                                 Seed: 181   Index: 184
+    Step   3: 9 / Weeper x2 (7.114s)
+    Step  18: 10 / Turtle x2 (7.487s)
+    Step  50: 11 / Weeper x2 (7.114s)
+    Step  68: 12 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 198   Index:   8
+  Step  11: 13 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 198   Index:  22
+Antlion's Nest                                                                Seed: 198   Index:  22
+Antlion B2F Outward Charm Room Steps                                          Seed: 198   Index:  37
+  Antlion B2F                                                                 Seed: 198   Index:  37
+  Antlion B2F Treasure Room                                                   Seed: 198   Index:  88
+    Extra Steps: 22
+  Antlion B2F                                                                 Seed: 198   Index: 110
+    Extra Steps: 12
+    Step  25: 14 / Cream x4 (7.523s)
+    Step  46: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 198   Index: 156
+  Step  28: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed: 198   Index: 194
+Overworld (Kaipo)                                                             Seed: 198   Index: 194
+Kaipo Revisited                                                               Seed: 198   Index: 194
+Overworld (Kaipo)                                                             Seed: 198   Index: 194
+Overworld (Damcyan)                                                           Seed: 198   Index: 194
+Mt.Hobs-West                                                                  Seed: 198   Index: 194
+  Step  27: 17 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 198   Index: 233
+Battle: MomBomb                                                               Seed: 198   Index: 248
+Mt.Hobs Summit                                                                Seed: 198   Index: 248
+Mt.Hobs-East                                                                  Seed: 198   Index: 254
+  Step  24: 18 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 215   Index:  44
+  Step  40: 19 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  57: 20 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 215   Index: 128
+  Optional Steps: 10
+  Extra Steps: 10
+Overworld (Fabul)                                                             Seed: 215   Index: 208
+Fabul Boat and Leviatan                                                       Seed: 215   Index: 215
+Overworld (Mysidia)                                                           Seed: 215   Index: 215
+Mysidia                                                                       Seed: 215   Index: 224
+Overworld (Mysidia)                                                           Seed: 215   Index: 224
+  Extra Steps: 8
+Overworld (Mt.Ordeals)                                                        Seed: 215   Index: 242
+  Step  17: 21 / Needler x2, SwordRat x2 (8.097s)
+  Step  69: 22 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 232   Index:  80
+  Extra Steps: 8
+  Step  51: 23 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 232   Index: 131
+  Step   6: 24 / Revenant x1, Ghoul x3 (8.911s)
+  Step  19: 25 / Lilith x1, Red Bone x2 (9.259s)
+Recruit Tellah                                                                Seed: 232   Index: 154
+Mt.Ordeals-3rd station                                                        Seed: 232   Index: 154
+  Extra Steps: 4
+  Step   9: 26 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed: 232   Index: 163
+  Step  27: 27 / Lilith x2 (9.842s)
+  Step  29: 28 / Soul x3, Ghoul x1, Revenant x1 (9.933s)
+Mt.Ordeals Summit                                                             Seed: 232   Index: 205
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 232   Index: 222
+Mt.Ordeals Summit                                                             Seed: 232   Index: 222
+Paladin                                                                       Seed: 232   Index: 226
+Mt.Ordeals Summit                                                             Seed: 232   Index: 226
+  Optional Steps: 0
+  Step   1: 29 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed: 232   Index: 248
+  Step   8: 30 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 249   Index:  34
+Mt.Ordeals                                                                    Seed: 249   Index:  64
+  Step   1: 31 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 249   Index: 108
+Take Chocobo to Mysidia                                                       Seed: 249   Index: 121
+Overworld (Mysidia)                                                           Seed: 249   Index: 121
+Town of Baron Serpent Road                                                    Seed: 249   Index: 121
+Credit Warp Fight Search                                                      Seed: 249   Index: 125
+  Overworld (Baron)                                                           Seed: 249   Index: 125
+    Extra Steps: 4
+    Step   1: 32 / Imp x3 (7.174s)
+    Step   4: 33 / Imp x4 (7.223s)
+   (Step  36: 34 / Eagle x3)
+   (Step  68: 35 / FloatEye x2)
+   (Step 100: 36 / Imp x3)
+   (Step 144: 37 / FloatEye x2)
+   (Step 166: 38 / Imp x3)
+   (Step 212: 39 / FloatEye x1, Eagle x2)
+
+Encounter Time:      260.113s
+Other Time:          550.993s
+Total Time:          811.106s
+
+Base Total Time:     854.178s
+Time Saved:          43.073s
+
+Optional Steps:      10
+Extra Steps:         242
+Encounters:          33
+
+Base Encounters:     44
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/148.txt
+++ b/data/routes/cw/148.txt
@@ -1,0 +1,145 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	148
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47966692
+VARS	FFFFFFFF:4 C307801:1 E305400:58 E307400:116 E307700:4 E307B01:64 E308000:6
+
+Overworld (Kaipo)                                                             Seed: 148   Index:   0
+Overworld (Kaipo)                                                             Seed: 148   Index:   1
+Kaipo                                                                         Seed: 148   Index:  37
+Overworld (Kaipo)                                                             Seed: 148   Index:  37
+  Step   7: 1 / Sand Man x4 (7.242s)
+  Step   8: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 148   Index:  69
+Recruit Tellah                                                                Seed: 148   Index: 101
+Watery Pass-South B1F                                                         Seed: 148   Index: 101
+  Step   6: 3 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 148   Index: 121
+  Step  28: 4 / Pike x3 (7.152s)
+  Step  53: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 148   Index: 211
+  Extra Steps: 58
+Watery Pass-South B2F                                                         Seed: 165   Index:  17
+Watery Pass-South B3F                                                         Seed: 165   Index:  56
+  Step  19: 6 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 165   Index:  90
+Watery Pass-North B1F                                                         Seed: 165   Index: 111
+  Step  27: 7 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 165   Index: 171
+Waterfalls B1F                                                                Seed: 165   Index: 180
+  Extra Steps: 116
+Waterfalls B2F                                                                Seed: 182   Index:  41
+Waterfalls Lake                                                               Seed: 182   Index:  86
+Battle: Octomamm                                                              Seed: 182   Index: 123
+Waterfalls Lake                                                               Seed: 182   Index: 123
+Overworld (Kaipo)                                                             Seed: 182   Index: 124
+Overworld (Damcyan)                                                           Seed: 182   Index: 135
+Damcyan                                                                       Seed: 182   Index: 139
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 182   Index: 146
+Antlion B1F                                                                   Seed: 182   Index: 146
+  Extra Steps: 4
+  Step  41: 8 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 182   Index: 188
+  Antlion B2F                                                                 Seed: 182   Index: 188
+    Step  14: 9 / Weeper x2 (7.114s)
+    Step  46: 10 / Turtle x2 (7.487s)
+    Step  64: 11 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 199   Index:  12
+  Step   7: 12 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 199   Index:  26
+Antlion's Nest                                                                Seed: 199   Index:  26
+Antlion B2F Outward Charm Room Steps                                          Seed: 199   Index:  41
+  Antlion B2F                                                                 Seed: 199   Index:  41
+  Antlion B2F Treasure Room                                                   Seed: 199   Index:  92
+    Extra Steps: 64
+  Antlion B2F                                                                 Seed: 199   Index: 156
+Antlion B1F                                                                   Seed: 199   Index: 190
+  Step   9: 13 / Basilisk x1, Imp x3 (6.783s)
+  Step  31: 14 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 199   Index: 228
+Overworld (Kaipo)                                                             Seed: 199   Index: 228
+Kaipo Revisited                                                               Seed: 199   Index: 228
+Overworld (Kaipo)                                                             Seed: 199   Index: 228
+Overworld (Damcyan)                                                           Seed: 199   Index: 228
+Mt.Hobs-West                                                                  Seed: 199   Index: 228
+Mt.Hobs Summit                                                                Seed: 216   Index:  11
+  Step  11: 15 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed: 216   Index:  26
+Mt.Hobs Summit                                                                Seed: 216   Index:  26
+Mt.Hobs-East                                                                  Seed: 216   Index:  32
+  Extra Steps: 6
+Overworld (Fabul)                                                             Seed: 216   Index:  84
+  Step  17: 16 / SwordRat x3, Needler x3 (7.663s)
+  Step  49: 17 / Cocktric x3 (8.241s)
+  Step  55: 18 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 216   Index: 168
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 216   Index: 228
+Fabul Boat and Leviatan                                                       Seed: 216   Index: 235
+Overworld (Mysidia)                                                           Seed: 216   Index: 235
+Mysidia                                                                       Seed: 216   Index: 244
+Overworld (Mysidia)                                                           Seed: 216   Index: 244
+Overworld (Mt.Ordeals)                                                        Seed: 216   Index: 254
+  Step   5: 19 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 233   Index:  92
+  Step  39: 20 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed: 233   Index: 135
+  Step   2: 21 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+  Step  15: 22 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed: 233   Index: 158
+Mt.Ordeals-3rd station                                                        Seed: 233   Index: 158
+  Step   5: 23 / Spirit x2, Soul x2, Red Bone x2 (9.695s)
+Mt.Ordeals-7th station                                                        Seed: 233   Index: 163
+  Step  27: 24 / Lilith x1, Red Bone x2 (8.912s)
+  Step  29: 25 / Soul x3, Ghoul x1, Revenant x1 (9.933s)
+Mt.Ordeals Summit                                                             Seed: 233   Index: 205
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 233   Index: 222
+Mt.Ordeals Summit                                                             Seed: 233   Index: 222
+Paladin                                                                       Seed: 233   Index: 226
+Mt.Ordeals Summit                                                             Seed: 233   Index: 226
+  Optional Steps: 0
+  Step   1: 26 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed: 233   Index: 248
+  Step   6: 27 / Lilith x2 (9.169s)
+  Step   8: 28 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-3rd station                                                        Seed: 250   Index:  34
+Mt.Ordeals                                                                    Seed: 250   Index:  64
+  Step   1: 29 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 250   Index: 108
+Take Chocobo to Mysidia                                                       Seed: 250   Index: 121
+Overworld (Mysidia)                                                           Seed: 250   Index: 121
+Town of Baron Serpent Road                                                    Seed: 250   Index: 121
+Credit Warp Fight Search                                                      Seed: 250   Index: 125
+  Overworld (Baron)                                                           Seed: 250   Index: 125
+    Extra Steps: 4
+    Step   1: 30 / Imp x3 (7.174s)
+    Step   4: 31 / Imp x4 (7.223s)
+   (Step  36: 32 / Imp x3)
+   (Step  55: 33 / Imp x4)
+   (Step  68: 34 / Eagle x3)
+   (Step 100: 35 / FloatEye x2)
+   (Step 144: 36 / Imp x3)
+   (Step 166: 37 / FloatEye x2)
+
+Encounter Time:      244.476s
+Other Time:          553.655s
+Total Time:          798.130s
+
+Base Total Time:     873.025s
+Time Saved:          74.895s
+
+Optional Steps:      0
+Extra Steps:         252
+Encounters:          31
+
+Base Encounters:     44
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/149.txt
+++ b/data/routes/cw/149.txt
@@ -1,0 +1,145 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	149
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48860525
+VARS	FFFFFFFF:34 C307801:1 E305400:58 E307400:116 E307700:4 E307B01:64 E308000:6 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 149   Index:   0
+Overworld (Kaipo)                                                             Seed: 149   Index:   1
+Kaipo                                                                         Seed: 149   Index:  37
+Overworld (Kaipo)                                                             Seed: 149   Index:  37
+  Step   7: 1 / Sand Man x4 (7.242s)
+  Step   8: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 149   Index:  69
+  Step  14: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 149   Index: 101
+Watery Pass-South B1F                                                         Seed: 149   Index: 101
+  Step   6: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 149   Index: 121
+  Step  28: 5 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 149   Index: 211
+  Extra Steps: 58
+Watery Pass-South B2F                                                         Seed: 166   Index:  17
+Watery Pass-South B3F                                                         Seed: 166   Index:  56
+Watery Pass-North B2F                                                         Seed: 166   Index:  90
+Watery Pass-North B1F                                                         Seed: 166   Index: 111
+  Step  60: 6 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 166   Index: 171
+Waterfalls B1F                                                                Seed: 166   Index: 180
+  Extra Steps: 116
+Waterfalls B2F                                                                Seed: 183   Index:  41
+Waterfalls Lake                                                               Seed: 183   Index:  86
+Battle: Octomamm                                                              Seed: 183   Index: 123
+Waterfalls Lake                                                               Seed: 183   Index: 123
+Overworld (Kaipo)                                                             Seed: 183   Index: 124
+Overworld (Damcyan)                                                           Seed: 183   Index: 135
+Damcyan                                                                       Seed: 183   Index: 139
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 183   Index: 146
+Antlion B1F                                                                   Seed: 183   Index: 146
+  Extra Steps: 4
+  Step  26: 7 / Turtle x1, Imp x2 (7.044s)
+  Step  41: 8 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 183   Index: 188
+  Antlion B2F                                                                 Seed: 183   Index: 188
+    Step  46: 9 / Weeper x2 (7.114s)
+    Step  64: 10 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 200   Index:  12
+  Step   7: 11 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed: 200   Index:  26
+Antlion's Nest                                                                Seed: 200   Index:  26
+Antlion B2F Outward Charm Room Steps                                          Seed: 200   Index:  41
+  Antlion B2F                                                                 Seed: 200   Index:  41
+  Antlion B2F Treasure Room                                                   Seed: 200   Index:  92
+    Extra Steps: 64
+  Antlion B2F                                                                 Seed: 200   Index: 156
+Antlion B1F                                                                   Seed: 200   Index: 190
+  Step   9: 12 / Cream x4 (7.523s)
+  Step  31: 13 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed: 200   Index: 228
+Overworld (Kaipo)                                                             Seed: 200   Index: 228
+Kaipo Revisited                                                               Seed: 200   Index: 228
+Overworld (Kaipo)                                                             Seed: 200   Index: 228
+Overworld (Damcyan)                                                           Seed: 200   Index: 228
+Mt.Hobs-West                                                                  Seed: 200   Index: 228
+Mt.Hobs Summit                                                                Seed: 217   Index:  11
+  Step  11: 14 / Gargoyle x1, Cocktric x2 (9.399s)
+Battle: MomBomb                                                               Seed: 217   Index:  26
+Mt.Hobs Summit                                                                Seed: 217   Index:  26
+Mt.Hobs-East                                                                  Seed: 217   Index:  32
+  Extra Steps: 6
+  Step  42: 15 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 217   Index:  84
+  Step  17: 16 / SwordRat x3, Needler x3 (7.663s)
+  Step  49: 17 / Cocktric x3 (8.241s)
+  Step  55: 18 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 217   Index: 168
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 217   Index: 228
+Fabul Boat and Leviatan                                                       Seed: 217   Index: 235
+Overworld (Mysidia)                                                           Seed: 217   Index: 235
+Mysidia                                                                       Seed: 217   Index: 244
+Overworld (Mysidia)                                                           Seed: 217   Index: 244
+Overworld (Mt.Ordeals)                                                        Seed: 217   Index: 254
+  Step   5: 19 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  36: 20 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed: 234   Index:  92
+  Step  39: 21 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 234   Index: 135
+  Step   2: 22 / Zombie x2, Ghoul x2 (7.661s)
+  Step  15: 23 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed: 234   Index: 158
+Mt.Ordeals-3rd station                                                        Seed: 234   Index: 158
+  Step   5: 24 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals-7th station                                                        Seed: 234   Index: 163
+  Step  27: 25 / Soul x3, Ghoul x1, Revenant x1 (9.933s)
+Mt.Ordeals Summit                                                             Seed: 234   Index: 205
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 234   Index: 223
+Mt.Ordeals Summit                                                             Seed: 234   Index: 223
+  Step   4: 26 / Soul x2, Ghoul x2, Revenant x2 (10.046s)
+Paladin                                                                       Seed: 234   Index: 227
+Mt.Ordeals Summit                                                             Seed: 234   Index: 227
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 234   Index: 250
+  Step   4: 27 / Ghoul x2, Soul x2 (8.971s)
+  Step   6: 28 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-3rd station                                                        Seed: 251   Index:  36
+Mt.Ordeals                                                                    Seed: 251   Index:  66
+  Step  31: 29 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 251   Index: 110
+Take Chocobo to Mysidia                                                       Seed: 251   Index: 123
+Overworld (Mysidia)                                                           Seed: 251   Index: 123
+Town of Baron Serpent Road                                                    Seed: 251   Index: 123
+Credit Warp Fight Search                                                      Seed: 251   Index: 127
+  Overworld (Baron)                                                           Seed: 251   Index: 127
+    Extra Steps: 34
+    Step   2: 30 / Imp x3 (7.174s)
+    Step  34: 31 / Imp x4 (7.223s)
+   (Step  53: 32 / Imp x3)
+   (Step  66: 33 / Imp x4)
+   (Step  98: 34 / Eagle x3)
+   (Step 142: 35 / FloatEye x2)
+   (Step 164: 36 / Imp x3)
+   (Step 193: 37 / FloatEye x2)
+
+Encounter Time:      243.375s
+Other Time:          569.629s
+Total Time:          813.003s
+
+Base Total Time:     839.929s
+Time Saved:          26.926s
+
+Optional Steps:      2
+Extra Steps:         282
+Encounters:          31
+
+Base Encounters:     44
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/150.txt
+++ b/data/routes/cw/150.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	150
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49472842
+VARS	FFFFFFFF:14 E302600:6 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 150   Index:   0
+Overworld (Kaipo)                                                             Seed: 150   Index:   1
+Kaipo                                                                         Seed: 150   Index:  37
+Overworld (Kaipo)                                                             Seed: 150   Index:  37
+  Step   7: 1 / Sand Man x4 (7.242s)
+  Step   8: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 150   Index:  69
+  Step  14: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 150   Index: 101
+Watery Pass-South B1F                                                         Seed: 150   Index: 101
+Watery Pass-South B2F                                                         Seed: 150   Index: 121
+  Step  28: 4 / Pike x3 (7.152s)
+  Step  52: 5 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 150   Index: 211
+Watery Pass-South B2F                                                         Seed: 150   Index: 215
+  Step   1: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  28: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 150   Index: 254
+  Step   7: 8 / Pike x3 (7.152s)
+  Step  13: 9 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed: 167   Index:  32
+Watery Pass-North B1F                                                         Seed: 167   Index:  53
+  Step  42: 10 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 167   Index: 113
+Waterfalls B1F                                                                Seed: 167   Index: 122
+Waterfalls B2F                                                                Seed: 167   Index: 123
+Waterfalls Lake                                                               Seed: 167   Index: 168
+  Step   3: 11 / Aligator x1, WaterBug x2 (7.292s)
+  Step  21: 12 / Zombie x6 (7.489s)
+  Step  28: 13 / Aligator x2 (7.544s)
+  Step  36: 14 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 167   Index: 205
+Waterfalls Lake                                                               Seed: 167   Index: 205
+Overworld (Kaipo)                                                             Seed: 167   Index: 206
+Overworld (Damcyan)                                                           Seed: 167   Index: 217
+Damcyan                                                                       Seed: 167   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 167   Index: 228
+Antlion B1F                                                                   Seed: 167   Index: 228
+  Step  37: 15 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed: 184   Index:  10
+  Antlion B2F                                                                 Seed: 184   Index:  10
+    Step  11: 16 / SandWorm x2 (6.841s)
+    Step  31: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 184   Index:  90
+Battle: Antlion                                                               Seed: 184   Index: 104
+Antlion's Nest                                                                Seed: 184   Index: 104
+Antlion B2F Outward Direct                                                    Seed: 184   Index: 119
+  Antlion B2F                                                                 Seed: 184   Index: 119
+    Step  26: 18 / Basilisk x1, Turtle x1 (7.124s)
+    Step  53: 19 / Turtle x2 (7.464s)
+    Step  68: 20 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 184   Index: 199
+  Step  34: 21 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 184   Index: 237
+Overworld (Kaipo)                                                             Seed: 184   Index: 237
+Kaipo Revisited                                                               Seed: 184   Index: 237
+Overworld (Kaipo)                                                             Seed: 184   Index: 237
+Overworld (Damcyan)                                                           Seed: 184   Index: 237
+Mt.Hobs-West                                                                  Seed: 184   Index: 237
+  Step  15: 22 / Gargoyle x1, Cocktric x2 (9.399s)
+  Step  25: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+  Step  38: 24 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 201   Index:  20
+Battle: MomBomb                                                               Seed: 201   Index:  35
+Mt.Hobs Summit                                                                Seed: 201   Index:  35
+Mt.Hobs-East                                                                  Seed: 201   Index:  41
+Overworld (Fabul)                                                             Seed: 201   Index:  87
+  Step  16: 25 / SwordRat x3, Needler x3 (7.663s)
+  Step  19: 26 / Cocktric x3 (8.241s)
+  Step  22: 27 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  48: 28 / SwordRat x3, Needler x3 (7.663s)
+  Step  64: 29 / SwordRat x3, Needler x3 (7.663s)
+  Step  69: 30 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 201   Index: 171
+  Optional Steps: 6
+Overworld (Fabul)                                                             Seed: 201   Index: 237
+Fabul Boat and Leviatan                                                       Seed: 201   Index: 244
+Overworld (Mysidia)                                                           Seed: 201   Index: 244
+Mysidia                                                                       Seed: 201   Index: 253
+Overworld (Mysidia)                                                           Seed: 201   Index: 253
+Overworld (Mt.Ordeals)                                                        Seed: 218   Index:   7
+  Step  15: 31 / Raven x1, Cocktric x3 (9.100s)
+  Step  29: 32 / Raven x1 (8.356s)
+  Step  67: 33 / Needler x2, SwordRat x2 (8.097s)
+  Step  94: 34 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 218   Index: 101
+  Step  32: 35 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 218   Index: 144
+Recruit Tellah                                                                Seed: 218   Index: 167
+Mt.Ordeals-3rd station                                                        Seed: 218   Index: 167
+Mt.Ordeals-7th station                                                        Seed: 218   Index: 172
+  Step   3: 36 / Ghoul x2, Soul x2 (9.197s)
+  Step  25: 37 / Revenant x1, Ghoul x3 (8.914s)
+  Step  29: 38 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 218   Index: 214
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 218   Index: 232
+Mt.Ordeals Summit                                                             Seed: 218   Index: 232
+Paladin                                                                       Seed: 218   Index: 236
+Mt.Ordeals Summit                                                             Seed: 218   Index: 236
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 235   Index:   3
+  Step  31: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 235   Index:  45
+  Step  21: 40 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed: 235   Index:  75
+Overworld (Mt.Ordeals)                                                        Seed: 235   Index: 119
+  Step  12: 41 / Imp Cap. x3, Needler x1 (7.897s)
+Take Chocobo to Mysidia                                                       Seed: 235   Index: 132
+Overworld (Mysidia)                                                           Seed: 235   Index: 132
+Town of Baron Serpent Road                                                    Seed: 235   Index: 132
+Credit Warp Fight Search                                                      Seed: 235   Index: 136
+  Overworld (Baron)                                                           Seed: 235   Index: 136
+    Extra Steps: 14
+    Step   1: 42 / FloatEye x1, Eagle x2 (7.365s)
+    Step  14: 43 / Imp x3, SwordRat x1 (7.227s)
+   (Step  27: 44 / Imp x4)
+   (Step  91: 45 / Imp x3, SwordRat x1)
+   (Step 118: 46 / Imp x3, SwordRat x1)
+   (Step 120: 47 / Eagle x3)
+   (Step 157: 48 / Imp x3)
+   (Step 217: 49 / Imp x4)
+
+Encounter Time:      334.829s
+Other Time:          488.362s
+Total Time:          823.192s
+
+Base Total Time:     835.600s
+Time Saved:          12.408s
+
+Optional Steps:      8
+Extra Steps:         14
+Encounters:          43
+
+Base Encounters:     43
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/151.txt
+++ b/data/routes/cw/151.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	151
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49653334
+VARS	FFFFFFFF:4 E302600:30 E305400:46 E307400:8 E307701:4 E308000:12 E308700:1 E308702:1 E309700:22
+
+Overworld (Kaipo)                                                             Seed: 151   Index:   0
+Overworld (Kaipo)                                                             Seed: 151   Index:   1
+Kaipo                                                                         Seed: 151   Index:  37
+Overworld (Kaipo)                                                             Seed: 151   Index:  37
+  Step   7: 1 / Sand Man x4 (7.242s)
+  Step   8: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 151   Index:  69
+  Step  14: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 151   Index: 101
+Watery Pass-South B1F                                                         Seed: 151   Index: 101
+  Step   4: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 151   Index: 121
+  Step  28: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  52: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 151   Index: 211
+  Extra Steps: 46
+Watery Pass-South B2F                                                         Seed: 168   Index:   5
+  Step   6: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 168   Index:  44
+Watery Pass-North B2F                                                         Seed: 168   Index:  78
+  Step  17: 8 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed: 168   Index:  99
+Overworld (Kaipo)                                                             Seed: 168   Index: 159
+Waterfalls B1F                                                                Seed: 168   Index: 168
+  Extra Steps: 8
+Waterfalls B2F                                                                Seed: 168   Index: 177
+  Step  12: 9 / Aligator x1, WaterBug x2 (7.292s)
+  Step  19: 10 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  27: 11 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed: 168   Index: 222
+Battle: Octomamm                                                              Seed: 185   Index:   3
+Waterfalls Lake                                                               Seed: 185   Index:   3
+Overworld (Kaipo)                                                             Seed: 185   Index:   4
+Overworld (Damcyan)                                                           Seed: 185   Index:  15
+Damcyan                                                                       Seed: 185   Index:  19
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 185   Index:  26
+Antlion B1F                                                                   Seed: 185   Index:  26
+  Step  15: 12 / Cream x4 (7.552s)
+  Step  37: 13 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed: 185   Index:  64
+  Antlion B2F                                                                 Seed: 185   Index:  64
+Antlion's Nest                                                                Seed: 185   Index: 144
+  Step   1: 14 / Cream x4 (7.552s)
+Battle: Antlion                                                               Seed: 185   Index: 158
+Antlion's Nest                                                                Seed: 185   Index: 158
+  Step  14: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed: 185   Index: 173
+  Antlion B2F                                                                 Seed: 185   Index: 173
+    Step  14: 16 / SandWorm x2 (6.858s)
+    Step  60: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  79: 18 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed: 185   Index: 253
+  Extra Steps: 4
+  Step   9: 19 / Turtle x1, Imp x2 (7.009s)
+  Step  41: 20 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 202   Index:  39
+Overworld (Kaipo)                                                             Seed: 202   Index:  39
+Kaipo Revisited                                                               Seed: 202   Index:  39
+Overworld (Kaipo)                                                             Seed: 202   Index:  39
+Overworld (Damcyan)                                                           Seed: 202   Index:  39
+Mt.Hobs-West                                                                  Seed: 202   Index:  39
+Mt.Hobs Summit                                                                Seed: 202   Index:  78
+Battle: MomBomb                                                               Seed: 202   Index:  93
+Mt.Hobs Summit                                                                Seed: 202   Index:  93
+Mt.Hobs-East                                                                  Seed: 202   Index:  99
+  Extra Steps: 12
+  Step   4: 21 / Turtle x2 (7.432s)
+  Step  10: 22 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  36: 23 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  52: 24 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 202   Index: 157
+  Step  42: 25 / SwordRat x3, Needler x3 (7.663s)
+  Step  64: 26 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 202   Index: 241
+  Optional Steps: 10
+  Extra Steps: 20
+Overworld (Fabul)                                                             Seed: 219   Index:  75
+Fabul Boat and Leviatan                                                       Seed: 219   Index:  82
+Overworld (Mysidia)                                                           Seed: 219   Index:  82
+Mysidia                                                                       Seed: 219   Index:  91
+Overworld (Mysidia)                                                           Seed: 219   Index:  91
+  Step  10: 27 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 219   Index: 101
+  Step  27: 28 / Raven x1, Cocktric x3 (9.100s)
+  Step  32: 29 / Raven x1, Cocktric x3 (9.100s)
+  Step  74: 30 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 219   Index: 195
+  Step   2: 31 / Lilith x1, Red Bone x2 (9.259s)
+  Step   6: 32 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 219   Index: 238
+Recruit Tellah                                                                Seed: 236   Index:   5
+Mt.Ordeals-3rd station                                                        Seed: 236   Index:   5
+Mt.Ordeals-7th station                                                        Seed: 236   Index:  10
+  Step  24: 33 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 236   Index:  52
+  Optional Steps: 1
+  Step  14: 34 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed: 236   Index:  70
+Mt.Ordeals Summit                                                             Seed: 236   Index:  70
+Paladin                                                                       Seed: 236   Index:  74
+Mt.Ordeals Summit                                                             Seed: 236   Index:  74
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 236   Index:  97
+  Step   1: 35 / Revenant x1, Ghoul x3 (8.489s)
+  Step  40: 36 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed: 236   Index: 139
+  Step  11: 37 / Spirit x2, Soul x2, Red Bone x2 (9.471s)
+  Step  24: 38 / Spirit x2, Soul x2, Red Bone x2 (9.471s)
+Mt.Ordeals                                                                    Seed: 236   Index: 169
+Overworld (Mt.Ordeals)                                                        Seed: 236   Index: 213
+Take Chocobo to Mysidia                                                       Seed: 236   Index: 226
+Overworld (Mysidia)                                                           Seed: 236   Index: 226
+Town of Baron Serpent Road                                                    Seed: 236   Index: 226
+  Extra Steps: 22
+Credit Warp Fight Search                                                      Seed: 236   Index: 252
+  Overworld (Baron)                                                           Seed: 236   Index: 252
+    Extra Steps: 4
+    Step   2: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step   4: 40 / Imp x4 (7.223s)
+   (Step  41: 41 / FloatEye x1, Eagle x2)
+   (Step 101: 42 / FloatEye x1, Eagle x2)
+   (Step 124: 43 / Imp x3, SwordRat x1)
+   (Step 184: 44 / Imp x3, SwordRat x1)
+   (Step 197: 45 / Imp x3, SwordRat x1)
+   (Step 229: 46 / Imp x3, SwordRat x1)
+
+Encounter Time:      313.340s
+Other Time:          512.855s
+Total Time:          826.195s
+
+Base Total Time:     841.246s
+Time Saved:          15.051s
+
+Optional Steps:      12
+Extra Steps:         116
+Encounters:          40
+
+Base Encounters:     44
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/152.txt
+++ b/data/routes/cw/152.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	152
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49583851
+VARS	FFFFFFFF:4 E000500:10 E302500:25 E302600:9 E305400:46 E307400:20 E308700:1 E308702:1 E309700:12
+
+Overworld (Kaipo)                                                             Seed: 152   Index:   0
+Overworld (Kaipo)                                                             Seed: 152   Index:   1
+  Step  24: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 152   Index:  37
+Overworld (Kaipo)                                                             Seed: 152   Index:  37
+  Step   7: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step   8: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 152   Index:  69
+  Step  14: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 152   Index: 101
+Watery Pass-South B1F                                                         Seed: 152   Index: 101
+  Step   4: 5 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F                                                         Seed: 152   Index: 121
+  Step  28: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  52: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 152   Index: 211
+  Extra Steps: 46
+Watery Pass-South B2F                                                         Seed: 169   Index:   5
+Watery Pass-South B3F                                                         Seed: 169   Index:  44
+Watery Pass-North B2F                                                         Seed: 169   Index:  78
+  Step  17: 8 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed: 169   Index:  99
+Overworld (Kaipo)                                                             Seed: 169   Index: 159
+Waterfalls B1F                                                                Seed: 169   Index: 168
+  Extra Steps: 20
+Waterfalls B2F                                                                Seed: 169   Index: 189
+  Step  15: 9 / Aligator x1, WaterBug x2 (7.292s)
+  Step  30: 10 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 169   Index: 234
+Battle: Octomamm                                                              Seed: 186   Index:  15
+Waterfalls Lake                                                               Seed: 186   Index:  15
+Overworld (Kaipo)                                                             Seed: 186   Index:  16
+  Step   5: 11 / SandMoth x2, Larva x2 (7.188s)
+Overworld (Damcyan)                                                           Seed: 186   Index:  27
+Damcyan                                                                       Seed: 186   Index:  31
+  Optional Steps: 1
+  Extra Steps: 24
+Overworld (Damcyan)                                                           Seed: 186   Index:  63
+Antlion B1F                                                                   Seed: 186   Index:  63
+Antlion B2F Inward Direct                                                     Seed: 186   Index: 101
+  Antlion B2F                                                                 Seed: 186   Index: 101
+    Step  44: 12 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  71: 13 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed: 186   Index: 181
+  Step   6: 14 / Cream x4 (7.552s)
+Battle: Antlion                                                               Seed: 186   Index: 195
+Antlion's Nest                                                                Seed: 186   Index: 195
+Antlion B2F Outward Direct                                                    Seed: 186   Index: 210
+  Antlion B2F                                                                 Seed: 186   Index: 210
+    Step  23: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  42: 16 / SandWorm x2 (6.858s)
+    Step  52: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 203   Index:  34
+  Step   4: 18 / Basilisk x1, Imp x3 (6.783s)
+  Step  36: 19 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 203   Index:  72
+Overworld (Kaipo)                                                             Seed: 203   Index:  72
+Kaipo Revisited                                                               Seed: 203   Index:  72
+Overworld (Kaipo)                                                             Seed: 203   Index:  72
+Overworld (Damcyan)                                                           Seed: 203   Index:  72
+Mt.Hobs-West                                                                  Seed: 203   Index:  72
+  Step  31: 20 / Gargoyle x1, Cocktric x2 (9.399s)
+  Step  37: 21 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 203   Index: 111
+Battle: MomBomb                                                               Seed: 203   Index: 126
+Mt.Hobs Summit                                                                Seed: 203   Index: 126
+Mt.Hobs-East                                                                  Seed: 203   Index: 132
+  Step   3: 22 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  19: 23 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 203   Index: 178
+  Step  21: 24 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  43: 25 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed: 220   Index:   6
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed: 220   Index:  75
+Fabul Boat and Leviatan                                                       Seed: 220   Index:  82
+Overworld (Mysidia)                                                           Seed: 220   Index:  82
+  Extra Steps: 10
+  Step  18: 26 / Imp Cap. x4, Imp x2 (8.293s)
+Mysidia                                                                       Seed: 220   Index: 101
+Overworld (Mysidia)                                                           Seed: 220   Index: 101
+Overworld (Mt.Ordeals)                                                        Seed: 220   Index: 111
+  Step  17: 27 / Raven x1 (8.356s)
+  Step  22: 28 / Raven x1 (8.356s)
+  Step  64: 29 / Raven x1, Cocktric x3 (9.100s)
+  Step  86: 30 / Raven x1 (8.356s)
+  Step  90: 31 / Raven x1, Cocktric x3 (9.100s)
+Mt.Ordeals                                                                    Seed: 220   Index: 205
+Mt.Ordeals-3rd station                                                        Seed: 220   Index: 248
+Recruit Tellah                                                                Seed: 237   Index:  15
+Mt.Ordeals-3rd station                                                        Seed: 237   Index:  15
+Mt.Ordeals-7th station                                                        Seed: 237   Index:  20
+  Step  14: 32 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 237   Index:  62
+  Optional Steps: 1
+  Step   4: 33 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed: 237   Index:  80
+Mt.Ordeals Summit                                                             Seed: 237   Index:  80
+Paladin                                                                       Seed: 237   Index:  84
+Mt.Ordeals Summit                                                             Seed: 237   Index:  84
+  Optional Steps: 1
+  Step  14: 34 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed: 237   Index: 107
+  Step   6: 35 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 237   Index: 149
+  Step   1: 36 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+  Step  14: 37 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 237   Index: 179
+Overworld (Mt.Ordeals)                                                        Seed: 237   Index: 223
+  Step   4: 38 / SwordRat x2, Imp x2, TinyMage x2 (7.453s)
+Take Chocobo to Mysidia                                                       Seed: 237   Index: 236
+Overworld (Mysidia)                                                           Seed: 237   Index: 236
+Town of Baron Serpent Road                                                    Seed: 237   Index: 236
+  Extra Steps: 12
+Credit Warp Fight Search                                                      Seed: 237   Index: 252
+  Overworld (Baron)                                                           Seed: 237   Index: 252
+    Extra Steps: 4
+    Step   2: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step   4: 40 / Imp x4 (7.223s)
+   (Step  41: 41 / FloatEye x1, Eagle x2)
+   (Step 101: 42 / FloatEye x1, Eagle x2)
+   (Step 124: 43 / Imp x3, SwordRat x1)
+   (Step 148: 44 / Imp x3, SwordRat x1)
+   (Step 184: 45 / Imp x3, SwordRat x1)
+   (Step 229: 46 / Imp x3, SwordRat x1)
+
+Encounter Time:      312.183s
+Other Time:          512.855s
+Total Time:          825.039s
+
+Base Total Time:     877.899s
+Time Saved:          52.860s
+
+Optional Steps:      12
+Extra Steps:         116
+Encounters:          40
+
+Base Encounters:     44
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/153.txt
+++ b/data/routes/cw/153.txt
@@ -1,0 +1,156 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	153
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50648220
+VARS	FFFFFFFF:4 E000600:2 E302600:32 E305400:46 E307400:20 E307F01:2 E309700:22
+
+Overworld (Kaipo)                                                             Seed: 153   Index:   0
+Overworld (Kaipo)                                                             Seed: 153   Index:   1
+  Step  24: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 153   Index:  37
+Overworld (Kaipo)                                                             Seed: 153   Index:  37
+  Step   7: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step   8: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 153   Index:  69
+  Step  14: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 153   Index: 101
+Watery Pass-South B1F                                                         Seed: 153   Index: 101
+  Step   4: 5 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F                                                         Seed: 153   Index: 121
+  Step  28: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  52: 7 / CaveToad x3 (7.014s)
+  Step  90: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 153   Index: 211
+  Extra Steps: 46
+Watery Pass-South B2F                                                         Seed: 170   Index:   5
+  Step  37: 9 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 170   Index:  44
+Watery Pass-North B2F                                                         Seed: 170   Index:  78
+  Step  17: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 170   Index:  99
+Overworld (Kaipo)                                                             Seed: 170   Index: 159
+Waterfalls B1F                                                                Seed: 170   Index: 168
+  Extra Steps: 20
+Waterfalls B2F                                                                Seed: 170   Index: 189
+  Step  15: 11 / Aligator x1, WaterBug x2 (7.292s)
+  Step  30: 12 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 170   Index: 234
+Battle: Octomamm                                                              Seed: 187   Index:  15
+Waterfalls Lake                                                               Seed: 187   Index:  15
+Overworld (Kaipo)                                                             Seed: 187   Index:  16
+  Step   5: 13 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 187   Index:  27
+Damcyan                                                                       Seed: 187   Index:  31
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 187   Index:  38
+Antlion B1F                                                                   Seed: 187   Index:  38
+  Step   2: 14 / Imp x3 (6.649s)
+  Step  25: 15 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed: 187   Index:  76
+  Antlion B2F                                                                 Seed: 187   Index:  76
+    Step  69: 16 / SandWorm x1, Sandpede x1 (6.829s)
+Antlion's Nest                                                                Seed: 187   Index: 156
+Battle: Antlion                                                               Seed: 187   Index: 170
+Antlion's Nest                                                                Seed: 187   Index: 170
+  Step   2: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed: 187   Index: 185
+  Antlion B2F                                                                 Seed: 187   Index: 185
+    Step   6: 18 / Basilisk x1, Turtle x1 (7.124s)
+    Step  48: 19 / Turtle x2 (7.464s)
+    Step  67: 20 / Turtle x2 (7.464s)
+    Step  77: 21 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 204   Index:   9
+  Step  29: 22 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 204   Index:  47
+Overworld (Kaipo)                                                             Seed: 204   Index:  47
+Kaipo Revisited                                                               Seed: 204   Index:  47
+Overworld (Kaipo)                                                             Seed: 204   Index:  47
+Overworld (Damcyan)                                                           Seed: 204   Index:  47
+Mt.Hobs-West                                                                  Seed: 204   Index:  47
+  Step  23: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed: 204   Index:  86
+Battle: MomBomb                                                               Seed: 204   Index: 101
+Mt.Hobs Summit                                                                Seed: 204   Index: 101
+  Extra Steps: 2
+  Step   8: 24 / Cocktric x3 (7.853s)
+Mt.Hobs-East                                                                  Seed: 204   Index: 109
+  Step  26: 25 / Gargoyle x2 (7.630s)
+  Step  42: 26 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 204   Index: 155
+  Step  44: 27 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  66: 28 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 204   Index: 239
+  Optional Steps: 10
+  Extra Steps: 22
+Overworld (Fabul)                                                             Seed: 221   Index:  75
+Fabul Boat and Leviatan                                                       Seed: 221   Index:  82
+Overworld (Mysidia)                                                           Seed: 221   Index:  82
+Mysidia                                                                       Seed: 221   Index:  91
+Overworld (Mysidia)                                                           Seed: 221   Index:  91
+  Step   9: 29 / Raven x1, Cocktric x3 (9.100s)
+Overworld (Mt.Ordeals)                                                        Seed: 221   Index: 101
+  Extra Steps: 2
+  Step  27: 30 / Raven x1 (8.356s)
+  Step  31: 31 / Raven x1, Cocktric x3 (9.100s)
+  Step  32: 32 / Raven x1 (8.356s)
+  Step  74: 33 / Needler x2, SwordRat x2 (8.097s)
+  Step  96: 34 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 221   Index: 197
+  Step   4: 35 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 221   Index: 240
+Recruit Tellah                                                                Seed: 238   Index:   7
+Mt.Ordeals-3rd station                                                        Seed: 238   Index:   7
+Mt.Ordeals-7th station                                                        Seed: 238   Index:  12
+  Step  22: 36 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed: 238   Index:  54
+  Optional Steps: 0
+  Step  12: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed: 238   Index:  71
+Mt.Ordeals Summit                                                             Seed: 238   Index:  71
+Paladin                                                                       Seed: 238   Index:  75
+Mt.Ordeals Summit                                                             Seed: 238   Index:  75
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 238   Index:  97
+  Step   1: 38 / Revenant x1, Ghoul x3 (8.489s)
+  Step  16: 39 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 238   Index: 139
+  Step  11: 40 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  23: 41 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 238   Index: 169
+Overworld (Mt.Ordeals)                                                        Seed: 238   Index: 213
+Take Chocobo to Mysidia                                                       Seed: 238   Index: 226
+Overworld (Mysidia)                                                           Seed: 238   Index: 226
+Town of Baron Serpent Road                                                    Seed: 238   Index: 226
+  Extra Steps: 22
+Credit Warp Fight Search                                                      Seed: 238   Index: 252
+  Overworld (Baron)                                                           Seed: 238   Index: 252
+    Extra Steps: 4
+    Step   2: 42 / FloatEye x1, Eagle x2 (7.365s)
+    Step   4: 43 / Imp x3, SwordRat x1 (7.227s)
+   (Step  41: 44 / Imp x3, SwordRat x1)
+   (Step 101: 45 / Imp x3, SwordRat x1)
+   (Step 124: 46 / Imp x3, SwordRat x1)
+   (Step 134: 47 / Eagle x3)
+   (Step 148: 48 / Imp x3)
+   (Step 184: 49 / Imp x4)
+
+Encounter Time:      329.361s
+Other Time:          513.388s
+Total Time:          842.749s
+
+Base Total Time:     890.981s
+Time Saved:          48.232s
+
+Optional Steps:      10
+Extra Steps:         118
+Encounters:          43
+
+Base Encounters:     46
+Encounters Saved:    3
+
+Number of Variables: 54

--- a/data/routes/cw/154.txt
+++ b/data/routes/cw/154.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	154
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50575816
+VARS	FFFFFFFF:40 E000200:4 E302500:3 E302600:30 E305400:46 E307400:16 E308700:1 E308702:1 E309700:24
+
+Overworld (Kaipo)                                                             Seed: 154   Index:   0
+Overworld (Kaipo)                                                             Seed: 154   Index:   1
+  Step  24: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 154   Index:  37
+Overworld (Kaipo)                                                             Seed: 154   Index:  37
+  Step   7: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 154   Index:  69
+  Step  14: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 154   Index: 101
+Watery Pass-South B1F                                                         Seed: 154   Index: 101
+  Step   4: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 154   Index: 121
+  Step  33: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  52: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  90: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 154   Index: 211
+  Extra Steps: 46
+Watery Pass-South B2F                                                         Seed: 171   Index:   5
+  Step  37: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 171   Index:  44
+Watery Pass-North B2F                                                         Seed: 171   Index:  78
+  Step  17: 9 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed: 171   Index:  99
+Overworld (Kaipo)                                                             Seed: 171   Index: 159
+  Extra Steps: 4
+  Step  12: 10 / Imp x4 (7.049s)
+Waterfalls B1F                                                                Seed: 171   Index: 172
+  Extra Steps: 16
+Waterfalls B2F                                                                Seed: 171   Index: 189
+  Step  30: 11 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed: 171   Index: 234
+Battle: Octomamm                                                              Seed: 188   Index:  15
+Waterfalls Lake                                                               Seed: 188   Index:  15
+Overworld (Kaipo)                                                             Seed: 188   Index:  16
+Overworld (Damcyan)                                                           Seed: 188   Index:  27
+Damcyan                                                                       Seed: 188   Index:  31
+  Optional Steps: 1
+  Extra Steps: 2
+Overworld (Damcyan)                                                           Seed: 188   Index:  41
+Antlion B1F                                                                   Seed: 188   Index:  41
+  Step  22: 12 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed: 188   Index:  79
+  Antlion B2F                                                                 Seed: 188   Index:  79
+    Step  25: 13 / Weeper x2 (7.114s)
+    Step  66: 14 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 188   Index: 159
+  Step  13: 15 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 188   Index: 173
+Antlion's Nest                                                                Seed: 188   Index: 173
+Antlion B2F Outward Direct                                                    Seed: 188   Index: 188
+  Antlion B2F                                                                 Seed: 188   Index: 188
+    Step   3: 16 / SandWorm x1, Sandpede x1 (6.848s)
+    Step  45: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  64: 18 / Basilisk x1, Turtle x1 (7.124s)
+    Step  74: 19 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 205   Index:  12
+  Step  26: 20 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 205   Index:  50
+Overworld (Kaipo)                                                             Seed: 205   Index:  50
+Kaipo Revisited                                                               Seed: 205   Index:  50
+Overworld (Kaipo)                                                             Seed: 205   Index:  50
+Overworld (Damcyan)                                                           Seed: 205   Index:  50
+Mt.Hobs-West                                                                  Seed: 205   Index:  50
+  Step  20: 21 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 205   Index:  89
+Battle: MomBomb                                                               Seed: 205   Index: 104
+Mt.Hobs Summit                                                                Seed: 205   Index: 104
+  Step   5: 22 / GrayBomb x2, Bomb x2 (8.430s)
+Mt.Hobs-East                                                                  Seed: 205   Index: 110
+  Step  24: 23 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  41: 24 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 205   Index: 156
+  Step  43: 25 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed: 205   Index: 240
+  Optional Steps: 10
+  Extra Steps: 20
+Overworld (Fabul)                                                             Seed: 222   Index:  74
+Fabul Boat and Leviatan                                                       Seed: 222   Index:  81
+Overworld (Mysidia)                                                           Seed: 222   Index:  81
+Mysidia                                                                       Seed: 222   Index:  90
+Overworld (Mysidia)                                                           Seed: 222   Index:  90
+  Step  10: 26 / Imp Cap. x4, Imp x2 (8.344s)
+Overworld (Mt.Ordeals)                                                        Seed: 222   Index: 100
+  Step  28: 27 / Raven x1 (8.356s)
+  Step  32: 28 / Raven x1 (8.356s)
+  Step  33: 29 / Raven x1, Cocktric x3 (9.100s)
+  Step  64: 30 / Raven x1 (8.356s)
+  Step  75: 31 / Raven x1, Cocktric x3 (9.100s)
+Mt.Ordeals                                                                    Seed: 222   Index: 194
+  Step   3: 32 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 222   Index: 237
+Recruit Tellah                                                                Seed: 239   Index:   4
+Mt.Ordeals-3rd station                                                        Seed: 239   Index:   4
+Mt.Ordeals-7th station                                                        Seed: 239   Index:   9
+  Step  25: 33 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 239   Index:  51
+  Optional Steps: 1
+  Step  15: 34 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed: 239   Index:  69
+Mt.Ordeals Summit                                                             Seed: 239   Index:  69
+Paladin                                                                       Seed: 239   Index:  73
+Mt.Ordeals Summit                                                             Seed: 239   Index:  73
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 239   Index:  96
+  Step   2: 35 / Revenant x1, Ghoul x3 (8.489s)
+  Step  17: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 239   Index: 138
+  Step  24: 37 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 239   Index: 168
+  Step  26: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 239   Index: 212
+Take Chocobo to Mysidia                                                       Seed: 239   Index: 225
+Overworld (Mysidia)                                                           Seed: 239   Index: 225
+Town of Baron Serpent Road                                                    Seed: 239   Index: 225
+  Extra Steps: 24
+Credit Warp Fight Search                                                      Seed: 239   Index: 253
+  Overworld (Baron)                                                           Seed: 239   Index: 253
+    Extra Steps: 40
+    Step   1: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  40: 40 / Imp x4 (7.223s)
+   (Step  90: 41 / FloatEye x1, Eagle x2)
+   (Step 100: 42 / Imp x3, SwordRat x1)
+   (Step 123: 43 / Imp x3, SwordRat x1)
+   (Step 133: 44 / Imp x3, SwordRat x1)
+   (Step 147: 45 / Imp x3, SwordRat x1)
+   (Step 183: 46 / Imp x3, SwordRat x1)
+
+Encounter Time:      309.521s
+Other Time:          532.024s
+Total Time:          841.544s
+
+Base Total Time:     872.486s
+Time Saved:          30.941s
+
+Optional Steps:      13
+Extra Steps:         152
+Encounters:          40
+
+Base Encounters:     46
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/155.txt
+++ b/data/routes/cw/155.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	155
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48814816
+VARS	FFFFFFFF:18 E000202:4 E302500:1 E302600:7 E305400:46 E307400:2 E307700:4
+
+Overworld (Kaipo)                                                             Seed: 155   Index:   0
+Overworld (Kaipo)                                                             Seed: 155   Index:   1
+  Step  24: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 155   Index:  37
+Overworld (Kaipo)                                                             Seed: 155   Index:  37
+  Step   7: 2 / SandWorm x1 (7.100s)
+Watery Pass-South B1F                                                         Seed: 155   Index:  69
+  Step  14: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 155   Index: 101
+Watery Pass-South B1F                                                         Seed: 155   Index: 101
+  Step   4: 4 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 155   Index: 121
+  Step  33: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  52: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  64: 7 / CaveToad x3 (7.014s)
+  Step  90: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 155   Index: 211
+  Extra Steps: 46
+Watery Pass-South B2F                                                         Seed: 172   Index:   5
+  Step  37: 9 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 172   Index:  44
+Watery Pass-North B2F                                                         Seed: 172   Index:  78
+  Step  17: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 172   Index:  99
+  Step  23: 11 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed: 172   Index: 159
+Waterfalls B1F                                                                Seed: 172   Index: 168
+  Extra Steps: 2
+Waterfalls B2F                                                                Seed: 172   Index: 171
+  Step   5: 12 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 172   Index: 216
+  Step   3: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 172   Index: 253
+Waterfalls Lake                                                               Seed: 172   Index: 253
+Overworld (Kaipo)                                                             Seed: 172   Index: 254
+Overworld (Damcyan)                                                           Seed: 189   Index:   9
+Damcyan                                                                       Seed: 189   Index:  13
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 189   Index:  21
+Antlion B1F                                                                   Seed: 189   Index:  21
+  Extra Steps: 4
+  Step  19: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  42: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed: 189   Index:  63
+  Antlion B2F                                                                 Seed: 189   Index:  63
+    Step  41: 16 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 189   Index: 143
+  Step   2: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 189   Index: 157
+Antlion's Nest                                                                Seed: 189   Index: 157
+  Step  15: 18 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B2F Outward Direct                                                    Seed: 189   Index: 172
+  Antlion B2F                                                                 Seed: 189   Index: 172
+    Step  19: 19 / Turtle x2 (7.464s)
+    Step  61: 20 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 189   Index: 252
+  Step  10: 21 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 206   Index:  34
+Overworld (Kaipo)                                                             Seed: 206   Index:  34
+  Extra Steps: 4
+  Step   4: 22 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed: 206   Index:  38
+Overworld (Kaipo)                                                             Seed: 206   Index:  38
+Overworld (Damcyan)                                                           Seed: 206   Index:  38
+Mt.Hobs-West                                                                  Seed: 206   Index:  38
+  Step  32: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed: 206   Index:  77
+Battle: MomBomb                                                               Seed: 206   Index:  92
+Mt.Hobs Summit                                                                Seed: 206   Index:  92
+Mt.Hobs-East                                                                  Seed: 206   Index:  98
+  Step  36: 24 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 206   Index: 144
+  Step   7: 25 / SwordRat x3, Needler x3 (7.663s)
+  Step  55: 26 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 206   Index: 228
+  Optional Steps: 7
+Overworld (Fabul)                                                             Seed: 223   Index:  39
+Fabul Boat and Leviatan                                                       Seed: 223   Index:  46
+Overworld (Mysidia)                                                           Seed: 223   Index:  46
+  Step   9: 27 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 223   Index:  55
+Overworld (Mysidia)                                                           Seed: 223   Index:  55
+Overworld (Mt.Ordeals)                                                        Seed: 223   Index:  65
+  Step   9: 28 / Raven x1 (8.356s)
+  Step  35: 29 / Raven x1, Cocktric x3 (9.100s)
+  Step  63: 30 / Raven x1 (8.356s)
+  Step  67: 31 / Raven x1, Cocktric x3 (9.100s)
+Mt.Ordeals                                                                    Seed: 223   Index: 159
+  Step   5: 32 / Spirit x2, Skelton x2 (8.285s)
+  Step  16: 33 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 223   Index: 202
+Recruit Tellah                                                                Seed: 223   Index: 225
+Mt.Ordeals-3rd station                                                        Seed: 223   Index: 225
+Mt.Ordeals-7th station                                                        Seed: 223   Index: 230
+Mt.Ordeals Summit                                                             Seed: 240   Index:  16
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 240   Index:  33
+Mt.Ordeals Summit                                                             Seed: 240   Index:  33
+  Step   1: 34 / Lilith x1, Red Bone x2 (8.744s)
+Paladin                                                                       Seed: 240   Index:  37
+Mt.Ordeals Summit                                                             Seed: 240   Index:  37
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 240   Index:  59
+  Step   7: 35 / Revenant x1, Ghoul x3 (8.489s)
+  Step  39: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 240   Index: 101
+  Step  12: 37 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 240   Index: 131
+  Step  31: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 240   Index: 175
+Take Chocobo to Mysidia                                                       Seed: 240   Index: 188
+Overworld (Mysidia)                                                           Seed: 240   Index: 188
+Town of Baron Serpent Road                                                    Seed: 240   Index: 188
+Credit Warp Fight Search                                                      Seed: 240   Index: 192
+  Overworld (Baron)                                                           Seed: 240   Index: 192
+    Extra Steps: 18
+    Step   2: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  18: 40 / Imp x4 (7.223s)
+   (Step 101: 41 / FloatEye x1, Eagle x2)
+   (Step 120: 42 / Imp x3, SwordRat x1)
+   (Step 151: 43 / Imp x3, SwordRat x1)
+   (Step 161: 44 / Imp x3, SwordRat x1)
+   (Step 184: 45 / Imp x3, SwordRat x1)
+   (Step 194: 46 / Imp x3, SwordRat x1)
+   (Step 208: 47 / Eagle x3)
+
+Encounter Time:      306.842s
+Other Time:          505.401s
+Total Time:          812.243s
+
+Base Total Time:     871.225s
+Time Saved:          58.983s
+
+Optional Steps:      8
+Extra Steps:         74
+Encounters:          40
+
+Base Encounters:     46
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/156.txt
+++ b/data/routes/cw/156.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	156
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49816107
+VARS	FFFFFFFF:18 E000202:4 E302500:1 E302600:7 E307000:6 E307400:42 E307700:4
+
+Overworld (Kaipo)                                                             Seed: 156   Index:   0
+Overworld (Kaipo)                                                             Seed: 156   Index:   1
+  Step  24: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 156   Index:  37
+Overworld (Kaipo)                                                             Seed: 156   Index:  37
+Watery Pass-South B1F                                                         Seed: 156   Index:  69
+Recruit Tellah                                                                Seed: 156   Index: 101
+Watery Pass-South B1F                                                         Seed: 156   Index: 101
+  Step   4: 2 / Zombie x4 (7.148s)
+  Step   7: 3 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 156   Index: 121
+  Step  33: 4 / CaveToad x3 (7.014s)
+  Step  52: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  64: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  90: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 156   Index: 211
+Watery Pass-South B2F                                                         Seed: 156   Index: 215
+  Extra Steps: 6
+  Step  45: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 173   Index:   4
+Watery Pass-North B2F                                                         Seed: 173   Index:  38
+  Step   4: 9 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed: 173   Index:  59
+  Step  36: 10 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 173   Index: 119
+  Step   3: 11 / SandMoth x2, Larva x2 (7.163s)
+Waterfalls B1F                                                                Seed: 173   Index: 128
+  Extra Steps: 42
+Waterfalls B2F                                                                Seed: 173   Index: 171
+  Step   5: 12 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 173   Index: 216
+  Step   3: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 173   Index: 253
+Waterfalls Lake                                                               Seed: 173   Index: 253
+Overworld (Kaipo)                                                             Seed: 173   Index: 254
+Overworld (Damcyan)                                                           Seed: 190   Index:   9
+Damcyan                                                                       Seed: 190   Index:  13
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 190   Index:  21
+Antlion B1F                                                                   Seed: 190   Index:  21
+  Extra Steps: 4
+  Step  19: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  42: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed: 190   Index:  63
+  Antlion B2F                                                                 Seed: 190   Index:  63
+    Step  41: 16 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 190   Index: 143
+Battle: Antlion                                                               Seed: 190   Index: 157
+Antlion's Nest                                                                Seed: 190   Index: 157
+  Step  15: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed: 190   Index: 172
+  Antlion B2F                                                                 Seed: 190   Index: 172
+    Step  19: 18 / Basilisk x1, Turtle x1 (7.124s)
+    Step  42: 19 / Turtle x2 (7.464s)
+    Step  61: 20 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 190   Index: 252
+  Step  10: 21 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 207   Index:  34
+Overworld (Kaipo)                                                             Seed: 207   Index:  34
+  Extra Steps: 4
+  Step   4: 22 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed: 207   Index:  38
+Overworld (Kaipo)                                                             Seed: 207   Index:  38
+Overworld (Damcyan)                                                           Seed: 207   Index:  38
+Mt.Hobs-West                                                                  Seed: 207   Index:  38
+  Step  32: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed: 207   Index:  77
+Battle: MomBomb                                                               Seed: 207   Index:  92
+Mt.Hobs Summit                                                                Seed: 207   Index:  92
+Mt.Hobs-East                                                                  Seed: 207   Index:  98
+  Step  36: 24 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 207   Index: 144
+  Step   7: 25 / SwordRat x3, Needler x3 (7.663s)
+  Step  55: 26 / Cocktric x3 (8.241s)
+  Step  63: 27 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 207   Index: 228
+  Optional Steps: 7
+Overworld (Fabul)                                                             Seed: 224   Index:  39
+Fabul Boat and Leviatan                                                       Seed: 224   Index:  46
+Overworld (Mysidia)                                                           Seed: 224   Index:  46
+  Step   9: 28 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 224   Index:  55
+Overworld (Mysidia)                                                           Seed: 224   Index:  55
+Overworld (Mt.Ordeals)                                                        Seed: 224   Index:  65
+  Step   9: 29 / Raven x1, Cocktric x3 (9.100s)
+  Step  35: 30 / Raven x1 (8.356s)
+  Step  63: 31 / Raven x1, Cocktric x3 (9.100s)
+  Step  67: 32 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 224   Index: 159
+  Step   5: 33 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 224   Index: 202
+Recruit Tellah                                                                Seed: 224   Index: 225
+Mt.Ordeals-3rd station                                                        Seed: 224   Index: 225
+  Step   3: 34 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals-7th station                                                        Seed: 224   Index: 230
+Mt.Ordeals Summit                                                             Seed: 241   Index:  16
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 241   Index:  33
+Mt.Ordeals Summit                                                             Seed: 241   Index:  33
+  Step   1: 35 / Revenant x1, Ghoul x3 (8.611s)
+Paladin                                                                       Seed: 241   Index:  37
+Mt.Ordeals Summit                                                             Seed: 241   Index:  37
+  Optional Steps: 0
+  Step  20: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed: 241   Index:  59
+  Step   7: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  39: 38 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 241   Index: 101
+  Step  12: 39 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 241   Index: 131
+  Step  31: 40 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 241   Index: 175
+Take Chocobo to Mysidia                                                       Seed: 241   Index: 188
+Overworld (Mysidia)                                                           Seed: 241   Index: 188
+Town of Baron Serpent Road                                                    Seed: 241   Index: 188
+Credit Warp Fight Search                                                      Seed: 241   Index: 192
+  Overworld (Baron)                                                           Seed: 241   Index: 192
+    Extra Steps: 18
+    Step   2: 41 / FloatEye x1, Eagle x2 (7.365s)
+    Step  18: 42 / Imp x3, SwordRat x1 (7.227s)
+   (Step 101: 43 / Imp x3, SwordRat x1)
+   (Step 120: 44 / Imp x3, SwordRat x1)
+   (Step 151: 45 / Imp x3, SwordRat x1)
+   (Step 184: 46 / Imp x3, SwordRat x1)
+   (Step 194: 47 / Eagle x3)
+   (Step 208: 48 / Imp x3)
+   (Step 210: 49 / Imp x3, SwordRat x1)
+
+Encounter Time:      323.502s
+Other Time:          505.401s
+Total Time:          828.903s
+
+Base Total Time:     874.121s
+Time Saved:          45.218s
+
+Optional Steps:      8
+Extra Steps:         74
+Encounters:          42
+
+Base Encounters:     46
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/157.txt
+++ b/data/routes/cw/157.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	157
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49352676
+VARS	FFFFFFFF:18 C307800:1 E302600:8 E307700:8 E307B00:12
+
+Overworld (Kaipo)                                                             Seed: 157   Index:   0
+Overworld (Kaipo)                                                             Seed: 157   Index:   1
+  Step  24: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 157   Index:  37
+Overworld (Kaipo)                                                             Seed: 157   Index:  37
+Watery Pass-South B1F                                                         Seed: 157   Index:  69
+Recruit Tellah                                                                Seed: 157   Index: 101
+Watery Pass-South B1F                                                         Seed: 157   Index: 101
+  Step   4: 2 / Zombie x4 (7.148s)
+  Step   7: 3 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 157   Index: 121
+  Step  33: 4 / CaveToad x3 (7.014s)
+  Step  64: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  90: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 157   Index: 211
+Watery Pass-South B2F                                                         Seed: 157   Index: 215
+  Step  33: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 157   Index: 254
+  Step   6: 8 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed: 174   Index:  32
+  Step  10: 9 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed: 174   Index:  53
+  Step  42: 10 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 174   Index: 113
+  Step   9: 11 / SandWorm x1 (7.231s)
+Waterfalls B1F                                                                Seed: 174   Index: 122
+Waterfalls B2F                                                                Seed: 174   Index: 123
+  Step  42: 12 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 174   Index: 168
+  Step   2: 13 / Aligator x1, WaterBug x2 (7.292s)
+  Step   8: 14 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 174   Index: 205
+Waterfalls Lake                                                               Seed: 174   Index: 205
+Overworld (Kaipo)                                                             Seed: 174   Index: 206
+Overworld (Damcyan)                                                           Seed: 174   Index: 217
+  Step   2: 15 / SandWorm x1 (7.264s)
+Damcyan                                                                       Seed: 174   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 174   Index: 228
+Antlion B1F                                                                   Seed: 174   Index: 228
+  Extra Steps: 8
+  Step  46: 16 / Imp x3 (6.649s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 191   Index:  18
+  Antlion B2F                                                                 Seed: 191   Index:  18
+    Step  22: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+  Antlion B2F Treasure Room                                                   Seed: 191   Index:  51
+    Extra Steps: 12
+  Antlion B2F                                                                 Seed: 191   Index:  63
+    Step  41: 18 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed: 191   Index: 115
+Battle: Antlion                                                               Seed: 191   Index: 129
+Antlion's Nest                                                                Seed: 191   Index: 129
+Antlion B2F Outward Direct                                                    Seed: 191   Index: 144
+  Antlion B2F                                                                 Seed: 191   Index: 144
+    Step  40: 19 / Turtle x2 (7.464s)
+    Step  47: 20 / Turtle x2 (7.464s)
+    Step  70: 21 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 191   Index: 224
+  Step   9: 22 / Cream x4 (7.523s)
+  Step  38: 23 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 208   Index:   6
+Overworld (Kaipo)                                                             Seed: 208   Index:   6
+Kaipo Revisited                                                               Seed: 208   Index:   6
+Overworld (Kaipo)                                                             Seed: 208   Index:   6
+Overworld (Damcyan)                                                           Seed: 208   Index:   6
+Mt.Hobs-West                                                                  Seed: 208   Index:   6
+  Step  32: 24 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 208   Index:  45
+Battle: MomBomb                                                               Seed: 208   Index:  60
+Mt.Hobs Summit                                                                Seed: 208   Index:  60
+Mt.Hobs-East                                                                  Seed: 208   Index:  66
+  Step   4: 25 / Spirit x2, Skelton x2 (8.237s)
+  Step  18: 26 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 208   Index: 112
+  Step  22: 27 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  39: 28 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 208   Index: 196
+  Optional Steps: 8
+Overworld (Fabul)                                                             Seed: 225   Index:   8
+Fabul Boat and Leviatan                                                       Seed: 225   Index:  15
+Overworld (Mysidia)                                                           Seed: 225   Index:  15
+Mysidia                                                                       Seed: 225   Index:  24
+Overworld (Mysidia)                                                           Seed: 225   Index:  24
+Overworld (Mt.Ordeals)                                                        Seed: 225   Index:  34
+  Step   2: 29 / Raven x1, Cocktric x3 (9.100s)
+  Step  21: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  40: 31 / Raven x1, Cocktric x3 (9.100s)
+  Step  66: 32 / Raven x1 (8.356s)
+  Step  94: 33 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed: 225   Index: 128
+  Step   4: 34 / Skelton x3, Red Bone x2 (8.244s)
+  Step  36: 35 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 225   Index: 171
+Recruit Tellah                                                                Seed: 225   Index: 194
+Mt.Ordeals-3rd station                                                        Seed: 225   Index: 194
+Mt.Ordeals-7th station                                                        Seed: 225   Index: 199
+  Step  29: 36 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 225   Index: 241
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 242   Index:   2
+Mt.Ordeals Summit                                                             Seed: 242   Index:   2
+Paladin                                                                       Seed: 242   Index:   6
+Mt.Ordeals Summit                                                             Seed: 242   Index:   6
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 242   Index:  28
+  Step  29: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  38: 38 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 242   Index:  70
+  Step  28: 39 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 242   Index: 100
+  Step  13: 40 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed: 242   Index: 144
+Take Chocobo to Mysidia                                                       Seed: 242   Index: 157
+Overworld (Mysidia)                                                           Seed: 242   Index: 157
+Town of Baron Serpent Road                                                    Seed: 242   Index: 157
+Credit Warp Fight Search                                                      Seed: 242   Index: 161
+  Overworld (Baron)                                                           Seed: 242   Index: 161
+    Extra Steps: 18
+    Step   1: 41 / FloatEye x1, Eagle x2 (7.365s)
+    Step  18: 42 / Imp x3, SwordRat x1 (7.227s)
+   (Step  33: 43 / Imp x3, SwordRat x1)
+   (Step  49: 44 / Imp x3, SwordRat x1)
+   (Step 151: 45 / Imp x3, SwordRat x1)
+   (Step 182: 46 / Imp x3, SwordRat x1)
+   (Step 215: 47 / Eagle x3)
+   (Step 225: 48 / Imp x3)
+   (Step 239: 49 / Imp x3, SwordRat x1)
+   (Step 241: 50 / Eagle x3)
+
+Encounter Time:      320.783s
+Other Time:          500.409s
+Total Time:          821.192s
+
+Base Total Time:     862.192s
+Time Saved:          41.000s
+
+Optional Steps:      8
+Extra Steps:         38
+Encounters:          42
+
+Base Encounters:     46
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/158.txt
+++ b/data/routes/cw/158.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	158
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49306522
+VARS	FFFFFFFF:16 C307801:1 E302500:1 E302600:9 E307700:8 E307B01:12 E308702:1 E309700:14
+
+Overworld (Kaipo)                                                             Seed: 158   Index:   0
+Overworld (Kaipo)                                                             Seed: 158   Index:   1
+  Step  24: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 158   Index:  37
+Overworld (Kaipo)                                                             Seed: 158   Index:  37
+Watery Pass-South B1F                                                         Seed: 158   Index:  69
+Recruit Tellah                                                                Seed: 158   Index: 101
+Watery Pass-South B1F                                                         Seed: 158   Index: 101
+  Step   7: 2 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 158   Index: 121
+  Step  17: 3 / Pike x3 (7.152s)
+  Step  33: 4 / CaveToad x3 (7.014s)
+  Step  64: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  90: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 158   Index: 211
+Watery Pass-South B2F                                                         Seed: 158   Index: 215
+  Step  33: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 158   Index: 254
+  Step   6: 8 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed: 175   Index:  32
+  Step  10: 9 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed: 175   Index:  53
+Overworld (Kaipo)                                                             Seed: 175   Index: 113
+  Step   9: 10 / Imp x4 (7.049s)
+Waterfalls B1F                                                                Seed: 175   Index: 122
+Waterfalls B2F                                                                Seed: 175   Index: 123
+  Step  42: 11 / Mad Toad x4 (7.317s)
+Waterfalls Lake                                                               Seed: 175   Index: 168
+  Step   2: 12 / Zombie x6 (7.489s)
+  Step   8: 13 / Aligator x1, WaterBug x2 (7.292s)
+  Step  34: 14 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 175   Index: 205
+Waterfalls Lake                                                               Seed: 175   Index: 205
+Overworld (Kaipo)                                                             Seed: 175   Index: 206
+Overworld (Damcyan)                                                           Seed: 175   Index: 217
+  Step   2: 15 / SandWorm x1 (7.264s)
+Damcyan                                                                       Seed: 175   Index: 221
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 175   Index: 229
+Antlion B1F                                                                   Seed: 175   Index: 229
+  Extra Steps: 8
+  Step  45: 16 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 192   Index:  19
+  Antlion B2F                                                                 Seed: 192   Index:  19
+    Step  21: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  44: 18 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed: 192   Index:  99
+  Step   5: 19 / Turtle x2 (7.487s)
+  Step   7: 20 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed: 192   Index: 113
+Antlion's Nest                                                                Seed: 192   Index: 113
+Antlion B2F Outward Charm Room Steps                                          Seed: 192   Index: 128
+  Antlion B2F                                                                 Seed: 192   Index: 128
+  Antlion B2F Treasure Room                                                   Seed: 192   Index: 179
+    Extra Steps: 12
+  Antlion B2F                                                                 Seed: 192   Index: 191
+    Step  23: 21 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 192   Index: 225
+Overworld (Damcyan)                                                           Seed: 209   Index:   7
+Overworld (Kaipo)                                                             Seed: 209   Index:   7
+Kaipo Revisited                                                               Seed: 209   Index:   7
+Overworld (Kaipo)                                                             Seed: 209   Index:   7
+Overworld (Damcyan)                                                           Seed: 209   Index:   7
+Mt.Hobs-West                                                                  Seed: 209   Index:   7
+  Step  31: 22 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 209   Index:  46
+Battle: MomBomb                                                               Seed: 209   Index:  61
+Mt.Hobs Summit                                                                Seed: 209   Index:  61
+Mt.Hobs-East                                                                  Seed: 209   Index:  67
+  Step   3: 23 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  17: 24 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 209   Index: 113
+  Step  21: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  26: 26 / Cocktric x3 (8.241s)
+  Step  38: 27 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 209   Index: 197
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed: 226   Index:  10
+Fabul Boat and Leviatan                                                       Seed: 226   Index:  17
+Overworld (Mysidia)                                                           Seed: 226   Index:  17
+Mysidia                                                                       Seed: 226   Index:  26
+Overworld (Mysidia)                                                           Seed: 226   Index:  26
+Overworld (Mt.Ordeals)                                                        Seed: 226   Index:  36
+  Step  19: 28 / Raven x1 (8.356s)
+  Step  38: 29 / Raven x1, Cocktric x3 (9.100s)
+  Step  64: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  92: 31 / Raven x1, Cocktric x3 (9.100s)
+Mt.Ordeals                                                                    Seed: 226   Index: 130
+  Step   2: 32 / Spirit x2, Skelton x2 (8.285s)
+  Step  34: 33 / Skelton x3, Red Bone x2 (8.244s)
+Mt.Ordeals-3rd station                                                        Seed: 226   Index: 173
+  Step  19: 34 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed: 226   Index: 196
+Mt.Ordeals-3rd station                                                        Seed: 226   Index: 196
+Mt.Ordeals-7th station                                                        Seed: 226   Index: 201
+  Step  27: 35 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 226   Index: 243
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 243   Index:   4
+Mt.Ordeals Summit                                                             Seed: 243   Index:   4
+Paladin                                                                       Seed: 243   Index:   8
+Mt.Ordeals Summit                                                             Seed: 243   Index:   8
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 243   Index:  31
+  Step  26: 36 / Revenant x1, Ghoul x3 (8.489s)
+  Step  34: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 243   Index:  73
+  Step  25: 38 / Spirit x2, Soul x2, Red Bone x2 (9.471s)
+Mt.Ordeals                                                                    Seed: 243   Index: 103
+  Step  10: 39 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 243   Index: 147
+Take Chocobo to Mysidia                                                       Seed: 243   Index: 160
+Overworld (Mysidia)                                                           Seed: 243   Index: 160
+Town of Baron Serpent Road                                                    Seed: 243   Index: 160
+  Extra Steps: 14
+Credit Warp Fight Search                                                      Seed: 243   Index: 178
+  Overworld (Baron)                                                           Seed: 243   Index: 178
+    Extra Steps: 16
+    Step   1: 40 / Imp x4 (7.223s)
+    Step  16: 41 / Imp x3, SwordRat x1 (7.227s)
+   (Step  32: 42 / Imp x3, SwordRat x1)
+   (Step 134: 43 / Imp x3, SwordRat x1)
+   (Step 159: 44 / Imp x3, SwordRat x1)
+   (Step 165: 45 / Imp x3, SwordRat x1)
+   (Step 208: 46 / Imp x3, SwordRat x1)
+   (Step 222: 47 / Eagle x3)
+   (Step 224: 48 / Imp x3)
+
+Encounter Time:      317.353s
+Other Time:          503.071s
+Total Time:          820.424s
+
+Base Total Time:     902.828s
+Time Saved:          82.404s
+
+Optional Steps:      11
+Extra Steps:         50
+Encounters:          41
+
+Base Encounters:     49
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/159.txt
+++ b/data/routes/cw/159.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	159
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48468710
+VARS	FFFFFFFF:18 C307801:1 E302600:10 E307000:6 E307700:2 E307B01:6 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 159   Index:   0
+Overworld (Kaipo)                                                             Seed: 159   Index:   1
+  Step  24: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 159   Index:  37
+Overworld (Kaipo)                                                             Seed: 159   Index:  37
+Watery Pass-South B1F                                                         Seed: 159   Index:  69
+  Step   6: 2 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 159   Index: 101
+Watery Pass-South B1F                                                         Seed: 159   Index: 101
+  Step   7: 3 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 159   Index: 121
+  Step  17: 4 / CaveToad x3 (7.014s)
+  Step  33: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  64: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  90: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 159   Index: 211
+Watery Pass-South B2F                                                         Seed: 159   Index: 215
+  Extra Steps: 6
+  Step  33: 8 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  45: 9 / Zombie x4 (7.148s)
+Watery Pass-South B3F                                                         Seed: 176   Index:   4
+Watery Pass-North B2F                                                         Seed: 176   Index:  38
+  Step   4: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 176   Index:  59
+Overworld (Kaipo)                                                             Seed: 176   Index: 119
+  Step   3: 11 / SandWorm x1 (7.231s)
+Waterfalls B1F                                                                Seed: 176   Index: 128
+Waterfalls B2F                                                                Seed: 176   Index: 129
+  Step  36: 12 / Zombie x6 (7.489s)
+  Step  41: 13 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed: 176   Index: 174
+  Step  28: 14 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 176   Index: 211
+Waterfalls Lake                                                               Seed: 176   Index: 211
+Overworld (Kaipo)                                                             Seed: 176   Index: 212
+  Step   7: 15 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 176   Index: 223
+Damcyan                                                                       Seed: 176   Index: 227
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 176   Index: 234
+Antlion B1F                                                                   Seed: 176   Index: 234
+  Extra Steps: 2
+  Step  40: 16 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 193   Index:  18
+  Antlion B2F                                                                 Seed: 193   Index:  18
+    Step  22: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 193   Index:  98
+  Step   6: 18 / Weeper x2 (7.114s)
+  Step   8: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 193   Index: 112
+Antlion's Nest                                                                Seed: 193   Index: 112
+Antlion B2F Outward Charm Room Steps                                          Seed: 193   Index: 127
+  Antlion B2F                                                                 Seed: 193   Index: 127
+    Step  29: 20 / Turtle x2 (7.464s)
+  Antlion B2F Treasure Room                                                   Seed: 193   Index: 178
+    Extra Steps: 6
+  Antlion B2F                                                                 Seed: 193   Index: 184
+    Step   7: 21 / Weeper x2 (7.132s)
+    Step  30: 22 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 193   Index: 218
+Overworld (Damcyan)                                                           Seed: 210   Index:   0
+Overworld (Kaipo)                                                             Seed: 210   Index:   0
+Kaipo Revisited                                                               Seed: 210   Index:   0
+Overworld (Kaipo)                                                             Seed: 210   Index:   0
+Overworld (Damcyan)                                                           Seed: 210   Index:   0
+Mt.Hobs-West                                                                  Seed: 210   Index:   0
+Mt.Hobs Summit                                                                Seed: 210   Index:  39
+Battle: MomBomb                                                               Seed: 210   Index:  54
+Mt.Hobs Summit                                                                Seed: 210   Index:  54
+Mt.Hobs-East                                                                  Seed: 210   Index:  60
+  Step  10: 23 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  24: 24 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 210   Index: 106
+  Step  28: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  33: 26 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 210   Index: 190
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 227   Index:   4
+Fabul Boat and Leviatan                                                       Seed: 227   Index:  11
+Overworld (Mysidia)                                                           Seed: 227   Index:  11
+Mysidia                                                                       Seed: 227   Index:  20
+Overworld (Mysidia)                                                           Seed: 227   Index:  20
+Overworld (Mt.Ordeals)                                                        Seed: 227   Index:  30
+  Step   6: 27 / Raven x1 (8.356s)
+  Step  25: 28 / Raven x1 (8.356s)
+  Step  70: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 227   Index: 124
+  Step   8: 30 / Red Bone x1, Skelton x3 (8.067s)
+  Step  40: 31 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed: 227   Index: 167
+  Step  23: 32 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed: 227   Index: 190
+Mt.Ordeals-3rd station                                                        Seed: 227   Index: 190
+  Step   2: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed: 227   Index: 195
+  Step  33: 34 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 227   Index: 237
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 227   Index: 255
+Mt.Ordeals Summit                                                             Seed: 227   Index: 255
+Paladin                                                                       Seed: 244   Index:   3
+Mt.Ordeals Summit                                                             Seed: 244   Index:   3
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 244   Index:  26
+  Step  31: 35 / Revenant x1, Ghoul x3 (8.489s)
+  Step  39: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 244   Index:  68
+Mt.Ordeals                                                                    Seed: 244   Index:  98
+  Step  15: 37 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+  Step  28: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 244   Index: 142
+Take Chocobo to Mysidia                                                       Seed: 244   Index: 155
+Overworld (Mysidia)                                                           Seed: 244   Index: 155
+Town of Baron Serpent Road                                                    Seed: 244   Index: 155
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed: 244   Index: 161
+  Overworld (Baron)                                                           Seed: 244   Index: 161
+    Extra Steps: 18
+    Step   1: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  18: 40 / Imp x4 (7.223s)
+   (Step  33: 41 / Imp x3, SwordRat x1)
+   (Step  49: 42 / Imp x3, SwordRat x1)
+   (Step 151: 43 / Imp x3, SwordRat x1)
+   (Step 176: 44 / Imp x6)
+   (Step 182: 45 / Imp x3, SwordRat x1)
+   (Step 225: 46 / Eagle x3)
+   (Step 241: 47 / Eagle x3)
+   (Step 254: 48 / Imp x3)
+
+Encounter Time:      307.139s
+Other Time:          499.344s
+Total Time:          806.484s
+
+Base Total Time:     845.542s
+Time Saved:          39.058s
+
+Optional Steps:      12
+Extra Steps:         34
+Encounters:          40
+
+Base Encounters:     44
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/160.txt
+++ b/data/routes/cw/160.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	160
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48395321
+VARS	FFFFFFFF:16 E000201:6 E302600:10 E307000:12 E308700:1 E308702:1 E309700:20
+
+Overworld (Kaipo)                                                             Seed: 160   Index:   0
+Overworld (Kaipo)                                                             Seed: 160   Index:   1
+  Step  15: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 160   Index:  37
+Overworld (Kaipo)                                                             Seed: 160   Index:  37
+Watery Pass-South B1F                                                         Seed: 160   Index:  69
+  Step   6: 2 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 160   Index: 101
+Watery Pass-South B1F                                                         Seed: 160   Index: 101
+  Step   7: 3 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 160   Index: 121
+  Step  17: 4 / CaveToad x3 (7.014s)
+  Step  33: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  64: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 160   Index: 211
+Watery Pass-South B2F                                                         Seed: 160   Index: 215
+  Extra Steps: 12
+  Step  33: 7 / CaveToad x3 (7.014s)
+  Step  45: 8 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  50: 9 / Zombie x4 (7.148s)
+Watery Pass-South B3F                                                         Seed: 177   Index:  10
+Watery Pass-North B2F                                                         Seed: 177   Index:  44
+Watery Pass-North B1F                                                         Seed: 177   Index:  65
+  Step  57: 10 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 177   Index: 125
+Waterfalls B1F                                                                Seed: 177   Index: 134
+Waterfalls B2F                                                                Seed: 177   Index: 135
+  Step  30: 11 / Mad Toad x4 (7.317s)
+  Step  35: 12 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 177   Index: 180
+  Step  22: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 177   Index: 217
+Waterfalls Lake                                                               Seed: 177   Index: 217
+Overworld (Kaipo)                                                             Seed: 177   Index: 218
+  Extra Steps: 6
+  Step  16: 14 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 177   Index: 235
+Damcyan                                                                       Seed: 177   Index: 239
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 177   Index: 246
+Antlion B1F                                                                   Seed: 177   Index: 246
+  Step  28: 15 / Basilisk x1, Imp x3 (6.775s)
+  Step  29: 16 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 194   Index:  28
+  Antlion B2F                                                                 Seed: 194   Index:  28
+    Step  76: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  78: 18 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 194   Index: 108
+Battle: Antlion                                                               Seed: 194   Index: 122
+Antlion's Nest                                                                Seed: 194   Index: 122
+Antlion B2F Outward Direct                                                    Seed: 194   Index: 137
+  Antlion B2F                                                                 Seed: 194   Index: 137
+    Step  19: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  47: 20 / Turtle x2 (7.464s)
+    Step  54: 21 / Weeper x2 (7.132s)
+    Step  77: 22 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 194   Index: 217
+Overworld (Damcyan)                                                           Seed: 194   Index: 255
+Overworld (Kaipo)                                                             Seed: 194   Index: 255
+Kaipo Revisited                                                               Seed: 194   Index: 255
+Overworld (Kaipo)                                                             Seed: 194   Index: 255
+Overworld (Damcyan)                                                           Seed: 194   Index: 255
+Mt.Hobs-West                                                                  Seed: 194   Index: 255
+  Step  23: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed: 211   Index:  38
+Battle: MomBomb                                                               Seed: 211   Index:  53
+Mt.Hobs Summit                                                                Seed: 211   Index:  53
+Mt.Hobs-East                                                                  Seed: 211   Index:  59
+  Step  25: 24 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 211   Index: 105
+  Step  29: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  34: 26 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 211   Index: 189
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 228   Index:   3
+Fabul Boat and Leviatan                                                       Seed: 228   Index:  10
+Overworld (Mysidia)                                                           Seed: 228   Index:  10
+Mysidia                                                                       Seed: 228   Index:  19
+Overworld (Mysidia)                                                           Seed: 228   Index:  19
+Overworld (Mt.Ordeals)                                                        Seed: 228   Index:  29
+  Step  26: 27 / Raven x1 (8.356s)
+  Step  71: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 228   Index: 123
+  Step   8: 29 / Spirit x2, Skelton x2 (8.285s)
+  Step   9: 30 / Red Bone x1, Skelton x3 (8.067s)
+  Step  41: 31 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 228   Index: 166
+Recruit Tellah                                                                Seed: 228   Index: 189
+Mt.Ordeals-3rd station                                                        Seed: 228   Index: 189
+  Step   1: 32 / Ghoul x1, Red Bone x2, Skelton x2 (8.832s)
+  Step   3: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed: 228   Index: 194
+  Step  34: 34 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 228   Index: 236
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 228   Index: 254
+Mt.Ordeals Summit                                                             Seed: 228   Index: 254
+Paladin                                                                       Seed: 245   Index:   2
+Mt.Ordeals Summit                                                             Seed: 245   Index:   2
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 245   Index:  25
+  Step  32: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  40: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 245   Index:  67
+Mt.Ordeals                                                                    Seed: 245   Index:  97
+  Step  29: 37 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+  Step  32: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 245   Index: 141
+Take Chocobo to Mysidia                                                       Seed: 245   Index: 154
+Overworld (Mysidia)                                                           Seed: 245   Index: 154
+Town of Baron Serpent Road                                                    Seed: 245   Index: 154
+  Extra Steps: 20
+Credit Warp Fight Search                                                      Seed: 245   Index: 178
+  Overworld (Baron)                                                           Seed: 245   Index: 178
+    Extra Steps: 16
+    Step   1: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  16: 40 / Imp x4 (7.223s)
+   (Step  32: 41 / Imp x3, SwordRat x1)
+   (Step 134: 42 / Imp x3, SwordRat x1)
+   (Step 159: 43 / Imp x3, SwordRat x1)
+   (Step 165: 44 / Imp x6)
+   (Step 224: 45 / Eagle x3)
+   (Step 237: 46 / Eagle x3)
+
+Encounter Time:      305.719s
+Other Time:          499.544s
+Total Time:          805.262s
+
+Base Total Time:     829.487s
+Time Saved:          24.225s
+
+Optional Steps:      12
+Extra Steps:         54
+Encounters:          40
+
+Base Encounters:     42
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/161.txt
+++ b/data/routes/cw/161.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	161
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48379925
+VARS	FFFFFFFF:20 E302500:7 E302600:14 E307700:2 E308000:6 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 161   Index:   0
+Overworld (Kaipo)                                                             Seed: 161   Index:   1
+  Step  15: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 161   Index:  37
+Overworld (Kaipo)                                                             Seed: 161   Index:  37
+Watery Pass-South B1F                                                         Seed: 161   Index:  69
+  Step   6: 2 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 161   Index: 101
+Watery Pass-South B1F                                                         Seed: 161   Index: 101
+  Step   7: 3 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 161   Index: 121
+  Step  17: 4 / CaveToad x3 (7.014s)
+  Step  64: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  75: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 161   Index: 211
+Watery Pass-South B2F                                                         Seed: 161   Index: 215
+  Step  33: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 161   Index: 254
+  Step  11: 8 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed: 178   Index:  32
+  Step   9: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B1F                                                         Seed: 178   Index:  53
+Overworld (Kaipo)                                                             Seed: 178   Index: 113
+  Step   9: 10 / Imp x4 (7.049s)
+Waterfalls B1F                                                                Seed: 178   Index: 122
+Waterfalls B2F                                                                Seed: 178   Index: 123
+  Step  42: 11 / Mad Toad x4 (7.317s)
+Waterfalls Lake                                                               Seed: 178   Index: 168
+  Step   2: 12 / Zombie x6 (7.489s)
+  Step  34: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 178   Index: 205
+Waterfalls Lake                                                               Seed: 178   Index: 205
+Overworld (Kaipo)                                                             Seed: 178   Index: 206
+Overworld (Damcyan)                                                           Seed: 178   Index: 217
+Damcyan                                                                       Seed: 178   Index: 221
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed: 178   Index: 235
+Antlion B1F                                                                   Seed: 178   Index: 235
+  Extra Steps: 2
+  Step  39: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  40: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed: 195   Index:  19
+  Antlion B2F                                                                 Seed: 195   Index:  19
+Antlion's Nest                                                                Seed: 195   Index:  99
+  Step   5: 16 / Cream x4 (7.552s)
+  Step   7: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 195   Index: 113
+Antlion's Nest                                                                Seed: 195   Index: 113
+Antlion B2F Outward Direct                                                    Seed: 195   Index: 128
+  Antlion B2F                                                                 Seed: 195   Index: 128
+    Step  28: 18 / Weeper x2 (7.132s)
+    Step  56: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 195   Index: 208
+  Step   6: 20 / Turtle x1, Imp x2 (7.009s)
+  Step  13: 21 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 195   Index: 246
+Overworld (Kaipo)                                                             Seed: 195   Index: 246
+Kaipo Revisited                                                               Seed: 195   Index: 246
+Overworld (Kaipo)                                                             Seed: 195   Index: 246
+Overworld (Damcyan)                                                           Seed: 195   Index: 246
+Mt.Hobs-West                                                                  Seed: 195   Index: 246
+  Step  32: 22 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 212   Index:  29
+Battle: MomBomb                                                               Seed: 212   Index:  44
+Mt.Hobs Summit                                                                Seed: 212   Index:  44
+Mt.Hobs-East                                                                  Seed: 212   Index:  50
+  Extra Steps: 6
+  Step  34: 23 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  51: 24 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 212   Index: 102
+  Step  32: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  37: 26 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 212   Index: 186
+  Optional Steps: 10
+  Extra Steps: 4
+Overworld (Fabul)                                                             Seed: 229   Index:   4
+Fabul Boat and Leviatan                                                       Seed: 229   Index:  11
+Overworld (Mysidia)                                                           Seed: 229   Index:  11
+Mysidia                                                                       Seed: 229   Index:  20
+Overworld (Mysidia)                                                           Seed: 229   Index:  20
+Overworld (Mt.Ordeals)                                                        Seed: 229   Index:  30
+  Step  25: 27 / Raven x1 (8.356s)
+  Step  70: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 229   Index: 124
+  Step   7: 29 / Spirit x2, Skelton x2 (8.285s)
+  Step  13: 30 / Red Bone x1, Skelton x3 (8.067s)
+  Step  40: 31 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 229   Index: 167
+  Step  23: 32 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed: 229   Index: 190
+Mt.Ordeals-3rd station                                                        Seed: 229   Index: 190
+  Step   2: 33 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals-7th station                                                        Seed: 229   Index: 195
+  Step  33: 34 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 229   Index: 237
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 229   Index: 255
+Mt.Ordeals Summit                                                             Seed: 229   Index: 255
+Paladin                                                                       Seed: 246   Index:   3
+Mt.Ordeals Summit                                                             Seed: 246   Index:   3
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 246   Index:  26
+  Step  31: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  39: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 246   Index:  68
+Mt.Ordeals                                                                    Seed: 246   Index:  98
+  Step  28: 37 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+  Step  31: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 246   Index: 142
+Take Chocobo to Mysidia                                                       Seed: 246   Index: 155
+Overworld (Mysidia)                                                           Seed: 246   Index: 155
+Town of Baron Serpent Road                                                    Seed: 246   Index: 155
+Credit Warp Fight Search                                                      Seed: 246   Index: 159
+  Overworld (Baron)                                                           Seed: 246   Index: 159
+    Extra Steps: 20
+    Step   2: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  20: 40 / Imp x4 (7.223s)
+   (Step  51: 41 / Imp x3, SwordRat x1)
+   (Step 153: 42 / Imp x3, SwordRat x1)
+   (Step 178: 43 / Imp x3, SwordRat x1)
+   (Step 243: 44 / Imp x3)
+   (Step 256: 45 / Eagle x3)
+
+Encounter Time:      308.657s
+Other Time:          496.349s
+Total Time:          805.006s
+
+Base Total Time:     816.081s
+Time Saved:          11.075s
+
+Optional Steps:      13
+Extra Steps:         38
+Encounters:          40
+
+Base Encounters:     41
+Encounters Saved:    1
+
+Number of Variables: 54

--- a/data/routes/cw/162.txt
+++ b/data/routes/cw/162.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	162
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48526865
+VARS	FFFFFFFF:20 C307801:1 E302500:6 E302600:10 E307700:4 E307B01:4 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 162   Index:   0
+Overworld (Kaipo)                                                             Seed: 162   Index:   1
+  Step  10: 1 / Sand Man x4 (7.172s)
+  Step  15: 2 / SandWorm x1 (6.973s)
+Kaipo                                                                         Seed: 162   Index:  37
+Overworld (Kaipo)                                                             Seed: 162   Index:  37
+Watery Pass-South B1F                                                         Seed: 162   Index:  69
+  Step   6: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 162   Index: 101
+Watery Pass-South B1F                                                         Seed: 162   Index: 101
+  Step   7: 4 / CaveToad x3 (7.014s)
+Watery Pass-South B2F                                                         Seed: 162   Index: 121
+  Step  17: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  75: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 162   Index: 211
+Watery Pass-South B2F                                                         Seed: 162   Index: 215
+  Step  33: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 162   Index: 254
+  Step  11: 8 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed: 179   Index:  32
+  Step   9: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B1F                                                         Seed: 179   Index:  53
+Overworld (Kaipo)                                                             Seed: 179   Index: 113
+  Step   9: 10 / Imp x4 (7.049s)
+Waterfalls B1F                                                                Seed: 179   Index: 122
+Waterfalls B2F                                                                Seed: 179   Index: 123
+  Step  42: 11 / Mad Toad x4 (7.317s)
+Waterfalls Lake                                                               Seed: 179   Index: 168
+  Step   2: 12 / Zombie x6 (7.489s)
+  Step  19: 13 / Aligator x1, WaterBug x2 (7.292s)
+  Step  34: 14 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 179   Index: 205
+Waterfalls Lake                                                               Seed: 179   Index: 205
+Overworld (Kaipo)                                                             Seed: 179   Index: 206
+Overworld (Damcyan)                                                           Seed: 179   Index: 217
+Damcyan                                                                       Seed: 179   Index: 221
+  Optional Steps: 0
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed: 179   Index: 234
+Antlion B1F                                                                   Seed: 179   Index: 234
+  Extra Steps: 4
+  Step  40: 15 / Basilisk x1, Imp x3 (6.775s)
+  Step  41: 16 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 196   Index:  20
+  Antlion B2F                                                                 Seed: 196   Index:  20
+Antlion's Nest                                                                Seed: 196   Index: 100
+  Step   3: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+  Step   6: 18 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed: 196   Index: 114
+Antlion's Nest                                                                Seed: 196   Index: 114
+Antlion B2F Outward Charm Room Steps                                          Seed: 196   Index: 129
+  Antlion B2F                                                                 Seed: 196   Index: 129
+    Step  27: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Antlion B2F Treasure Room                                                   Seed: 196   Index: 180
+    Extra Steps: 4
+  Antlion B2F                                                                 Seed: 196   Index: 184
+    Step  30: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 196   Index: 218
+  Step   3: 21 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 213   Index:   0
+Overworld (Kaipo)                                                             Seed: 213   Index:   0
+Kaipo Revisited                                                               Seed: 213   Index:   0
+Overworld (Kaipo)                                                             Seed: 213   Index:   0
+Overworld (Damcyan)                                                           Seed: 213   Index:   0
+Mt.Hobs-West                                                                  Seed: 213   Index:   0
+  Step  22: 22 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 213   Index:  39
+Battle: MomBomb                                                               Seed: 213   Index:  54
+Mt.Hobs Summit                                                                Seed: 213   Index:  54
+Mt.Hobs-East                                                                  Seed: 213   Index:  60
+  Step  24: 23 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  41: 24 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 213   Index: 106
+  Step  27: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  28: 26 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  33: 27 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 213   Index: 190
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 230   Index:   4
+Fabul Boat and Leviatan                                                       Seed: 230   Index:  11
+Overworld (Mysidia)                                                           Seed: 230   Index:  11
+Mysidia                                                                       Seed: 230   Index:  20
+Overworld (Mysidia)                                                           Seed: 230   Index:  20
+Overworld (Mt.Ordeals)                                                        Seed: 230   Index:  30
+  Step  25: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 230   Index: 124
+  Step   7: 29 / Spirit x2, Skelton x2 (8.285s)
+  Step  13: 30 / Red Bone x1, Skelton x3 (8.067s)
+  Step  39: 31 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 230   Index: 167
+  Step  23: 32 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed: 230   Index: 190
+Mt.Ordeals-3rd station                                                        Seed: 230   Index: 190
+  Step   2: 33 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals-7th station                                                        Seed: 230   Index: 195
+  Step  33: 34 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed: 230   Index: 237
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 230   Index: 255
+Mt.Ordeals Summit                                                             Seed: 230   Index: 255
+Paladin                                                                       Seed: 247   Index:   3
+Mt.Ordeals Summit                                                             Seed: 247   Index:   3
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 247   Index:  26
+  Step  31: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  39: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 247   Index:  68
+Mt.Ordeals                                                                    Seed: 247   Index:  98
+  Step  28: 37 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+  Step  31: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 247   Index: 142
+Take Chocobo to Mysidia                                                       Seed: 247   Index: 155
+Overworld (Mysidia)                                                           Seed: 247   Index: 155
+Town of Baron Serpent Road                                                    Seed: 247   Index: 155
+Credit Warp Fight Search                                                      Seed: 247   Index: 159
+  Overworld (Baron)                                                           Seed: 247   Index: 159
+    Extra Steps: 20
+    Step   2: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  20: 40 / Imp x4 (7.223s)
+   (Step  34: 41 / Imp x3, SwordRat x1)
+   (Step 178: 42 / Imp x3, SwordRat x1)
+   (Step 243: 43 / Imp x3, SwordRat x1)
+   (Step 256: 44 / Imp x3)
+
+Encounter Time:      307.575s
+Other Time:          499.877s
+Total Time:          807.451s
+
+Base Total Time:     819.635s
+Time Saved:          12.184s
+
+Optional Steps:      12
+Extra Steps:         34
+Encounters:          40
+
+Base Encounters:     42
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/163.txt
+++ b/data/routes/cw/163.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	163
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48961992
+VARS	FFFFFFFF:20 C307801:1 E302600:10 E307000:12 E307B01:2 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 163   Index:   0
+Overworld (Kaipo)                                                             Seed: 163   Index:   1
+  Step  10: 1 / Sand Man x4 (7.172s)
+  Step  15: 2 / SandWorm x1 (6.973s)
+Kaipo                                                                         Seed: 163   Index:  37
+Overworld (Kaipo)                                                             Seed: 163   Index:  37
+Watery Pass-South B1F                                                         Seed: 163   Index:  69
+  Step   6: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 163   Index: 101
+Watery Pass-South B1F                                                         Seed: 163   Index: 101
+Watery Pass-South B2F                                                         Seed: 163   Index: 121
+  Step  17: 4 / CaveToad x3 (7.014s)
+  Step  75: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  83: 6 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 163   Index: 211
+Watery Pass-South B2F                                                         Seed: 163   Index: 215
+  Extra Steps: 12
+  Step  33: 7 / CaveToad x3 (7.014s)
+  Step  50: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 180   Index:  10
+  Step  11: 9 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  31: 10 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 180   Index:  44
+Watery Pass-North B1F                                                         Seed: 180   Index:  65
+Overworld (Kaipo)                                                             Seed: 180   Index: 125
+Waterfalls B1F                                                                Seed: 180   Index: 134
+Waterfalls B2F                                                                Seed: 180   Index: 135
+  Step  30: 11 / Mad Toad x4 (7.317s)
+  Step  35: 12 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 180   Index: 180
+  Step   7: 13 / Aligator x1, WaterBug x2 (7.292s)
+  Step  22: 14 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 180   Index: 217
+Waterfalls Lake                                                               Seed: 180   Index: 217
+Overworld (Kaipo)                                                             Seed: 180   Index: 218
+Overworld (Damcyan)                                                           Seed: 180   Index: 229
+Damcyan                                                                       Seed: 180   Index: 233
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 180   Index: 240
+Antlion B1F                                                                   Seed: 180   Index: 240
+  Step  35: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed: 197   Index:  22
+  Antlion B2F                                                                 Seed: 197   Index:  22
+Antlion's Nest                                                                Seed: 197   Index: 102
+  Step   1: 16 / Cream x4 (7.552s)
+  Step   4: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 197   Index: 116
+Antlion's Nest                                                                Seed: 197   Index: 116
+Antlion B2F Outward Charm Room Steps                                          Seed: 197   Index: 131
+  Antlion B2F                                                                 Seed: 197   Index: 131
+    Step   4: 18 / Weeper x2 (7.132s)
+    Step  25: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Antlion B2F Treasure Room                                                   Seed: 197   Index: 182
+    Extra Steps: 2
+  Antlion B2F                                                                 Seed: 197   Index: 184
+    Step  30: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 197   Index: 218
+  Step   3: 21 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed: 214   Index:   0
+Overworld (Kaipo)                                                             Seed: 214   Index:   0
+Kaipo Revisited                                                               Seed: 214   Index:   0
+Overworld (Kaipo)                                                             Seed: 214   Index:   0
+Overworld (Damcyan)                                                           Seed: 214   Index:   0
+Mt.Hobs-West                                                                  Seed: 214   Index:   0
+  Step  22: 22 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 214   Index:  39
+Battle: MomBomb                                                               Seed: 214   Index:  54
+Mt.Hobs Summit                                                                Seed: 214   Index:  54
+Mt.Hobs-East                                                                  Seed: 214   Index:  60
+  Step  24: 23 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  41: 24 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 214   Index: 106
+  Step  27: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  28: 26 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  33: 27 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 214   Index: 190
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 231   Index:   4
+Fabul Boat and Leviatan                                                       Seed: 231   Index:  11
+Overworld (Mysidia)                                                           Seed: 231   Index:  11
+Mysidia                                                                       Seed: 231   Index:  20
+Overworld (Mysidia)                                                           Seed: 231   Index:  20
+Overworld (Mt.Ordeals)                                                        Seed: 231   Index:  30
+  Step  25: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 231   Index: 124
+  Step   7: 29 / Spirit x2, Skelton x2 (8.285s)
+  Step  13: 30 / Red Bone x1, Skelton x3 (8.067s)
+  Step  26: 31 / Spirit x2, Skelton x2 (8.285s)
+  Step  39: 32 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 231   Index: 167
+  Step  23: 33 / Lilith x1, Red Bone x2 (9.259s)
+Recruit Tellah                                                                Seed: 231   Index: 190
+Mt.Ordeals-3rd station                                                        Seed: 231   Index: 190
+  Step   2: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed: 231   Index: 195
+  Step  33: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 231   Index: 237
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed: 231   Index: 255
+Mt.Ordeals Summit                                                             Seed: 231   Index: 255
+Paladin                                                                       Seed: 248   Index:   3
+Mt.Ordeals Summit                                                             Seed: 248   Index:   3
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 248   Index:  26
+  Step  31: 36 / Revenant x1, Ghoul x3 (8.489s)
+  Step  39: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed: 248   Index:  68
+Mt.Ordeals                                                                    Seed: 248   Index:  98
+  Step  28: 38 / Red Bone x1, Skelton x3 (7.844s)
+  Step  31: 39 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 248   Index: 142
+Take Chocobo to Mysidia                                                       Seed: 248   Index: 155
+Overworld (Mysidia)                                                           Seed: 248   Index: 155
+Town of Baron Serpent Road                                                    Seed: 248   Index: 155
+Credit Warp Fight Search                                                      Seed: 248   Index: 159
+  Overworld (Baron)                                                           Seed: 248   Index: 159
+    Extra Steps: 20
+    Step   2: 40 / Imp x4 (7.223s)
+    Step  20: 41 / Imp x3, SwordRat x1 (7.227s)
+   (Step  34: 42 / Imp x3, SwordRat x1)
+   (Step  66: 43 / Imp x3, SwordRat x1)
+   (Step 132: 44 / Imp x3)
+   (Step 178: 45 / Eagle x3)
+   (Step 256: 46 / Eagle x3)
+
+Encounter Time:      314.815s
+Other Time:          499.877s
+Total Time:          814.691s
+
+Base Total Time:     819.106s
+Time Saved:          4.414s
+
+Optional Steps:      12
+Extra Steps:         34
+Encounters:          41
+
+Base Encounters:     42
+Encounters Saved:    1
+
+Number of Variables: 54

--- a/data/routes/cw/164.txt
+++ b/data/routes/cw/164.txt
@@ -1,0 +1,147 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	164
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48706452
+VARS	FFFFFFFF:34
+
+Overworld (Kaipo)                                                             Seed: 164   Index:   0
+Overworld (Kaipo)                                                             Seed: 164   Index:   1
+  Step  10: 1 / Sand Man x4 (7.172s)
+  Step  15: 2 / SandWorm x1 (6.973s)
+Kaipo                                                                         Seed: 164   Index:  37
+Overworld (Kaipo)                                                             Seed: 164   Index:  37
+Watery Pass-South B1F                                                         Seed: 164   Index:  69
+  Step   6: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 164   Index: 101
+Watery Pass-South B1F                                                         Seed: 164   Index: 101
+Watery Pass-South B2F                                                         Seed: 164   Index: 121
+  Step  17: 4 / CaveToad x3 (7.014s)
+  Step  68: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  75: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  83: 7 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 164   Index: 211
+Watery Pass-South B2F                                                         Seed: 164   Index: 215
+Watery Pass-South B3F                                                         Seed: 164   Index: 254
+  Step  11: 8 / CaveToad x3 (7.014s)
+  Step  23: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed: 181   Index:  32
+  Step   9: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 181   Index:  53
+Overworld (Kaipo)                                                             Seed: 181   Index: 113
+Waterfalls B1F                                                                Seed: 181   Index: 122
+Waterfalls B2F                                                                Seed: 181   Index: 123
+Waterfalls Lake                                                               Seed: 181   Index: 168
+  Step   2: 11 / Mad Toad x4 (7.317s)
+  Step  19: 12 / Zombie x6 (7.489s)
+  Step  34: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 181   Index: 205
+Waterfalls Lake                                                               Seed: 181   Index: 205
+Overworld (Kaipo)                                                             Seed: 181   Index: 206
+Overworld (Damcyan)                                                           Seed: 181   Index: 217
+Damcyan                                                                       Seed: 181   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 181   Index: 228
+Antlion B1F                                                                   Seed: 181   Index: 228
+  Step   6: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  24: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed: 198   Index:  10
+  Antlion B2F                                                                 Seed: 198   Index:  10
+    Step   9: 16 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 198   Index:  90
+  Step  13: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 198   Index: 104
+Antlion's Nest                                                                Seed: 198   Index: 104
+  Step   2: 18 / Weeper x2 (7.132s)
+  Step   5: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed: 198   Index: 119
+  Antlion B2F                                                                 Seed: 198   Index: 119
+    Step  16: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  37: 21 / SandWorm x2 (6.858s)
+    Step  65: 22 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 198   Index: 199
+  Step  22: 23 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 198   Index: 237
+Overworld (Kaipo)                                                             Seed: 198   Index: 237
+Kaipo Revisited                                                               Seed: 198   Index: 237
+Overworld (Kaipo)                                                             Seed: 198   Index: 237
+Overworld (Damcyan)                                                           Seed: 198   Index: 237
+Mt.Hobs-West                                                                  Seed: 198   Index: 237
+Mt.Hobs Summit                                                                Seed: 215   Index:  20
+  Step   2: 24 / Spirit x2, Skelton x2 (9.087s)
+Battle: MomBomb                                                               Seed: 215   Index:  35
+Mt.Hobs Summit                                                                Seed: 215   Index:  35
+Mt.Hobs-East                                                                  Seed: 215   Index:  41
+  Step  43: 25 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 215   Index:  87
+  Step  14: 26 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  46: 27 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  52: 28 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 215   Index: 171
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 215   Index: 231
+Fabul Boat and Leviatan                                                       Seed: 215   Index: 238
+Overworld (Mysidia)                                                           Seed: 215   Index: 238
+Mysidia                                                                       Seed: 215   Index: 247
+Overworld (Mysidia)                                                           Seed: 215   Index: 247
+Overworld (Mt.Ordeals)                                                        Seed: 232   Index:   1
+  Step   2: 29 / Raven x1 (8.356s)
+  Step  54: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 232   Index:  95
+  Step  36: 31 / Spirit x2, Skelton x2 (8.285s)
+  Step  42: 32 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 232   Index: 138
+  Step  12: 33 / Lilith x1, Red Bone x2 (9.259s)
+Recruit Tellah                                                                Seed: 232   Index: 161
+Mt.Ordeals-3rd station                                                        Seed: 232   Index: 161
+  Step   2: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed: 232   Index: 166
+  Step  24: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  26: 36 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed: 232   Index: 208
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 232   Index: 225
+Mt.Ordeals Summit                                                             Seed: 232   Index: 225
+  Step   2: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.808s)
+Paladin                                                                       Seed: 232   Index: 229
+Mt.Ordeals Summit                                                             Seed: 232   Index: 229
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 232   Index: 251
+  Step   5: 38 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 249   Index:  37
+  Step  28: 39 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 249   Index:  67
+Overworld (Mt.Ordeals)                                                        Seed: 249   Index: 111
+Take Chocobo to Mysidia                                                       Seed: 249   Index: 124
+Overworld (Mysidia)                                                           Seed: 249   Index: 124
+Town of Baron Serpent Road                                                    Seed: 249   Index: 124
+Credit Warp Fight Search                                                      Seed: 249   Index: 128
+  Overworld (Baron)                                                           Seed: 249   Index: 128
+    Extra Steps: 34
+    Step   1: 40 / Imp x4 (7.223s)
+    Step  33: 41 / Imp x3, SwordRat x1 (7.227s)
+   (Step  65: 42 / Imp x3, SwordRat x1)
+   (Step  97: 43 / Imp x3, SwordRat x1)
+   (Step 141: 44 / Imp x3)
+   (Step 163: 45 / Eagle x3)
+   (Step 209: 46 / Eagle x3)
+
+Encounter Time:      311.428s
+Other Time:          499.012s
+Total Time:          810.439s
+
+Base Total Time:     810.439s
+Time Saved:          0.000s
+
+Optional Steps:      0
+Extra Steps:         34
+Encounters:          41
+
+Base Encounters:     41
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/165.txt
+++ b/data/routes/cw/165.txt
@@ -1,0 +1,147 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	165
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48534984
+VARS	FFFFFFFF:20 E302600:2 E308700:1 E308702:1 E309700:28
+
+Overworld (Kaipo)                                                             Seed: 165   Index:   0
+Overworld (Kaipo)                                                             Seed: 165   Index:   1
+  Step   4: 1 / Sand Man x4 (7.172s)
+  Step  10: 2 / SandMoth x2, Larva x2 (7.009s)
+  Step  15: 3 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 165   Index:  37
+Overworld (Kaipo)                                                             Seed: 165   Index:  37
+Watery Pass-South B1F                                                         Seed: 165   Index:  69
+  Step   6: 4 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed: 165   Index: 101
+Watery Pass-South B1F                                                         Seed: 165   Index: 101
+Watery Pass-South B2F                                                         Seed: 165   Index: 121
+  Step  68: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  75: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  83: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 165   Index: 211
+Watery Pass-South B2F                                                         Seed: 165   Index: 215
+Watery Pass-South B3F                                                         Seed: 165   Index: 254
+  Step  11: 8 / CaveToad x3 (7.014s)
+  Step  23: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed: 182   Index:  32
+  Step   9: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 182   Index:  53
+Overworld (Kaipo)                                                             Seed: 182   Index: 113
+Waterfalls B1F                                                                Seed: 182   Index: 122
+Waterfalls B2F                                                                Seed: 182   Index: 123
+  Step  22: 11 / TinyMage x4 (7.558s)
+Waterfalls Lake                                                               Seed: 182   Index: 168
+  Step  19: 12 / Zombie x6 (7.489s)
+  Step  34: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 182   Index: 205
+Waterfalls Lake                                                               Seed: 182   Index: 205
+Overworld (Kaipo)                                                             Seed: 182   Index: 206
+Overworld (Damcyan)                                                           Seed: 182   Index: 217
+Damcyan                                                                       Seed: 182   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 182   Index: 228
+Antlion B1F                                                                   Seed: 182   Index: 228
+  Step   6: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  24: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed: 199   Index:  10
+  Antlion B2F                                                                 Seed: 199   Index:  10
+    Step   9: 16 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 199   Index:  90
+  Step  13: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 199   Index: 104
+Antlion's Nest                                                                Seed: 199   Index: 104
+  Step   2: 18 / Weeper x2 (7.132s)
+  Step   5: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed: 199   Index: 119
+  Antlion B2F                                                                 Seed: 199   Index: 119
+    Step  16: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  37: 21 / SandWorm x2 (6.858s)
+    Step  80: 22 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 199   Index: 199
+  Step  22: 23 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 199   Index: 237
+Overworld (Kaipo)                                                             Seed: 199   Index: 237
+Kaipo Revisited                                                               Seed: 199   Index: 237
+Overworld (Kaipo)                                                             Seed: 199   Index: 237
+Overworld (Damcyan)                                                           Seed: 199   Index: 237
+Mt.Hobs-West                                                                  Seed: 199   Index: 237
+Mt.Hobs Summit                                                                Seed: 216   Index:  20
+  Step   2: 24 / Spirit x2, Skelton x2 (9.087s)
+Battle: MomBomb                                                               Seed: 216   Index:  35
+Mt.Hobs Summit                                                                Seed: 216   Index:  35
+Mt.Hobs-East                                                                  Seed: 216   Index:  41
+Overworld (Fabul)                                                             Seed: 216   Index:  87
+  Step  14: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  46: 26 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  52: 27 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 216   Index: 171
+  Optional Steps: 2
+Overworld (Fabul)                                                             Seed: 216   Index: 233
+Fabul Boat and Leviatan                                                       Seed: 216   Index: 240
+Overworld (Mysidia)                                                           Seed: 216   Index: 240
+Mysidia                                                                       Seed: 216   Index: 249
+Overworld (Mysidia)                                                           Seed: 216   Index: 249
+Overworld (Mt.Ordeals)                                                        Seed: 233   Index:   3
+Mt.Ordeals                                                                    Seed: 233   Index:  97
+  Step  34: 28 / Spirit x2, Skelton x2 (8.285s)
+  Step  40: 29 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 233   Index: 140
+  Step  10: 30 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+  Step  23: 31 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed: 233   Index: 163
+Mt.Ordeals-3rd station                                                        Seed: 233   Index: 163
+Mt.Ordeals-7th station                                                        Seed: 233   Index: 168
+  Step  22: 32 / Ghoul x2, Soul x2 (9.197s)
+  Step  24: 33 / Soul x3, Ghoul x1, Revenant x1 (9.933s)
+Mt.Ordeals Summit                                                             Seed: 233   Index: 210
+  Optional Steps: 1
+  Step  17: 34 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed: 233   Index: 228
+Mt.Ordeals Summit                                                             Seed: 233   Index: 228
+Paladin                                                                       Seed: 233   Index: 232
+Mt.Ordeals Summit                                                             Seed: 233   Index: 232
+  Optional Steps: 1
+  Step  22: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed: 233   Index: 255
+  Step   1: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 250   Index:  41
+  Step  24: 37 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 250   Index:  71
+Overworld (Mt.Ordeals)                                                        Seed: 250   Index: 115
+  Step  11: 38 / SwordRat x2, Imp x2, TinyMage x2 (7.453s)
+Take Chocobo to Mysidia                                                       Seed: 250   Index: 128
+Overworld (Mysidia)                                                           Seed: 250   Index: 128
+Town of Baron Serpent Road                                                    Seed: 250   Index: 128
+  Extra Steps: 28
+Credit Warp Fight Search                                                      Seed: 250   Index: 160
+  Overworld (Baron)                                                           Seed: 250   Index: 160
+    Extra Steps: 20
+    Step   1: 39 / FloatEye x1, Eagle x2 (7.365s)
+    Step  20: 40 / Imp x4 (7.223s)
+   (Step  33: 41 / Imp x3, SwordRat x1)
+   (Step  65: 42 / Imp x3, SwordRat x1)
+   (Step 109: 43 / Imp x3, SwordRat x1)
+   (Step 131: 44 / Imp x3)
+   (Step 255: 45 / Eagle x3)
+
+Encounter Time:      308.575s
+Other Time:          499.012s
+Total Time:          807.586s
+
+Base Total Time:     807.696s
+Time Saved:          0.110s
+
+Optional Steps:      4
+Extra Steps:         48
+Encounters:          40
+
+Base Encounters:     40
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/166.txt
+++ b/data/routes/cw/166.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	166
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48770704
+VARS	FFFFFFFF:34
+
+Overworld (Kaipo)                                                             Seed: 166   Index:   0
+Overworld (Kaipo)                                                             Seed: 166   Index:   1
+  Step   4: 1 / Sand Man x4 (7.172s)
+  Step  10: 2 / SandMoth x2, Larva x2 (7.009s)
+  Step  15: 3 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 166   Index:  37
+Overworld (Kaipo)                                                             Seed: 166   Index:  37
+Watery Pass-South B1F                                                         Seed: 166   Index:  69
+Recruit Tellah                                                                Seed: 166   Index: 101
+Watery Pass-South B1F                                                         Seed: 166   Index: 101
+Watery Pass-South B2F                                                         Seed: 166   Index: 121
+  Step  50: 4 / CaveToad x3 (7.014s)
+  Step  68: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  75: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  83: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 166   Index: 211
+Watery Pass-South B2F                                                         Seed: 166   Index: 215
+Watery Pass-South B3F                                                         Seed: 166   Index: 254
+  Step  11: 8 / CaveToad x3 (7.014s)
+  Step  23: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed: 183   Index:  32
+  Step   9: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 183   Index:  53
+Overworld (Kaipo)                                                             Seed: 183   Index: 113
+Waterfalls B1F                                                                Seed: 183   Index: 122
+Waterfalls B2F                                                                Seed: 183   Index: 123
+  Step  22: 11 / TinyMage x4 (7.558s)
+Waterfalls Lake                                                               Seed: 183   Index: 168
+  Step   4: 12 / Zombie x6 (7.489s)
+  Step  19: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 183   Index: 205
+Waterfalls Lake                                                               Seed: 183   Index: 205
+Overworld (Kaipo)                                                             Seed: 183   Index: 206
+Overworld (Damcyan)                                                           Seed: 183   Index: 217
+Damcyan                                                                       Seed: 183   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 183   Index: 228
+Antlion B1F                                                                   Seed: 183   Index: 228
+  Step   6: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  24: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed: 200   Index:  10
+  Antlion B2F                                                                 Seed: 200   Index:  10
+    Step   9: 16 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 200   Index:  90
+  Step  13: 17 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 200   Index: 104
+Antlion's Nest                                                                Seed: 200   Index: 104
+  Step   5: 18 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed: 200   Index: 119
+  Antlion B2F                                                                 Seed: 200   Index: 119
+    Step  16: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  32: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  37: 21 / SandWorm x2 (6.858s)
+    Step  80: 22 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 200   Index: 199
+  Step  22: 23 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 200   Index: 237
+Overworld (Kaipo)                                                             Seed: 200   Index: 237
+Kaipo Revisited                                                               Seed: 200   Index: 237
+Overworld (Kaipo)                                                             Seed: 200   Index: 237
+Overworld (Damcyan)                                                           Seed: 200   Index: 237
+Mt.Hobs-West                                                                  Seed: 200   Index: 237
+Mt.Hobs Summit                                                                Seed: 217   Index:  20
+  Step   2: 24 / Spirit x2, Skelton x2 (9.087s)
+Battle: MomBomb                                                               Seed: 217   Index:  35
+Mt.Hobs Summit                                                                Seed: 217   Index:  35
+Mt.Hobs-East                                                                  Seed: 217   Index:  41
+  Step  33: 25 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 217   Index:  87
+  Step  14: 26 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  46: 27 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  52: 28 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 217   Index: 171
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 217   Index: 231
+Fabul Boat and Leviatan                                                       Seed: 217   Index: 238
+Overworld (Mysidia)                                                           Seed: 217   Index: 238
+Mysidia                                                                       Seed: 217   Index: 247
+Overworld (Mysidia)                                                           Seed: 217   Index: 247
+Overworld (Mt.Ordeals)                                                        Seed: 234   Index:   1
+  Step   2: 29 / Raven x1 (8.356s)
+  Step  33: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 234   Index:  95
+  Step  36: 31 / Spirit x2, Skelton x2 (8.285s)
+  Step  42: 32 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 234   Index: 138
+  Step  12: 33 / Lilith x1, Red Bone x2 (9.259s)
+Recruit Tellah                                                                Seed: 234   Index: 161
+Mt.Ordeals-3rd station                                                        Seed: 234   Index: 161
+  Step   2: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed: 234   Index: 166
+  Step  24: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed: 234   Index: 208
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 234   Index: 225
+Mt.Ordeals Summit                                                             Seed: 234   Index: 225
+  Step   2: 36 / Revenant x1, Ghoul x3 (8.611s)
+Paladin                                                                       Seed: 234   Index: 229
+Mt.Ordeals Summit                                                             Seed: 234   Index: 229
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 234   Index: 251
+  Step   3: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step   5: 38 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 251   Index:  37
+Mt.Ordeals                                                                    Seed: 251   Index:  67
+  Step  30: 39 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed: 251   Index: 111
+Take Chocobo to Mysidia                                                       Seed: 251   Index: 124
+Overworld (Mysidia)                                                           Seed: 251   Index: 124
+Town of Baron Serpent Road                                                    Seed: 251   Index: 124
+Credit Warp Fight Search                                                      Seed: 251   Index: 128
+  Overworld (Baron)                                                           Seed: 251   Index: 128
+    Extra Steps: 34
+    Step   1: 40 / Imp x3, SwordRat x1 (7.227s)
+    Step  33: 41 / Imp x3, SwordRat x1 (7.227s)
+   (Step  52: 42 / Imp x3, SwordRat x1)
+   (Step  65: 43 / Imp x3, SwordRat x1)
+   (Step  97: 44 / Imp x3)
+   (Step 141: 45 / Eagle x3)
+   (Step 163: 46 / Eagle x3)
+   (Step 192: 47 / Imp x4)
+
+Encounter Time:      312.497s
+Other Time:          499.012s
+Total Time:          811.509s
+
+Base Total Time:     811.509s
+Time Saved:          0.000s
+
+Optional Steps:      0
+Extra Steps:         34
+Encounters:          41
+
+Base Encounters:     41
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/167.txt
+++ b/data/routes/cw/167.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	167
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49293603
+VARS	FFFFFFFF:20 E309700:32
+
+Overworld (Kaipo)                                                             Seed: 167   Index:   0
+Overworld (Kaipo)                                                             Seed: 167   Index:   1
+  Step   4: 1 / Sand Man x4 (7.172s)
+  Step  10: 2 / SandMoth x2, Larva x2 (7.009s)
+  Step  15: 3 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 167   Index:  37
+Overworld (Kaipo)                                                             Seed: 167   Index:  37
+Watery Pass-South B1F                                                         Seed: 167   Index:  69
+  Step  26: 4 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed: 167   Index: 101
+Watery Pass-South B1F                                                         Seed: 167   Index: 101
+Watery Pass-South B2F                                                         Seed: 167   Index: 121
+  Step  50: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  68: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  75: 7 / Pike x2, EvilShel x2 (7.149s)
+  Step  83: 8 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 167   Index: 211
+Watery Pass-South B2F                                                         Seed: 167   Index: 215
+Watery Pass-South B3F                                                         Seed: 167   Index: 254
+  Step  23: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B2F                                                         Seed: 184   Index:  32
+  Step   9: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 184   Index:  53
+Overworld (Kaipo)                                                             Seed: 184   Index: 113
+Waterfalls B1F                                                                Seed: 184   Index: 122
+Waterfalls B2F                                                                Seed: 184   Index: 123
+  Step  22: 11 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 184   Index: 168
+  Step   4: 12 / Aligator x2 (7.544s)
+  Step  19: 13 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 184   Index: 205
+Waterfalls Lake                                                               Seed: 184   Index: 205
+Overworld (Kaipo)                                                             Seed: 184   Index: 206
+Overworld (Damcyan)                                                           Seed: 184   Index: 217
+Damcyan                                                                       Seed: 184   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 184   Index: 228
+Antlion B1F                                                                   Seed: 184   Index: 228
+  Step   5: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  24: 15 / Basilisk x1, Imp x3 (6.775s)
+  Step  34: 16 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 201   Index:  10
+  Antlion B2F                                                                 Seed: 201   Index:  10
+    Step   9: 17 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed: 201   Index:  90
+  Step  13: 18 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed: 201   Index: 104
+Antlion's Nest                                                                Seed: 201   Index: 104
+  Step   5: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed: 201   Index: 119
+  Antlion B2F                                                                 Seed: 201   Index: 119
+    Step  16: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  32: 21 / SandWorm x2 (6.858s)
+    Step  80: 22 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 201   Index: 199
+  Step  22: 23 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed: 201   Index: 237
+Overworld (Kaipo)                                                             Seed: 201   Index: 237
+Kaipo Revisited                                                               Seed: 201   Index: 237
+Overworld (Kaipo)                                                             Seed: 201   Index: 237
+Overworld (Damcyan)                                                           Seed: 201   Index: 237
+Mt.Hobs-West                                                                  Seed: 201   Index: 237
+Mt.Hobs Summit                                                                Seed: 218   Index:  20
+  Step   2: 24 / Spirit x2, Skelton x2 (9.087s)
+Battle: MomBomb                                                               Seed: 218   Index:  35
+Mt.Hobs Summit                                                                Seed: 218   Index:  35
+  Step   1: 25 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed: 218   Index:  41
+  Step  33: 26 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 218   Index:  87
+  Step  14: 27 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  46: 28 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  52: 29 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 218   Index: 171
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 218   Index: 231
+Fabul Boat and Leviatan                                                       Seed: 218   Index: 238
+Overworld (Mysidia)                                                           Seed: 218   Index: 238
+Mysidia                                                                       Seed: 218   Index: 247
+Overworld (Mysidia)                                                           Seed: 218   Index: 247
+Overworld (Mt.Ordeals)                                                        Seed: 235   Index:   1
+  Step  33: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  65: 31 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 235   Index:  95
+  Step  36: 32 / Red Bone x1, Skelton x3 (8.067s)
+  Step  42: 33 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed: 235   Index: 138
+  Step  12: 34 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed: 235   Index: 161
+Mt.Ordeals-3rd station                                                        Seed: 235   Index: 161
+  Step   2: 35 / Zombie x2, Ghoul x2 (7.616s)
+Mt.Ordeals-7th station                                                        Seed: 235   Index: 166
+Mt.Ordeals Summit                                                             Seed: 235   Index: 208
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 235   Index: 225
+Mt.Ordeals Summit                                                             Seed: 235   Index: 225
+  Step   2: 36 / Revenant x1, Ghoul x3 (8.611s)
+Paladin                                                                       Seed: 235   Index: 229
+Mt.Ordeals Summit                                                             Seed: 235   Index: 229
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 235   Index: 251
+  Step   3: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step   5: 38 / Revenant x1, Ghoul x3 (8.489s)
+  Step  42: 39 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed: 252   Index:  37
+Mt.Ordeals                                                                    Seed: 252   Index:  67
+  Step  30: 40 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 252   Index: 111
+Take Chocobo to Mysidia                                                       Seed: 252   Index: 124
+Overworld (Mysidia)                                                           Seed: 252   Index: 124
+Town of Baron Serpent Road                                                    Seed: 252   Index: 124
+  Extra Steps: 32
+Credit Warp Fight Search                                                      Seed: 252   Index: 160
+  Overworld (Baron)                                                           Seed: 252   Index: 160
+    Extra Steps: 20
+    Step   1: 41 / Imp x3, SwordRat x1 (7.227s)
+    Step  20: 42 / Imp x3, SwordRat x1 (7.227s)
+   (Step  33: 43 / Imp x3, SwordRat x1)
+   (Step  65: 44 / Imp x3)
+   (Step 109: 45 / Eagle x3)
+   (Step 131: 46 / Eagle x3)
+   (Step 160: 47 / Imp x4)
+   (Step 254: 48 / Imp x3)
+
+Encounter Time:      320.133s
+Other Time:          500.076s
+Total Time:          820.209s
+
+Base Total Time:     828.729s
+Time Saved:          8.519s
+
+Optional Steps:      0
+Extra Steps:         52
+Encounters:          42
+
+Base Encounters:     42
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/168.txt
+++ b/data/routes/cw/168.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	168
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48697340
+VARS	FFFFFFFF:14 E302500:2 E302600:9 E307100:10 E307400:12 E308700:1 E308702:1 E309700:16
+
+Overworld (Kaipo)                                                             Seed: 168   Index:   0
+Overworld (Kaipo)                                                             Seed: 168   Index:   1
+  Step   4: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  10: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 168   Index:  37
+Overworld (Kaipo)                                                             Seed: 168   Index:  37
+Watery Pass-South B1F                                                         Seed: 168   Index:  69
+  Step  26: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 168   Index: 101
+Watery Pass-South B1F                                                         Seed: 168   Index: 101
+Watery Pass-South B2F                                                         Seed: 168   Index: 121
+  Step  50: 4 / CaveToad x3 (7.014s)
+  Step  55: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  68: 6 / Pike x2, EvilShel x2 (7.149s)
+  Step  83: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 168   Index: 211
+Watery Pass-South B2F                                                         Seed: 168   Index: 215
+Watery Pass-South B3F                                                         Seed: 168   Index: 254
+  Extra Steps: 10
+  Step  23: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 185   Index:  42
+  Step  21: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B1F                                                         Seed: 185   Index:  63
+Overworld (Kaipo)                                                             Seed: 185   Index: 123
+Waterfalls B1F                                                                Seed: 185   Index: 132
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed: 185   Index: 145
+  Step  27: 10 / Zombie x6 (7.489s)
+  Step  42: 11 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 185   Index: 190
+Battle: Octomamm                                                              Seed: 185   Index: 227
+Waterfalls Lake                                                               Seed: 185   Index: 227
+Overworld (Kaipo)                                                             Seed: 185   Index: 228
+  Step   5: 12 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 185   Index: 239
+Damcyan                                                                       Seed: 185   Index: 243
+  Optional Steps: 0
+  Extra Steps: 2
+Overworld (Damcyan)                                                           Seed: 185   Index: 252
+Antlion B1F                                                                   Seed: 185   Index: 252
+  Step  10: 13 / Turtle x2 (7.487s)
+Antlion B2F Inward Direct                                                     Seed: 202   Index:  34
+  Antlion B2F                                                                 Seed: 202   Index:  34
+    Step   4: 14 / Basilisk x1, Imp x3 (6.775s)
+    Step  69: 15 / Basilisk x1, Turtle x1 (7.110s)
+    Step  75: 16 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 202   Index: 114
+Battle: Antlion                                                               Seed: 202   Index: 128
+Antlion's Nest                                                                Seed: 202   Index: 128
+  Step   7: 17 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B2F Outward Direct                                                    Seed: 202   Index: 143
+  Antlion B2F                                                                 Seed: 202   Index: 143
+    Step   8: 18 / Weeper x2 (7.132s)
+    Step  56: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  78: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 202   Index: 223
+Overworld (Damcyan)                                                           Seed: 219   Index:   5
+Overworld (Kaipo)                                                             Seed: 219   Index:   5
+Kaipo Revisited                                                               Seed: 219   Index:   5
+Overworld (Kaipo)                                                             Seed: 219   Index:   5
+Overworld (Damcyan)                                                           Seed: 219   Index:   5
+Mt.Hobs-West                                                                  Seed: 219   Index:   5
+  Step  31: 21 / GrayBomb x2, Bomb x2 (10.938s)
+Mt.Hobs Summit                                                                Seed: 219   Index:  44
+Battle: MomBomb                                                               Seed: 219   Index:  59
+Mt.Hobs Summit                                                                Seed: 219   Index:  59
+Mt.Hobs-East                                                                  Seed: 219   Index:  65
+  Step   9: 22 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  36: 23 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 219   Index: 111
+  Step  17: 24 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  22: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  64: 26 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 219   Index: 195
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed: 236   Index:   8
+Fabul Boat and Leviatan                                                       Seed: 236   Index:  15
+Overworld (Mysidia)                                                           Seed: 236   Index:  15
+Mysidia                                                                       Seed: 236   Index:  24
+Overworld (Mysidia)                                                           Seed: 236   Index:  24
+  Step  10: 27 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed: 236   Index:  34
+  Step  32: 28 / Raven x1 (8.356s)
+  Step  64: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 236   Index: 128
+  Step   9: 30 / Red Bone x1, Skelton x3 (8.067s)
+  Step  22: 31 / Spirit x2, Skelton x2 (8.285s)
+  Step  35: 32 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 236   Index: 171
+Recruit Tellah                                                                Seed: 236   Index: 194
+Mt.Ordeals-3rd station                                                        Seed: 236   Index: 194
+Mt.Ordeals-7th station                                                        Seed: 236   Index: 199
+  Step  28: 33 / Soul x3, Ghoul x1, Revenant x1 (9.933s)
+Mt.Ordeals Summit                                                             Seed: 236   Index: 241
+  Optional Steps: 1
+  Step  13: 34 / Lilith x1 (8.745s)
+  Step  15: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed: 253   Index:   3
+Mt.Ordeals Summit                                                             Seed: 253   Index:   3
+Paladin                                                                       Seed: 253   Index:   7
+Mt.Ordeals Summit                                                             Seed: 253   Index:   7
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed: 253   Index:  30
+  Step   7: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed: 253   Index:  72
+  Step  25: 37 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed: 253   Index: 102
+  Step  18: 38 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed: 253   Index: 146
+Take Chocobo to Mysidia                                                       Seed: 253   Index: 159
+Overworld (Mysidia)                                                           Seed: 253   Index: 159
+Town of Baron Serpent Road                                                    Seed: 253   Index: 159
+  Extra Steps: 16
+Credit Warp Fight Search                                                      Seed: 253   Index: 179
+  Overworld (Baron)                                                           Seed: 253   Index: 179
+    Extra Steps: 14
+    Step   1: 39 / Imp x3, SwordRat x1 (7.227s)
+    Step  14: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  46: 41 / Imp x3, SwordRat x1)
+   (Step  90: 42 / Imp x3, SwordRat x1)
+   (Step 106: 43 / Imp x3, SwordRat x1)
+   (Step 112: 44 / Imp x3)
+   (Step 141: 45 / Eagle x3)
+   (Step 235: 46 / Eagle x3)
+
+Encounter Time:      311.276s
+Other Time:          499.012s
+Total Time:          810.288s
+
+Base Total Time:     834.619s
+Time Saved:          24.331s
+
+Optional Steps:      11
+Extra Steps:         54
+Encounters:          40
+
+Base Encounters:     42
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/169.txt
+++ b/data/routes/cw/169.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	169
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49836955
+VARS	FFFFFFFF:8 C307800:1 E302500:2 E302600:28 E305400:4 E307200:6 E307400:12 E307B00:68 E308000:14 E308700:1 E308702:1 E309700:14
+
+Overworld (Kaipo)                                                             Seed: 169   Index:   0
+Overworld (Kaipo)                                                             Seed: 169   Index:   1
+  Step   4: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  10: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 169   Index:  37
+Overworld (Kaipo)                                                             Seed: 169   Index:  37
+Watery Pass-South B1F                                                         Seed: 169   Index:  69
+  Step  26: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 169   Index: 101
+Watery Pass-South B1F                                                         Seed: 169   Index: 101
+Watery Pass-South B2F                                                         Seed: 169   Index: 121
+  Step  50: 4 / CaveToad x3 (7.014s)
+  Step  55: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  68: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  83: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 169   Index: 211
+  Extra Steps: 4
+Watery Pass-South B2F                                                         Seed: 169   Index: 219
+Watery Pass-South B3F                                                         Seed: 186   Index:   2
+  Step  19: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 186   Index:  36
+  Extra Steps: 6
+  Step   4: 9 / Pike x3 (7.152s)
+  Step  27: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 186   Index:  63
+Overworld (Kaipo)                                                             Seed: 186   Index: 123
+Waterfalls B1F                                                                Seed: 186   Index: 132
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed: 186   Index: 145
+  Step  27: 11 / Jelly x4 (7.324s)
+  Step  42: 12 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed: 186   Index: 190
+Battle: Octomamm                                                              Seed: 186   Index: 227
+Waterfalls Lake                                                               Seed: 186   Index: 227
+Overworld (Kaipo)                                                             Seed: 186   Index: 228
+  Step   5: 13 / SandMoth x2, Larva x2 (7.188s)
+Overworld (Damcyan)                                                           Seed: 186   Index: 239
+Damcyan                                                                       Seed: 186   Index: 243
+  Optional Steps: 0
+  Extra Steps: 2
+Overworld (Damcyan)                                                           Seed: 186   Index: 252
+Antlion B1F                                                                   Seed: 186   Index: 252
+  Step  10: 14 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 203   Index:  34
+  Antlion B2F                                                                 Seed: 203   Index:  34
+    Step   4: 15 / Basilisk x1, Turtle x1 (7.110s)
+  Antlion B2F Treasure Room                                                   Seed: 203   Index:  67
+    Extra Steps: 68
+  Antlion B2F                                                                 Seed: 203   Index: 135
+    Step  16: 16 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 203   Index: 187
+  Step  12: 17 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 203   Index: 201
+Antlion's Nest                                                                Seed: 203   Index: 201
+Antlion B2F Outward Direct                                                    Seed: 203   Index: 216
+  Antlion B2F                                                                 Seed: 203   Index: 216
+    Step  76: 18 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 220   Index:  40
+  Step  34: 19 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed: 220   Index:  78
+Overworld (Kaipo)                                                             Seed: 220   Index:  78
+Kaipo Revisited                                                               Seed: 220   Index:  78
+Overworld (Kaipo)                                                             Seed: 220   Index:  78
+Overworld (Damcyan)                                                           Seed: 220   Index:  78
+Mt.Hobs-West                                                                  Seed: 220   Index:  78
+  Step  22: 20 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 220   Index: 117
+  Step  11: 21 / Gargoyle x2 (8.791s)
+Battle: MomBomb                                                               Seed: 220   Index: 132
+Mt.Hobs Summit                                                                Seed: 220   Index: 132
+  Step   1: 22 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed: 220   Index: 138
+  Extra Steps: 14
+  Step  37: 23 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  59: 24 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 220   Index: 198
+  Step   3: 25 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 237   Index:  26
+  Optional Steps: 10
+  Extra Steps: 18
+Overworld (Fabul)                                                             Seed: 237   Index: 114
+Fabul Boat and Leviatan                                                       Seed: 237   Index: 121
+Overworld (Mysidia)                                                           Seed: 237   Index: 121
+Mysidia                                                                       Seed: 237   Index: 130
+Overworld (Mysidia)                                                           Seed: 237   Index: 130
+Overworld (Mt.Ordeals)                                                        Seed: 237   Index: 140
+  Step  10: 26 / Raven x1 (8.356s)
+  Step  23: 27 / Raven x1 (8.356s)
+  Step  87: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 237   Index: 234
+  Step  20: 29 / Spirit x2, Skelton x2 (8.285s)
+  Step  22: 30 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 254   Index:  21
+  Step  16: 31 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed: 254   Index:  44
+Mt.Ordeals-3rd station                                                        Seed: 254   Index:  44
+Mt.Ordeals-7th station                                                        Seed: 254   Index:  49
+Mt.Ordeals Summit                                                             Seed: 254   Index:  91
+  Optional Steps: 1
+  Step   6: 32 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed: 254   Index: 109
+Mt.Ordeals Summit                                                             Seed: 254   Index: 109
+Paladin                                                                       Seed: 254   Index: 113
+Mt.Ordeals Summit                                                             Seed: 254   Index: 113
+  Optional Steps: 1
+  Step   7: 33 / Lilith x2 (9.169s)
+Mt.Ordeals-7th station                                                        Seed: 254   Index: 136
+  Step   8: 34 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed: 254   Index: 178
+  Step   2: 35 / Zombie x2, Ghoul x2 (7.552s)
+  Step  15: 36 / Spirit x2, Soul x2, Red Bone x2 (9.471s)
+Mt.Ordeals                                                                    Seed: 254   Index: 208
+  Step  17: 37 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed: 254   Index: 252
+Take Chocobo to Mysidia                                                       Seed:  15   Index:   9
+Overworld (Mysidia)                                                           Seed:  15   Index:   9
+Town of Baron Serpent Road                                                    Seed:  15   Index:   9
+  Extra Steps: 14
+Credit Warp Fight Search                                                      Seed:  15   Index:  27
+  Overworld (Baron)                                                           Seed:  15   Index:  27
+    Extra Steps: 8
+    Step   2: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step   8: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  37: 40 / Imp x3, SwordRat x1)
+   (Step 131: 41 / Imp x3, SwordRat x1)
+   (Step 185: 42 / Imp x3, SwordRat x1)
+   (Step 195: 43 / Imp x3, SwordRat x1)
+   (Step 236: 44 / Imp x3)
+
+Encounter Time:      302.751s
+Other Time:          526.500s
+Total Time:          829.250s
+
+Base Total Time:     923.827s
+Time Saved:          94.577s
+
+Optional Steps:      12
+Extra Steps:         146
+Encounters:          39
+
+Base Encounters:     47
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/170.txt
+++ b/data/routes/cw/170.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	170
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49220849
+VARS	FFFFFFFF:16
+
+Overworld (Kaipo)                                                             Seed: 170   Index:   0
+Overworld (Kaipo)                                                             Seed: 170   Index:   1
+  Step   4: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed: 170   Index:  37
+Overworld (Kaipo)                                                             Seed: 170   Index:  37
+  Step   5: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 170   Index:  69
+  Step  26: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 170   Index: 101
+Watery Pass-South B1F                                                         Seed: 170   Index: 101
+Watery Pass-South B2F                                                         Seed: 170   Index: 121
+  Step  50: 4 / CaveToad x3 (7.014s)
+  Step  55: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  68: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 170   Index: 211
+Watery Pass-South B2F                                                         Seed: 170   Index: 215
+  Step   4: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed: 170   Index: 254
+Watery Pass-North B2F                                                         Seed: 187   Index:  32
+  Step   8: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 187   Index:  53
+  Step  10: 9 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 187   Index: 113
+Waterfalls B1F                                                                Seed: 187   Index: 122
+Waterfalls B2F                                                                Seed: 187   Index: 123
+  Step  22: 10 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 187   Index: 168
+  Step   4: 11 / Jelly x4 (7.324s)
+  Step  23: 12 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed: 187   Index: 205
+Waterfalls Lake                                                               Seed: 187   Index: 205
+Overworld (Kaipo)                                                             Seed: 187   Index: 206
+Overworld (Damcyan)                                                           Seed: 187   Index: 217
+Damcyan                                                                       Seed: 187   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 187   Index: 228
+Antlion B1F                                                                   Seed: 187   Index: 228
+  Step   5: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+  Step  24: 14 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  34: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed: 204   Index:  10
+  Antlion B2F                                                                 Seed: 204   Index:  10
+    Step  28: 16 / Cream x4 (7.552s)
+    Step  60: 17 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed: 204   Index:  90
+Battle: Antlion                                                               Seed: 204   Index: 104
+Antlion's Nest                                                                Seed: 204   Index: 104
+  Step   5: 18 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed: 204   Index: 119
+  Antlion B2F                                                                 Seed: 204   Index: 119
+    Step  16: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  32: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  80: 21 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 204   Index: 199
+Overworld (Damcyan)                                                           Seed: 204   Index: 237
+Overworld (Kaipo)                                                             Seed: 204   Index: 237
+Kaipo Revisited                                                               Seed: 204   Index: 237
+Overworld (Kaipo)                                                             Seed: 204   Index: 237
+Overworld (Damcyan)                                                           Seed: 204   Index: 237
+Mt.Hobs-West                                                                  Seed: 204   Index: 237
+  Step   7: 22 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 221   Index:  20
+Battle: MomBomb                                                               Seed: 221   Index:  35
+Mt.Hobs Summit                                                                Seed: 221   Index:  35
+  Step   1: 23 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed: 221   Index:  41
+  Step  33: 24 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 221   Index:  87
+  Step  13: 25 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  14: 26 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  41: 27 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  45: 28 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  46: 29 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 221   Index: 171
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 221   Index: 231
+Fabul Boat and Leviatan                                                       Seed: 221   Index: 238
+Overworld (Mysidia)                                                           Seed: 221   Index: 238
+Mysidia                                                                       Seed: 221   Index: 247
+Overworld (Mysidia)                                                           Seed: 221   Index: 247
+Overworld (Mt.Ordeals)                                                        Seed: 238   Index:   1
+  Step  33: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  65: 31 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 238   Index:  95
+  Step   3: 32 / Red Bone x1, Skelton x3 (8.067s)
+  Step  18: 33 / Lilith x1, Red Bone x2 (9.259s)
+Mt.Ordeals-3rd station                                                        Seed: 238   Index: 138
+  Step  12: 34 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed: 238   Index: 161
+Mt.Ordeals-3rd station                                                        Seed: 238   Index: 161
+  Step   1: 35 / Zombie x2, Ghoul x2 (7.616s)
+Mt.Ordeals-7th station                                                        Seed: 238   Index: 166
+Mt.Ordeals Summit                                                             Seed: 238   Index: 208
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed: 238   Index: 225
+Mt.Ordeals Summit                                                             Seed: 238   Index: 225
+  Step   2: 36 / Revenant x1, Ghoul x3 (8.611s)
+Paladin                                                                       Seed: 238   Index: 229
+Mt.Ordeals Summit                                                             Seed: 238   Index: 229
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed: 238   Index: 251
+  Step   3: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step   5: 38 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  42: 39 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed: 255   Index:  37
+Mt.Ordeals                                                                    Seed: 255   Index:  67
+  Step  30: 40 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed: 255   Index: 111
+  Step   9: 41 / Imp Cap. x4, Imp x2 (8.400s)
+Take Chocobo to Mysidia                                                       Seed: 255   Index: 124
+Overworld (Mysidia)                                                           Seed: 255   Index: 124
+Town of Baron Serpent Road                                                    Seed: 255   Index: 124
+Credit Warp Fight Search                                                      Seed: 255   Index: 128
+  Overworld (Baron)                                                           Seed: 255   Index: 128
+    Extra Steps: 16
+    Step   2: 42 / Imp x3, SwordRat x1 (7.227s)
+    Step  16: 43 / Imp x3, SwordRat x1 (7.227s)
+   (Step  52: 44 / Imp x3)
+   (Step 130: 45 / Eagle x3)
+   (Step 141: 46 / Eagle x3)
+   (Step 157: 47 / Imp x4)
+   (Step 192: 48 / Imp x3)
+
+Encounter Time:      329.571s
+Other Time:          489.427s
+Total Time:          818.999s
+
+Base Total Time:     818.999s
+Time Saved:          0.000s
+
+Optional Steps:      0
+Extra Steps:         16
+Encounters:          43
+
+Base Encounters:     43
+Encounters Saved:    0
+
+Number of Variables: 54

--- a/data/routes/cw/171.txt
+++ b/data/routes/cw/171.txt
@@ -1,0 +1,156 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	171
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	51022671
+VARS	FFFFFFFF:28 C307800:1 E302500:76 E302600:10 E305400:4 E307200:6 E307400:12 E307B00:10 E308000:2 E308501:2 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 171   Index:   0
+Overworld (Kaipo)                                                             Seed: 171   Index:   1
+  Step   3: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step   4: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 171   Index:  37
+Overworld (Kaipo)                                                             Seed: 171   Index:  37
+  Step   5: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 171   Index:  69
+  Step  26: 4 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed: 171   Index: 101
+Watery Pass-South B1F                                                         Seed: 171   Index: 101
+Watery Pass-South B2F                                                         Seed: 171   Index: 121
+  Step  50: 5 / Pike x2, EvilShel x2 (7.149s)
+  Step  55: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 171   Index: 211
+  Extra Steps: 4
+Watery Pass-South B2F                                                         Seed: 171   Index: 219
+Watery Pass-South B3F                                                         Seed: 188   Index:   2
+Watery Pass-North B2F                                                         Seed: 188   Index:  36
+  Extra Steps: 6
+  Step   4: 7 / Zombie x4 (7.148s)
+  Step  27: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 188   Index:  63
+  Step  41: 9 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 188   Index: 123
+Waterfalls B1F                                                                Seed: 188   Index: 132
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed: 188   Index: 145
+  Step  27: 10 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 188   Index: 190
+  Step   1: 11 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 188   Index: 227
+Waterfalls Lake                                                               Seed: 188   Index: 227
+Overworld (Kaipo)                                                             Seed: 188   Index: 228
+  Step   5: 12 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 188   Index: 239
+Damcyan                                                                       Seed: 188   Index: 243
+  Optional Steps: 0
+  Extra Steps: 76
+Overworld (Damcyan)                                                           Seed: 205   Index:  70
+Antlion B1F                                                                   Seed: 205   Index:  70
+Antlion B2F Inward Charm Room Steps                                           Seed: 205   Index: 108
+  Antlion B2F                                                                 Seed: 205   Index: 108
+    Step   1: 13 / SandWorm x2 (6.841s)
+    Step  26: 14 / Basilisk x1, Imp x3 (6.775s)
+  Antlion B2F Treasure Room                                                   Seed: 205   Index: 141
+    Extra Steps: 10
+  Antlion B2F                                                                 Seed: 205   Index: 151
+    Step  48: 15 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 205   Index: 203
+Battle: Antlion                                                               Seed: 205   Index: 217
+Antlion's Nest                                                                Seed: 205   Index: 217
+Antlion B2F Outward Direct                                                    Seed: 205   Index: 232
+  Antlion B2F                                                                 Seed: 205   Index: 232
+    Step  12: 16 / Cream x4 (7.523s)
+    Step  60: 17 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed: 222   Index:  56
+  Step  18: 18 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 222   Index:  94
+Overworld (Kaipo)                                                             Seed: 222   Index:  94
+Kaipo Revisited                                                               Seed: 222   Index:  94
+Overworld (Kaipo)                                                             Seed: 222   Index:  94
+Overworld (Damcyan)                                                           Seed: 222   Index:  94
+Mt.Hobs-West                                                                  Seed: 222   Index:  94
+  Step   6: 19 / Bomb x3 (8.832s)
+  Step  34: 20 / Bomb x3 (8.832s)
+  Step  38: 21 / GrayBomb x2, Bomb x2 (10.938s)
+Mt.Hobs Summit                                                                Seed: 222   Index: 133
+Battle: MomBomb                                                               Seed: 222   Index: 148
+Mt.Hobs Summit                                                                Seed: 222   Index: 148
+Mt.Hobs-East                                                                  Seed: 222   Index: 154
+  Extra Steps: 2
+  Step  10: 22 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  21: 23 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  43: 24 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 222   Index: 202
+Fabul                                                                         Seed: 239   Index:  30
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 239   Index: 100
+Fabul Boat and Leviatan                                                       Seed: 239   Index: 107
+Overworld (Mysidia)                                                           Seed: 239   Index: 107
+  Step   6: 25 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 239   Index: 116
+Overworld (Mysidia)                                                           Seed: 239   Index: 116
+Overworld (Mt.Ordeals)                                                        Seed: 239   Index: 126
+  Step  24: 26 / Raven x1 (8.356s)
+  Step  36: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  37: 28 / Raven x1 (8.356s)
+  Step  68: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 239   Index: 220
+  Step   7: 30 / Red Bone x1, Skelton x3 (8.067s)
+  Step  34: 31 / Spirit x2, Skelton x2 (8.285s)
+  Step  36: 32 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:   0   Index:   7
+Recruit Tellah                                                                Seed:   0   Index:  30
+Mt.Ordeals-3rd station                                                        Seed:   0   Index:  30
+  Extra Steps: 2
+  Step   7: 33 / Ghoul x1, Red Bone x2, Skelton x2 (8.832s)
+Mt.Ordeals-7th station                                                        Seed:   0   Index:  37
+Mt.Ordeals Summit                                                             Seed:   0   Index:  79
+  Optional Steps: 1
+  Step   8: 34 / Lilith x1 (8.745s)
+  Step  18: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed:   0   Index:  97
+Mt.Ordeals Summit                                                             Seed:   0   Index:  97
+Paladin                                                                       Seed:   0   Index: 101
+Mt.Ordeals Summit                                                             Seed:   0   Index: 101
+  Optional Steps: 1
+  Step  19: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed:   0   Index: 124
+  Step   6: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  20: 38 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:   0   Index: 166
+  Step  14: 39 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:   0   Index: 196
+Overworld (Mt.Ordeals)                                                        Seed:   0   Index: 240
+Take Chocobo to Mysidia                                                       Seed:   0   Index: 253
+Overworld (Mysidia)                                                           Seed:   0   Index: 253
+Town of Baron Serpent Road                                                    Seed:   0   Index: 253
+Credit Warp Fight Search                                                      Seed:  17   Index:   1
+  Overworld (Baron)                                                           Seed:  17   Index:   1
+    Extra Steps: 28
+    Step   1: 40 / Imp x3, SwordRat x1 (7.227s)
+    Step  28: 41 / Imp x3, SwordRat x1 (7.227s)
+   (Step  63: 42 / Imp x3, SwordRat x1)
+   (Step  92: 43 / Eagle x3)
+   (Step 157: 44 / Imp x3)
+   (Step 211: 45 / Eagle x3)
+   (Step 221: 46 / Eagle x3)
+
+Encounter Time:      318.753s
+Other Time:          530.227s
+Total Time:          848.980s
+
+Base Total Time:     912.129s
+Time Saved:          63.150s
+
+Optional Steps:      12
+Extra Steps:         140
+Encounters:          41
+
+Base Encounters:     47
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/172.txt
+++ b/data/routes/cw/172.txt
@@ -1,0 +1,156 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	172
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50909499
+VARS	FFFFFFFF:28 C307801:1 E000202:14 E302600:10 E305400:4 E307200:6 E307400:58 E307B01:6 E308000:22 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 172   Index:   0
+Overworld (Kaipo)                                                             Seed: 172   Index:   1
+  Step   3: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step   4: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 172   Index:  37
+Overworld (Kaipo)                                                             Seed: 172   Index:  37
+  Step   5: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 172   Index:  69
+  Step  26: 4 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed: 172   Index: 101
+Watery Pass-South B1F                                                         Seed: 172   Index: 101
+Watery Pass-South B2F                                                         Seed: 172   Index: 121
+  Step   1: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  50: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  55: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 172   Index: 211
+  Extra Steps: 4
+Watery Pass-South B2F                                                         Seed: 172   Index: 219
+Watery Pass-South B3F                                                         Seed: 189   Index:   2
+  Step  16: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 189   Index:  36
+  Extra Steps: 6
+  Step   4: 9 / Pike x3 (7.152s)
+  Step  27: 10 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 189   Index:  63
+  Step  41: 11 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 189   Index: 123
+Waterfalls B1F                                                                Seed: 189   Index: 132
+  Extra Steps: 58
+Waterfalls B2F                                                                Seed: 189   Index: 191
+  Step  42: 12 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed: 189   Index: 236
+  Step  26: 13 / Mad Toad x4 (7.317s)
+Battle: Octomamm                                                              Seed: 206   Index:  17
+Waterfalls Lake                                                               Seed: 206   Index:  17
+Overworld (Kaipo)                                                             Seed: 206   Index:  18
+Overworld (Damcyan)                                                           Seed: 206   Index:  29
+Damcyan                                                                       Seed: 206   Index:  33
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 206   Index:  40
+Antlion B1F                                                                   Seed: 206   Index:  40
+  Step  30: 14 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Direct                                                     Seed: 206   Index:  78
+  Antlion B2F                                                                 Seed: 206   Index:  78
+    Step  56: 15 / Weeper x2 (7.114s)
+    Step  73: 16 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 206   Index: 158
+Battle: Antlion                                                               Seed: 206   Index: 172
+Antlion's Nest                                                                Seed: 206   Index: 172
+Antlion B2F Outward Charm Room Steps                                          Seed: 206   Index: 187
+  Antlion B2F                                                                 Seed: 206   Index: 187
+    Step  12: 17 / Basilisk x1, Turtle x1 (7.124s)
+  Antlion B2F Treasure Room                                                   Seed: 206   Index: 238
+    Extra Steps: 6
+  Antlion B2F                                                                 Seed: 206   Index: 244
+Antlion B1F                                                                   Seed: 223   Index:  22
+  Step  14: 18 / Turtle x2 (7.464s)
+  Step  33: 19 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed: 223   Index:  60
+Overworld (Kaipo)                                                             Seed: 223   Index:  60
+  Extra Steps: 14
+  Step  14: 20 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed: 223   Index:  74
+Overworld (Kaipo)                                                             Seed: 223   Index:  74
+Overworld (Damcyan)                                                           Seed: 223   Index:  74
+Mt.Hobs-West                                                                  Seed: 223   Index:  74
+  Step  26: 21 / GrayBomb x2, Bomb x2 (10.938s)
+Mt.Hobs Summit                                                                Seed: 223   Index: 113
+  Step  15: 22 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed: 223   Index: 128
+Mt.Hobs Summit                                                                Seed: 223   Index: 128
+  Step   4: 23 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed: 223   Index: 134
+  Extra Steps: 22
+  Step  30: 24 / Turtle x2 (7.432s)
+  Step  41: 25 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 223   Index: 202
+Fabul                                                                         Seed: 240   Index:  30
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 240   Index: 100
+Fabul Boat and Leviatan                                                       Seed: 240   Index: 107
+Overworld (Mysidia)                                                           Seed: 240   Index: 107
+  Step   6: 26 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 240   Index: 116
+Overworld (Mysidia)                                                           Seed: 240   Index: 116
+Overworld (Mt.Ordeals)                                                        Seed: 240   Index: 126
+  Step  24: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  36: 28 / Raven x1 (8.356s)
+  Step  68: 29 / Raven x1 (8.356s)
+  Step  84: 30 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 240   Index: 220
+  Step  34: 31 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed:   1   Index:   7
+Recruit Tellah                                                                Seed:   1   Index:  30
+Mt.Ordeals-3rd station                                                        Seed:   1   Index:  30
+Mt.Ordeals-7th station                                                        Seed:   1   Index:  35
+  Step   2: 32 / Revenant x1, Ghoul x3 (8.914s)
+  Step  21: 33 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed:   1   Index:  77
+  Optional Steps: 1
+  Step  10: 34 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed:   1   Index:  95
+Mt.Ordeals Summit                                                             Seed:   1   Index:  95
+  Step   2: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.808s)
+Paladin                                                                       Seed:   1   Index:  99
+Mt.Ordeals Summit                                                             Seed:   1   Index:  99
+  Optional Steps: 1
+  Step  21: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed:   1   Index: 122
+  Step   8: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  22: 38 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:   1   Index: 164
+  Step  16: 39 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:   1   Index: 194
+Overworld (Mt.Ordeals)                                                        Seed:   1   Index: 238
+Take Chocobo to Mysidia                                                       Seed:   1   Index: 251
+Overworld (Mysidia)                                                           Seed:   1   Index: 251
+Town of Baron Serpent Road                                                    Seed:   1   Index: 251
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed:  18   Index:   1
+  Overworld (Baron)                                                           Seed:  18   Index:   1
+    Extra Steps: 28
+    Step   1: 40 / Imp x3, SwordRat x1 (7.227s)
+    Step  28: 41 / Imp x3, SwordRat x1 (7.227s)
+   (Step  63: 42 / Imp x3, SwordRat x1)
+   (Step  92: 43 / Eagle x3)
+   (Step 157: 44 / Imp x3)
+   (Step 221: 45 / Eagle x3)
+   (Step 223: 46 / Eagle x3)
+
+Encounter Time:      316.870s
+Other Time:          530.227s
+Total Time:          847.097s
+
+Base Total Time:     915.065s
+Time Saved:          67.968s
+
+Optional Steps:      12
+Extra Steps:         140
+Encounters:          41
+
+Base Encounters:     47
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/173.txt
+++ b/data/routes/cw/173.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	173
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49889906
+VARS	FFFFFFFF:28 C307801:1 E000202:14 E302500:30 E302600:12 E305400:4 E307B01:40 E308000:18 E308700:1 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed: 173   Index:   0
+Overworld (Kaipo)                                                             Seed: 173   Index:   1
+  Step   3: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed: 173   Index:  37
+Overworld (Kaipo)                                                             Seed: 173   Index:  37
+  Step   5: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 173   Index:  69
+  Step  26: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 173   Index: 101
+Watery Pass-South B1F                                                         Seed: 173   Index: 101
+Watery Pass-South B2F                                                         Seed: 173   Index: 121
+  Step   1: 4 / CaveToad x3 (7.014s)
+  Step  44: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  55: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 173   Index: 211
+  Extra Steps: 4
+Watery Pass-South B2F                                                         Seed: 173   Index: 219
+Watery Pass-South B3F                                                         Seed: 190   Index:   2
+  Step  16: 7 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 190   Index:  36
+  Step   4: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 190   Index:  57
+  Step   6: 9 / Zombie x4 (7.148s)
+  Step  47: 10 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 190   Index: 117
+Waterfalls B1F                                                                Seed: 190   Index: 126
+Waterfalls B2F                                                                Seed: 190   Index: 127
+  Step  45: 11 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 190   Index: 172
+  Step  19: 12 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed: 190   Index: 209
+Waterfalls Lake                                                               Seed: 190   Index: 209
+Overworld (Kaipo)                                                             Seed: 190   Index: 210
+  Step   4: 13 / SandWorm x1 (7.264s)
+Overworld (Damcyan)                                                           Seed: 190   Index: 221
+Damcyan                                                                       Seed: 190   Index: 225
+  Optional Steps: 0
+  Extra Steps: 30
+Overworld (Damcyan)                                                           Seed: 207   Index:   6
+Antlion B1F                                                                   Seed: 207   Index:   6
+  Step  32: 14 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Direct                                                     Seed: 207   Index:  44
+  Antlion B2F                                                                 Seed: 207   Index:  44
+    Step  26: 15 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 207   Index: 124
+  Step  10: 16 / Cream x4 (7.552s)
+Battle: Antlion                                                               Seed: 207   Index: 138
+Antlion's Nest                                                                Seed: 207   Index: 138
+  Step  13: 17 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B2F Outward Charm Room Steps                                          Seed: 207   Index: 153
+  Antlion B2F                                                                 Seed: 207   Index: 153
+  Antlion B2F Treasure Room                                                   Seed: 207   Index: 204
+    Extra Steps: 40
+  Antlion B2F                                                                 Seed: 207   Index: 244
+Antlion B1F                                                                   Seed: 224   Index:  22
+  Step  14: 18 / Turtle x2 (7.464s)
+  Step  33: 19 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed: 224   Index:  60
+Overworld (Kaipo)                                                             Seed: 224   Index:  60
+  Extra Steps: 14
+  Step  14: 20 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed: 224   Index:  74
+Overworld (Kaipo)                                                             Seed: 224   Index:  74
+Overworld (Damcyan)                                                           Seed: 224   Index:  74
+Mt.Hobs-West                                                                  Seed: 224   Index:  74
+  Step  26: 21 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 224   Index: 113
+  Step  15: 22 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed: 224   Index: 128
+Mt.Hobs Summit                                                                Seed: 224   Index: 128
+  Step   4: 23 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed: 224   Index: 134
+  Extra Steps: 18
+  Step  30: 24 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 224   Index: 198
+  Step  30: 25 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 241   Index:  26
+  Optional Steps: 10
+  Extra Steps: 2
+Overworld (Fabul)                                                             Seed: 241   Index:  98
+Fabul Boat and Leviatan                                                       Seed: 241   Index: 105
+Overworld (Mysidia)                                                           Seed: 241   Index: 105
+  Step   8: 26 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 241   Index: 114
+Overworld (Mysidia)                                                           Seed: 241   Index: 114
+Overworld (Mt.Ordeals)                                                        Seed: 241   Index: 124
+  Step  38: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  70: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  86: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 241   Index: 218
+Mt.Ordeals-3rd station                                                        Seed:   2   Index:   5
+Recruit Tellah                                                                Seed:   2   Index:  28
+Mt.Ordeals-3rd station                                                        Seed:   2   Index:  28
+Mt.Ordeals-7th station                                                        Seed:   2   Index:  33
+  Step   4: 30 / Revenant x1, Ghoul x3 (8.914s)
+  Step  23: 31 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed:   2   Index:  75
+  Optional Steps: 1
+  Step  12: 32 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:   2   Index:  93
+Mt.Ordeals Summit                                                             Seed:   2   Index:  93
+  Step   4: 33 / Ghoul x2, Soul x2 (8.941s)
+Paladin                                                                       Seed:   2   Index:  97
+Mt.Ordeals Summit                                                             Seed:   2   Index:  97
+  Optional Steps: 1
+  Step  23: 34 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-7th station                                                        Seed:   2   Index: 120
+  Step  10: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  24: 36 / Revenant x1, Ghoul x3 (8.489s)
+  Step  26: 37 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:   2   Index: 162
+Mt.Ordeals                                                                    Seed:   2   Index: 192
+Overworld (Mt.Ordeals)                                                        Seed:   2   Index: 236
+Take Chocobo to Mysidia                                                       Seed:   2   Index: 249
+Overworld (Mysidia)                                                           Seed:   2   Index: 249
+Town of Baron Serpent Road                                                    Seed:   2   Index: 249
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed:  19   Index:   1
+  Overworld (Baron)                                                           Seed:  19   Index:   1
+    Extra Steps: 28
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step  28: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  66: 40 / Imp x3, SwordRat x1)
+   (Step  92: 41 / Imp x3, SwordRat x1)
+   (Step 157: 42 / Imp x3, SwordRat x1)
+   (Step 221: 43 / Eagle x3)
+   (Step 223: 44 / Imp x3)
+
+Encounter Time:      299.905s
+Other Time:          530.227s
+Total Time:          830.131s
+
+Base Total Time:     916.187s
+Time Saved:          86.056s
+
+Optional Steps:      12
+Extra Steps:         140
+Encounters:          39
+
+Base Encounters:     47
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/174.txt
+++ b/data/routes/cw/174.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	174
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49931042
+VARS	FFFFFFFF:28 E302500:3 E302600:10 E305400:60 E307400:50 E308700:1 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed: 174   Index:   0
+Overworld (Kaipo)                                                             Seed: 174   Index:   1
+  Step   3: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed: 174   Index:  37
+Overworld (Kaipo)                                                             Seed: 174   Index:  37
+  Step   5: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 174   Index:  69
+Recruit Tellah                                                                Seed: 174   Index: 101
+Watery Pass-South B1F                                                         Seed: 174   Index: 101
+Watery Pass-South B2F                                                         Seed: 174   Index: 121
+  Step   1: 3 / Pike x3 (7.152s)
+  Step  44: 4 / CaveToad x3 (7.014s)
+  Step  49: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  55: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 174   Index: 211
+  Extra Steps: 60
+Watery Pass-South B2F                                                         Seed: 191   Index:  19
+  Step  21: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed: 191   Index:  58
+  Step   5: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 191   Index:  92
+  Step  12: 9 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed: 191   Index: 113
+Overworld (Kaipo)                                                             Seed: 191   Index: 173
+Waterfalls B1F                                                                Seed: 191   Index: 182
+  Extra Steps: 50
+Waterfalls B2F                                                                Seed: 191   Index: 233
+  Step  29: 10 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 208   Index:  22
+  Step  16: 11 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 208   Index:  59
+Waterfalls Lake                                                               Seed: 208   Index:  59
+Overworld (Kaipo)                                                             Seed: 208   Index:  60
+  Step  10: 12 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 208   Index:  71
+Damcyan                                                                       Seed: 208   Index:  75
+  Optional Steps: 1
+  Extra Steps: 2
+Overworld (Damcyan)                                                           Seed: 208   Index:  85
+Antlion B1F                                                                   Seed: 208   Index:  85
+Antlion B2F Inward Direct                                                     Seed: 208   Index: 123
+  Antlion B2F                                                                 Seed: 208   Index: 123
+    Step  11: 13 / SandWorm x2 (6.841s)
+Antlion's Nest                                                                Seed: 208   Index: 203
+  Step   4: 14 / Basilisk x1, Imp x3 (6.775s)
+Battle: Antlion                                                               Seed: 208   Index: 217
+Antlion's Nest                                                                Seed: 208   Index: 217
+Antlion B2F Outward Direct                                                    Seed: 208   Index: 232
+  Antlion B2F                                                                 Seed: 208   Index: 232
+    Step  10: 15 / Weeper x2 (7.132s)
+    Step  12: 16 / Cream x4 (7.523s)
+    Step  27: 17 / Basilisk x1, Turtle x1 (7.124s)
+    Step  60: 18 / Weeper x2 (7.132s)
+    Step  79: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed: 225   Index:  56
+Overworld (Damcyan)                                                           Seed: 225   Index:  94
+Overworld (Kaipo)                                                             Seed: 225   Index:  94
+Kaipo Revisited                                                               Seed: 225   Index:  94
+Overworld (Kaipo)                                                             Seed: 225   Index:  94
+Overworld (Damcyan)                                                           Seed: 225   Index:  94
+Mt.Hobs-West                                                                  Seed: 225   Index:  94
+  Step   6: 20 / Bomb x3 (8.832s)
+  Step  34: 21 / Skelton x4 (8.683s)
+  Step  38: 22 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 225   Index: 133
+Battle: MomBomb                                                               Seed: 225   Index: 148
+Mt.Hobs Summit                                                                Seed: 225   Index: 148
+Mt.Hobs-East                                                                  Seed: 225   Index: 154
+  Step  10: 23 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 225   Index: 200
+  Step  28: 24 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 242   Index:  28
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 242   Index:  98
+Fabul Boat and Leviatan                                                       Seed: 242   Index: 105
+Overworld (Mysidia)                                                           Seed: 242   Index: 105
+  Step   8: 25 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 242   Index: 114
+Overworld (Mysidia)                                                           Seed: 242   Index: 114
+Overworld (Mt.Ordeals)                                                        Seed: 242   Index: 124
+  Step  38: 26 / Raven x1 (8.356s)
+  Step  55: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  70: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  86: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 242   Index: 218
+Mt.Ordeals-3rd station                                                        Seed:   3   Index:   5
+Recruit Tellah                                                                Seed:   3   Index:  28
+Mt.Ordeals-3rd station                                                        Seed:   3   Index:  28
+Mt.Ordeals-7th station                                                        Seed:   3   Index:  33
+  Step   4: 30 / Revenant x1, Ghoul x3 (8.914s)
+  Step  23: 31 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed:   3   Index:  75
+  Optional Steps: 1
+  Step  12: 32 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:   3   Index:  93
+Mt.Ordeals Summit                                                             Seed:   3   Index:  93
+Paladin                                                                       Seed:   3   Index:  97
+Mt.Ordeals Summit                                                             Seed:   3   Index:  97
+  Optional Steps: 1
+  Step  23: 33 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed:   3   Index: 120
+  Step  10: 34 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+  Step  24: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  26: 36 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed:   3   Index: 162
+  Step  20: 37 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:   3   Index: 192
+Overworld (Mt.Ordeals)                                                        Seed:   3   Index: 236
+Take Chocobo to Mysidia                                                       Seed:   3   Index: 249
+Overworld (Mysidia)                                                           Seed:   3   Index: 249
+Town of Baron Serpent Road                                                    Seed:   3   Index: 249
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed:  20   Index:   1
+  Overworld (Baron)                                                           Seed:  20   Index:   1
+    Extra Steps: 28
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step  28: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  66: 40 / Imp x6)
+   (Step  92: 41 / Imp x3, SwordRat x1)
+   (Step 221: 42 / Imp x3, SwordRat x1)
+   (Step 223: 43 / Eagle x3)
+   (Step 250: 44 / Imp x3)
+
+Encounter Time:      304.117s
+Other Time:          526.699s
+Total Time:          830.816s
+
+Base Total Time:     880.315s
+Time Saved:          49.500s
+
+Optional Steps:      13
+Extra Steps:         144
+Encounters:          39
+
+Base Encounters:     47
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/175.txt
+++ b/data/routes/cw/175.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	175
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49834522
+VARS	FFFFFFFF:4 C307801:1 E302500:1 E302600:30 E305400:60 E307400:8 E307B01:20 E308700:1 E308702:1 E309700:94
+
+Overworld (Kaipo)                                                             Seed: 175   Index:   0
+Overworld (Kaipo)                                                             Seed: 175   Index:   1
+  Step   3: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed: 175   Index:  37
+Overworld (Kaipo)                                                             Seed: 175   Index:  37
+  Step   5: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 175   Index:  69
+Recruit Tellah                                                                Seed: 175   Index: 101
+Watery Pass-South B1F                                                         Seed: 175   Index: 101
+Watery Pass-South B2F                                                         Seed: 175   Index: 121
+  Step   1: 3 / Pike x3 (7.152s)
+  Step  44: 4 / CaveToad x3 (7.014s)
+  Step  49: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  81: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 175   Index: 211
+  Extra Steps: 60
+Watery Pass-South B2F                                                         Seed: 192   Index:  19
+  Step  21: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed: 192   Index:  58
+Watery Pass-North B2F                                                         Seed: 192   Index:  92
+  Step  12: 8 / CaveToad x3 (7.014s)
+  Step  14: 9 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed: 192   Index: 113
+Overworld (Kaipo)                                                             Seed: 192   Index: 173
+Waterfalls B1F                                                                Seed: 192   Index: 182
+  Extra Steps: 8
+Waterfalls B2F                                                                Seed: 192   Index: 191
+  Step  23: 10 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed: 192   Index: 236
+Battle: Octomamm                                                              Seed: 209   Index:  17
+Waterfalls Lake                                                               Seed: 209   Index:  17
+Overworld (Kaipo)                                                             Seed: 209   Index:  18
+Overworld (Damcyan)                                                           Seed: 209   Index:  29
+Damcyan                                                                       Seed: 209   Index:  33
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 209   Index:  41
+Antlion B1F                                                                   Seed: 209   Index:  41
+  Step  29: 11 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 209   Index:  79
+  Antlion B2F                                                                 Seed: 209   Index:  79
+    Step   5: 12 / Basilisk x1, Turtle x1 (7.110s)
+    Step  55: 13 / SandWorm x2 (6.841s)
+    Step  60: 14 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 209   Index: 159
+Battle: Antlion                                                               Seed: 209   Index: 173
+Antlion's Nest                                                                Seed: 209   Index: 173
+Antlion B2F Outward Charm Room Steps                                          Seed: 209   Index: 188
+  Antlion B2F                                                                 Seed: 209   Index: 188
+    Step  19: 15 / Weeper x2 (7.132s)
+  Antlion B2F Treasure Room                                                   Seed: 209   Index: 239
+    Extra Steps: 20
+  Antlion B2F                                                                 Seed: 226   Index:   3
+Antlion B1F                                                                   Seed: 226   Index:  37
+  Step  18: 16 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 226   Index:  75
+Overworld (Kaipo)                                                             Seed: 226   Index:  75
+Kaipo Revisited                                                               Seed: 226   Index:  75
+Overworld (Kaipo)                                                             Seed: 226   Index:  75
+Overworld (Damcyan)                                                           Seed: 226   Index:  75
+Mt.Hobs-West                                                                  Seed: 226   Index:  75
+  Step  25: 17 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 226   Index: 114
+  Step  14: 18 / Gargoyle x2 (8.791s)
+Battle: MomBomb                                                               Seed: 226   Index: 129
+Mt.Hobs Summit                                                                Seed: 226   Index: 129
+  Step   3: 19 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed: 226   Index: 135
+  Step  29: 20 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 226   Index: 181
+  Step  11: 21 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  47: 22 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 243   Index:   9
+  Optional Steps: 10
+  Extra Steps: 20
+Overworld (Fabul)                                                             Seed: 243   Index:  99
+Fabul Boat and Leviatan                                                       Seed: 243   Index: 106
+Overworld (Mysidia)                                                           Seed: 243   Index: 106
+  Step   7: 23 / Imp Cap. x4, Imp x2 (8.293s)
+Mysidia                                                                       Seed: 243   Index: 115
+Overworld (Mysidia)                                                           Seed: 243   Index: 115
+Overworld (Mt.Ordeals)                                                        Seed: 243   Index: 125
+  Step  37: 24 / Needler x2, SwordRat x2 (8.097s)
+  Step  54: 25 / Raven x1 (8.356s)
+  Step  69: 26 / Raven x1 (8.356s)
+  Step  85: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 243   Index: 219
+Mt.Ordeals-3rd station                                                        Seed:   4   Index:   6
+Recruit Tellah                                                                Seed:   4   Index:  29
+Mt.Ordeals-3rd station                                                        Seed:   4   Index:  29
+Mt.Ordeals-7th station                                                        Seed:   4   Index:  34
+  Step  22: 28 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed:   4   Index:  76
+  Optional Steps: 1
+  Step   5: 29 / Ghoul x2, Soul x2 (9.197s)
+  Step  11: 30 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:   4   Index:  94
+Mt.Ordeals Summit                                                             Seed:   4   Index:  94
+Paladin                                                                       Seed:   4   Index:  98
+Mt.Ordeals Summit                                                             Seed:   4   Index:  98
+  Optional Steps: 1
+  Step  22: 31 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed:   4   Index: 121
+  Step   9: 32 / Revenant x1, Ghoul x3 (8.489s)
+  Step  23: 33 / Ghoul x2, Soul x2 (8.971s)
+  Step  25: 34 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-3rd station                                                        Seed:   4   Index: 163
+  Step  19: 35 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed:   4   Index: 193
+Overworld (Mt.Ordeals)                                                        Seed:   4   Index: 237
+Take Chocobo to Mysidia                                                       Seed:   4   Index: 250
+Overworld (Mysidia)                                                           Seed:   4   Index: 250
+Town of Baron Serpent Road                                                    Seed:   4   Index: 250
+  Extra Steps: 94
+Credit Warp Fight Search                                                      Seed:  21   Index:  92
+  Overworld (Baron)                                                           Seed:  21   Index:  92
+    Extra Steps: 4
+    Step   1: 36 / FloatEye x2 (7.230s)
+    Step   4: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step 130: 38 / FloatEye x1, Eagle x2)
+   (Step 132: 39 / Imp x3, SwordRat x1)
+   (Step 159: 40 / Imp x6)
+   (Step 195: 41 / Imp x3, SwordRat x1)
+   (Step 237: 42 / Eagle x3)
+
+Encounter Time:      287.801s
+Other Time:          541.408s
+Total Time:          829.210s
+
+Base Total Time:     852.295s
+Time Saved:          23.085s
+
+Optional Steps:      13
+Extra Steps:         206
+Encounters:          37
+
+Base Encounters:     46
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/176.txt
+++ b/data/routes/cw/176.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	176
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49583523
+VARS	FFFFFFFF:4 E302500:21 E302600:78 E305400:60 E307400:32 E307700:16 E308000:12 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 176   Index:   0
+Overworld (Kaipo)                                                             Seed: 176   Index:   1
+  Step   3: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed: 176   Index:  37
+Overworld (Kaipo)                                                             Seed: 176   Index:  37
+  Step   5: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 176   Index:  69
+Recruit Tellah                                                                Seed: 176   Index: 101
+Watery Pass-South B1F                                                         Seed: 176   Index: 101
+Watery Pass-South B2F                                                         Seed: 176   Index: 121
+  Step   1: 3 / Pike x3 (7.152s)
+  Step  44: 4 / CaveToad x3 (7.014s)
+  Step  49: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  81: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 176   Index: 211
+  Extra Steps: 60
+Watery Pass-South B2F                                                         Seed: 193   Index:  19
+Watery Pass-South B3F                                                         Seed: 193   Index:  58
+Watery Pass-North B2F                                                         Seed: 193   Index:  92
+  Step  12: 7 / Zombie x4 (7.148s)
+  Step  14: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 193   Index: 113
+  Step  43: 9 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 193   Index: 173
+Waterfalls B1F                                                                Seed: 193   Index: 182
+  Extra Steps: 32
+Waterfalls B2F                                                                Seed: 193   Index: 215
+Waterfalls Lake                                                               Seed: 210   Index:   4
+Battle: Octomamm                                                              Seed: 210   Index:  41
+Waterfalls Lake                                                               Seed: 210   Index:  41
+Overworld (Kaipo)                                                             Seed: 210   Index:  42
+Overworld (Damcyan)                                                           Seed: 210   Index:  53
+Damcyan                                                                       Seed: 210   Index:  57
+  Optional Steps: 1
+  Extra Steps: 20
+Overworld (Damcyan)                                                           Seed: 210   Index:  85
+Antlion B1F                                                                   Seed: 210   Index:  85
+  Extra Steps: 16
+  Step  49: 10 / Basilisk x1, Imp x3 (6.775s)
+  Step  54: 11 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 210   Index: 139
+  Antlion B2F                                                                 Seed: 210   Index: 139
+    Step  61: 12 / Basilisk x1, Turtle x1 (7.110s)
+    Step  68: 13 / SandWorm x2 (6.841s)
+Antlion's Nest                                                                Seed: 210   Index: 219
+Battle: Antlion                                                               Seed: 210   Index: 233
+Antlion's Nest                                                                Seed: 210   Index: 233
+  Step   9: 14 / Turtle x2 (7.464s)
+  Step  11: 15 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed: 210   Index: 248
+  Antlion B2F                                                                 Seed: 210   Index: 248
+    Step  11: 16 / Basilisk x1, Imp x3 (6.783s)
+    Step  63: 17 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed: 227   Index:  72
+  Step  28: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed: 227   Index: 110
+Overworld (Kaipo)                                                             Seed: 227   Index: 110
+Kaipo Revisited                                                               Seed: 227   Index: 110
+Overworld (Kaipo)                                                             Seed: 227   Index: 110
+Overworld (Damcyan)                                                           Seed: 227   Index: 110
+Mt.Hobs-West                                                                  Seed: 227   Index: 110
+  Step  22: 19 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 227   Index: 149
+  Step  15: 20 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed: 227   Index: 164
+Mt.Hobs Summit                                                                Seed: 227   Index: 164
+Mt.Hobs-East                                                                  Seed: 227   Index: 170
+  Extra Steps: 12
+  Step  20: 21 / Spirit x2, Skelton x2 (8.237s)
+  Step  22: 22 / Red Bone x1, Skelton x3 (8.007s)
+  Step  58: 23 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 227   Index: 228
+Fabul                                                                         Seed: 244   Index:  56
+  Optional Steps: 10
+  Extra Steps: 68
+Overworld (Fabul)                                                             Seed: 244   Index: 194
+Fabul Boat and Leviatan                                                       Seed: 244   Index: 201
+Overworld (Mysidia)                                                           Seed: 244   Index: 201
+  Step   9: 24 / Needler x2, SwordRat x2 (8.011s)
+Mysidia                                                                       Seed: 244   Index: 210
+Overworld (Mysidia)                                                           Seed: 244   Index: 210
+Overworld (Mt.Ordeals)                                                        Seed: 244   Index: 220
+  Step  73: 25 / Raven x1 (8.356s)
+  Step  92: 26 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:   5   Index:  58
+  Step  23: 27 / Red Bone x1, Skelton x3 (8.067s)
+  Step  29: 28 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:   5   Index: 101
+Recruit Tellah                                                                Seed:   5   Index: 124
+Mt.Ordeals-3rd station                                                        Seed:   5   Index: 124
+Mt.Ordeals-7th station                                                        Seed:   5   Index: 129
+  Step   1: 29 / Ghoul x2, Soul x2 (9.197s)
+  Step  15: 30 / Revenant x1, Ghoul x3 (8.914s)
+  Step  17: 31 / Ghoul x2, Soul x2 (9.197s)
+  Step  30: 32 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed:   5   Index: 171
+  Optional Steps: 0
+  Step  11: 33 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed:   5   Index: 188
+Mt.Ordeals Summit                                                             Seed:   5   Index: 188
+Paladin                                                                       Seed:   5   Index: 192
+Mt.Ordeals Summit                                                             Seed:   5   Index: 192
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:   5   Index: 215
+Mt.Ordeals-3rd station                                                        Seed:  22   Index:   1
+  Step   1: 34 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals                                                                    Seed:  22   Index:  31
+  Step  36: 35 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed:  22   Index:  75
+Take Chocobo to Mysidia                                                       Seed:  22   Index:  88
+Overworld (Mysidia)                                                           Seed:  22   Index:  88
+Town of Baron Serpent Road                                                    Seed:  22   Index:  88
+Credit Warp Fight Search                                                      Seed:  22   Index:  92
+  Overworld (Baron)                                                           Seed:  22   Index:  92
+    Extra Steps: 4
+    Step   1: 36 / FloatEye x1, Eagle x2 (7.365s)
+    Step   4: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step 114: 38 / FloatEye x1, Eagle x2)
+   (Step 132: 39 / Imp x3, SwordRat x1)
+   (Step 159: 40 / Imp x3)
+   (Step 195: 41 / Imp x3, SwordRat x1)
+   (Step 237: 42 / Eagle x3)
+
+Encounter Time:      286.620s
+Other Time:          538.413s
+Total Time:          825.033s
+
+Base Total Time:     846.468s
+Time Saved:          21.434s
+
+Optional Steps:      12
+Extra Steps:         212
+Encounters:          37
+
+Base Encounters:     45
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/177.txt
+++ b/data/routes/cw/177.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	177
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49708899
+VARS	FFFFFFFF:4 C307801:1 E302600:78 E305400:60 E307400:8 E307B01:22 E307F01:28 E308000:18 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 177   Index:   0
+Overworld (Kaipo)                                                             Seed: 177   Index:   1
+  Step   3: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step   8: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 177   Index:  37
+Overworld (Kaipo)                                                             Seed: 177   Index:  37
+  Step   5: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 177   Index:  69
+Recruit Tellah                                                                Seed: 177   Index: 101
+Watery Pass-South B1F                                                         Seed: 177   Index: 101
+Watery Pass-South B2F                                                         Seed: 177   Index: 121
+  Step   1: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  44: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  49: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  81: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 177   Index: 211
+  Extra Steps: 60
+Watery Pass-South B2F                                                         Seed: 194   Index:  19
+Watery Pass-South B3F                                                         Seed: 194   Index:  58
+Watery Pass-North B2F                                                         Seed: 194   Index:  92
+  Step  12: 8 / CaveToad x3 (7.014s)
+  Step  14: 9 / Pike x3 (7.152s)
+Watery Pass-North B1F                                                         Seed: 194   Index: 113
+  Step  43: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 194   Index: 173
+Waterfalls B1F                                                                Seed: 194   Index: 182
+  Extra Steps: 8
+Waterfalls B2F                                                                Seed: 194   Index: 191
+  Step  23: 11 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 194   Index: 236
+Battle: Octomamm                                                              Seed: 211   Index:  17
+Waterfalls Lake                                                               Seed: 211   Index:  17
+Overworld (Kaipo)                                                             Seed: 211   Index:  18
+  Step   4: 12 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 211   Index:  29
+Damcyan                                                                       Seed: 211   Index:  33
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 211   Index:  40
+Antlion B1F                                                                   Seed: 211   Index:  40
+Antlion B2F Inward Direct                                                     Seed: 211   Index:  78
+  Antlion B2F                                                                 Seed: 211   Index:  78
+    Step   6: 13 / SandWorm x2 (6.841s)
+    Step  56: 14 / Turtle x2 (7.487s)
+    Step  61: 15 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 211   Index: 158
+Battle: Antlion                                                               Seed: 211   Index: 172
+Antlion's Nest                                                                Seed: 211   Index: 172
+Antlion B2F Outward Charm Room Steps                                          Seed: 211   Index: 187
+  Antlion B2F                                                                 Seed: 211   Index: 187
+    Step  13: 16 / Basilisk x1, Imp x3 (6.783s)
+    Step  20: 17 / Basilisk x1, Turtle x1 (7.124s)
+  Antlion B2F Treasure Room                                                   Seed: 211   Index: 238
+    Extra Steps: 22
+  Antlion B2F                                                                 Seed: 228   Index:   4
+Antlion B1F                                                                   Seed: 228   Index:  38
+  Step  17: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed: 228   Index:  76
+Overworld (Kaipo)                                                             Seed: 228   Index:  76
+Kaipo Revisited                                                               Seed: 228   Index:  76
+Overworld (Kaipo)                                                             Seed: 228   Index:  76
+Overworld (Damcyan)                                                           Seed: 228   Index:  76
+Mt.Hobs-West                                                                  Seed: 228   Index:  76
+Mt.Hobs Summit                                                                Seed: 228   Index: 115
+Battle: MomBomb                                                               Seed: 228   Index: 130
+Mt.Hobs Summit                                                                Seed: 228   Index: 130
+  Extra Steps: 28
+  Step   1: 19 / Skelton x4 (7.819s)
+  Step   2: 20 / Skelton x4 (7.819s)
+  Step  34: 21 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed: 228   Index: 164
+  Extra Steps: 18
+  Step  26: 22 / Red Bone x1, Skelton x3 (8.007s)
+  Step  28: 23 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  64: 24 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 228   Index: 228
+Fabul                                                                         Seed: 245   Index:  56
+  Optional Steps: 10
+  Extra Steps: 68
+Overworld (Fabul)                                                             Seed: 245   Index: 194
+Fabul Boat and Leviatan                                                       Seed: 245   Index: 201
+Overworld (Mysidia)                                                           Seed: 245   Index: 201
+  Step   9: 25 / Raven x1 (8.246s)
+Mysidia                                                                       Seed: 245   Index: 210
+Overworld (Mysidia)                                                           Seed: 245   Index: 210
+Overworld (Mt.Ordeals)                                                        Seed: 245   Index: 220
+  Step  92: 26 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:   6   Index:  58
+  Step  23: 27 / Red Bone x1, Skelton x3 (8.067s)
+  Step  29: 28 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:   6   Index: 101
+Recruit Tellah                                                                Seed:   6   Index: 124
+Mt.Ordeals-3rd station                                                        Seed:   6   Index: 124
+Mt.Ordeals-7th station                                                        Seed:   6   Index: 129
+  Step   1: 29 / Ghoul x2, Soul x2 (9.197s)
+  Step  17: 30 / Revenant x1, Ghoul x3 (8.914s)
+  Step  30: 31 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed:   6   Index: 171
+  Optional Steps: 0
+  Step  11: 32 / Revenant x1, Ghoul x3 (8.914s)
+  Step  12: 33 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed:   6   Index: 188
+Mt.Ordeals Summit                                                             Seed:   6   Index: 188
+Paladin                                                                       Seed:   6   Index: 192
+Mt.Ordeals Summit                                                             Seed:   6   Index: 192
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:   6   Index: 215
+Mt.Ordeals-3rd station                                                        Seed:  23   Index:   1
+  Step   1: 34 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals                                                                    Seed:  23   Index:  31
+  Step  36: 35 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed:  23   Index:  75
+Take Chocobo to Mysidia                                                       Seed:  23   Index:  88
+Overworld (Mysidia)                                                           Seed:  23   Index:  88
+Town of Baron Serpent Road                                                    Seed:  23   Index:  88
+Credit Warp Fight Search                                                      Seed:  23   Index:  92
+  Overworld (Baron)                                                           Seed:  23   Index:  92
+    Extra Steps: 4
+    Step   1: 36 / FloatEye x1, Eagle x2 (7.365s)
+    Step   4: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step 114: 38 / FloatEye x1, Eagle x2)
+   (Step 132: 39 / Imp x3, SwordRat x1)
+   (Step 147: 40 / Imp x3)
+   (Step 159: 41 / Imp x3, SwordRat x1)
+   (Step 195: 42 / Eagle x3)
+   (Step 237: 43 / Eagle x3)
+
+Encounter Time:      285.179s
+Other Time:          541.941s
+Total Time:          827.119s
+
+Base Total Time:     850.414s
+Time Saved:          23.295s
+
+Optional Steps:      11
+Extra Steps:         208
+Encounters:          37
+
+Base Encounters:     45
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/178.txt
+++ b/data/routes/cw/178.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	178
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49797499
+VARS	FFFFFFFF:30 E000202:16 E302500:69 E302600:9 E305400:60 E307100:12 E307400:26 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 178   Index:   0
+Overworld (Kaipo)                                                             Seed: 178   Index:   1
+  Step   3: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step   8: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 178   Index:  37
+Overworld (Kaipo)                                                             Seed: 178   Index:  37
+  Step   4: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 178   Index:  69
+Recruit Tellah                                                                Seed: 178   Index: 101
+Watery Pass-South B1F                                                         Seed: 178   Index: 101
+Watery Pass-South B2F                                                         Seed: 178   Index: 121
+  Step   1: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  44: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  49: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  81: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 178   Index: 211
+  Extra Steps: 60
+Watery Pass-South B2F                                                         Seed: 195   Index:  19
+Watery Pass-South B3F                                                         Seed: 195   Index:  58
+  Extra Steps: 12
+Watery Pass-North B2F                                                         Seed: 195   Index: 104
+  Step   2: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 195   Index: 125
+  Step  31: 9 / Zombie x4 (7.148s)
+  Step  59: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 195   Index: 185
+Waterfalls B1F                                                                Seed: 195   Index: 194
+  Extra Steps: 26
+Waterfalls B2F                                                                Seed: 195   Index: 221
+Waterfalls Lake                                                               Seed: 212   Index:  10
+  Step  12: 11 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 212   Index:  47
+Waterfalls Lake                                                               Seed: 212   Index:  47
+Overworld (Kaipo)                                                             Seed: 212   Index:  48
+Overworld (Damcyan)                                                           Seed: 212   Index:  59
+Damcyan                                                                       Seed: 212   Index:  63
+  Optional Steps: 1
+  Extra Steps: 68
+Overworld (Damcyan)                                                           Seed: 212   Index: 139
+Antlion B1F                                                                   Seed: 212   Index: 139
+Antlion B2F Inward Direct                                                     Seed: 212   Index: 177
+  Antlion B2F                                                                 Seed: 212   Index: 177
+    Step  23: 12 / Basilisk x1, Turtle x1 (7.110s)
+    Step  30: 13 / SandWorm x1, Sandpede x1 (6.829s)
+    Step  65: 14 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 229   Index:   1
+  Step   2: 15 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed: 229   Index:  15
+Antlion's Nest                                                                Seed: 229   Index:  15
+Antlion B2F Outward Direct                                                    Seed: 229   Index:  30
+  Antlion B2F                                                                 Seed: 229   Index:  30
+    Step  25: 16 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 229   Index: 110
+  Step  21: 17 / Basilisk x1, Imp x3 (6.783s)
+  Step  27: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed: 229   Index: 148
+Overworld (Kaipo)                                                             Seed: 229   Index: 148
+  Extra Steps: 16
+  Step  16: 19 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed: 229   Index: 164
+Overworld (Kaipo)                                                             Seed: 229   Index: 164
+Overworld (Damcyan)                                                           Seed: 229   Index: 164
+Mt.Hobs-West                                                                  Seed: 229   Index: 164
+  Step  26: 20 / Bomb x3 (8.832s)
+  Step  28: 21 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 229   Index: 203
+Battle: MomBomb                                                               Seed: 229   Index: 218
+Mt.Hobs Summit                                                                Seed: 229   Index: 218
+Mt.Hobs-East                                                                  Seed: 229   Index: 224
+  Step   4: 22 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 246   Index:  14
+  Step  43: 23 / Cocktric x3 (8.241s)
+  Step  51: 24 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed: 246   Index:  98
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed: 246   Index: 167
+Fabul Boat and Leviatan                                                       Seed: 246   Index: 174
+Overworld (Mysidia)                                                           Seed: 246   Index: 174
+  Step   5: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.462s)
+Mysidia                                                                       Seed: 246   Index: 183
+Overworld (Mysidia)                                                           Seed: 246   Index: 183
+Overworld (Mt.Ordeals)                                                        Seed: 246   Index: 193
+  Step   1: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  17: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:   7   Index:  31
+  Step  25: 28 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:   7   Index:  74
+  Step   7: 29 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+  Step  13: 30 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:   7   Index:  97
+Mt.Ordeals-3rd station                                                        Seed:   7   Index:  97
+Mt.Ordeals-7th station                                                        Seed:   7   Index: 102
+Mt.Ordeals Summit                                                             Seed:   7   Index: 144
+  Optional Steps: 1
+  Step   2: 31 / Ghoul x2, Soul x2 (9.197s)
+  Step  15: 32 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:   7   Index: 162
+Mt.Ordeals Summit                                                             Seed:   7   Index: 162
+Paladin                                                                       Seed:   7   Index: 166
+Mt.Ordeals Summit                                                             Seed:   7   Index: 166
+  Optional Steps: 1
+  Step  16: 33 / Ghoul x2, Soul x2 (8.971s)
+  Step  17: 34 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-7th station                                                        Seed:   7   Index: 189
+  Step  34: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:   7   Index: 231
+Mt.Ordeals                                                                    Seed:  24   Index:   5
+Overworld (Mt.Ordeals)                                                        Seed:  24   Index:  49
+Take Chocobo to Mysidia                                                       Seed:  24   Index:  62
+Overworld (Mysidia)                                                           Seed:  24   Index:  62
+Town of Baron Serpent Road                                                    Seed:  24   Index:  62
+Credit Warp Fight Search                                                      Seed:  24   Index:  66
+  Overworld (Baron)                                                           Seed:  24   Index:  66
+    Extra Steps: 30
+    Step   1: 36 / FloatEye x1, Eagle x2 (7.365s)
+    Step  30: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step 140: 38 / FloatEye x1, Eagle x2)
+   (Step 158: 39 / Imp x3, SwordRat x1)
+   (Step 173: 40 / Imp x3)
+   (Step 185: 41 / Imp x3, SwordRat x1)
+   (Step 187: 42 / Eagle x3)
+   (Step 216: 43 / Eagle x3)
+   (Step 221: 44 / Imp x3)
+
+Encounter Time:      283.258s
+Other Time:          545.335s
+Total Time:          828.594s
+
+Base Total Time:     862.220s
+Time Saved:          33.627s
+
+Optional Steps:      12
+Extra Steps:         212
+Encounters:          37
+
+Base Encounters:     45
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/179.txt
+++ b/data/routes/cw/179.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	179
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49846912
+VARS	FFFFFFFF:34 C307800:1 C307801:1 E302500:16 E305400:20 E307400:14 E307B00:8 E307B01:26
+
+Overworld (Kaipo)                                                             Seed: 179   Index:   0
+Overworld (Kaipo)                                                             Seed: 179   Index:   1
+  Step   8: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed: 179   Index:  37
+Overworld (Kaipo)                                                             Seed: 179   Index:  37
+  Step   4: 2 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 179   Index:  69
+Recruit Tellah                                                                Seed: 179   Index: 101
+Watery Pass-South B1F                                                         Seed: 179   Index: 101
+Watery Pass-South B2F                                                         Seed: 179   Index: 121
+  Step  44: 3 / CaveToad x3 (7.014s)
+  Step  49: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  66: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  81: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 179   Index: 211
+  Extra Steps: 20
+Watery Pass-South B2F                                                         Seed: 179   Index: 235
+Watery Pass-South B3F                                                         Seed: 196   Index:  18
+  Step   1: 7 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 196   Index:  52
+Watery Pass-North B1F                                                         Seed: 196   Index:  73
+  Step  30: 8 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  33: 9 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 196   Index: 133
+Waterfalls B1F                                                                Seed: 196   Index: 142
+  Extra Steps: 14
+Waterfalls B2F                                                                Seed: 196   Index: 157
+  Step  27: 10 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed: 196   Index: 202
+  Step  12: 11 / Jelly x4 (7.324s)
+  Step  19: 12 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed: 196   Index: 239
+Waterfalls Lake                                                               Seed: 196   Index: 239
+Overworld (Kaipo)                                                             Seed: 196   Index: 240
+Overworld (Damcyan)                                                           Seed: 196   Index: 251
+Damcyan                                                                       Seed: 196   Index: 255
+  Optional Steps: 0
+  Extra Steps: 16
+Overworld (Damcyan)                                                           Seed: 213   Index:  22
+Antlion B1F                                                                   Seed: 213   Index:  22
+Antlion B2F Inward Charm Room Steps                                           Seed: 213   Index:  60
+  Antlion B2F                                                                 Seed: 213   Index:  60
+    Step  24: 13 / SandWorm x1, Sandpede x1 (6.829s)
+  Antlion B2F Treasure Room                                                   Seed: 213   Index:  93
+    Extra Steps: 8
+  Antlion B2F                                                                 Seed: 213   Index: 101
+    Step  32: 14 / Turtle x2 (7.487s)
+    Step  38: 15 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 213   Index: 153
+Battle: Antlion                                                               Seed: 213   Index: 167
+Antlion's Nest                                                                Seed: 213   Index: 167
+Antlion B2F Outward Charm Room Steps                                          Seed: 213   Index: 182
+  Antlion B2F                                                                 Seed: 213   Index: 182
+    Step  18: 16 / Basilisk x1, Imp x3 (6.783s)
+    Step  25: 17 / Basilisk x1, Turtle x1 (7.124s)
+  Antlion B2F Treasure Room                                                   Seed: 213   Index: 233
+    Extra Steps: 26
+  Antlion B2F                                                                 Seed: 230   Index:   3
+Antlion B1F                                                                   Seed: 230   Index:  37
+  Step  18: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed: 230   Index:  75
+Overworld (Kaipo)                                                             Seed: 230   Index:  75
+Kaipo Revisited                                                               Seed: 230   Index:  75
+Overworld (Kaipo)                                                             Seed: 230   Index:  75
+Overworld (Damcyan)                                                           Seed: 230   Index:  75
+Mt.Hobs-West                                                                  Seed: 230   Index:  75
+Mt.Hobs Summit                                                                Seed: 230   Index: 114
+Battle: MomBomb                                                               Seed: 230   Index: 129
+Mt.Hobs Summit                                                                Seed: 230   Index: 129
+  Step   2: 19 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed: 230   Index: 135
+  Step   2: 20 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  28: 21 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 230   Index: 181
+  Step   9: 22 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  11: 23 / Cocktric x3 (8.241s)
+  Step  47: 24 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed: 247   Index:   9
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed: 247   Index:  69
+Fabul Boat and Leviatan                                                       Seed: 247   Index:  76
+Overworld (Mysidia)                                                           Seed: 247   Index:  76
+Mysidia                                                                       Seed: 247   Index:  85
+Overworld (Mysidia)                                                           Seed: 247   Index:  85
+Overworld (Mt.Ordeals)                                                        Seed: 247   Index:  95
+  Step  31: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  34: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  66: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  67: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  84: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed: 247   Index: 189
+  Step   4: 30 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  21: 31 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed: 247   Index: 232
+Recruit Tellah                                                                Seed: 247   Index: 255
+Mt.Ordeals-3rd station                                                        Seed: 247   Index: 255
+Mt.Ordeals-7th station                                                        Seed:   8   Index:   4
+Mt.Ordeals Summit                                                             Seed:   8   Index:  46
+  Optional Steps: 0
+  Step  10: 32 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:   8   Index:  63
+Mt.Ordeals Summit                                                             Seed:   8   Index:  63
+Paladin                                                                       Seed:   8   Index:  67
+Mt.Ordeals Summit                                                             Seed:   8   Index:  67
+  Optional Steps: 0
+  Step  14: 33 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed:   8   Index:  89
+Mt.Ordeals-3rd station                                                        Seed:   8   Index: 131
+  Step  15: 34 / Lilith x1, Red Bone x2 (8.437s)
+  Step  28: 35 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed:   8   Index: 161
+  Step  21: 36 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+  Step  22: 37 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:   8   Index: 205
+Take Chocobo to Mysidia                                                       Seed:   8   Index: 218
+Overworld (Mysidia)                                                           Seed:   8   Index: 218
+Town of Baron Serpent Road                                                    Seed:   8   Index: 218
+Credit Warp Fight Search                                                      Seed:   8   Index: 222
+  Overworld (Baron)                                                           Seed:   8   Index: 222
+    Extra Steps: 34
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step  33: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  86: 40 / Imp x3)
+   (Step 101: 41 / Eagle x3)
+   (Step 130: 42 / Eagle x3)
+   (Step 240: 43 / Eagle x3)
+
+Encounter Time:      298.856s
+Other Time:          530.560s
+Total Time:          829.416s
+
+Base Total Time:     894.674s
+Time Saved:          65.258s
+
+Optional Steps:      0
+Extra Steps:         118
+Encounters:          39
+
+Base Encounters:     45
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/180.txt
+++ b/data/routes/cw/180.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	180
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50369090
+VARS	FFFFFFFF:10 C307800:1 E302500:32 E302600:10 E305400:60 E307400:38 E307B00:34
+
+Overworld (Kaipo)                                                             Seed: 180   Index:   0
+Overworld (Kaipo)                                                             Seed: 180   Index:   1
+  Step   8: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  20: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 180   Index:  37
+Overworld (Kaipo)                                                             Seed: 180   Index:  37
+  Step   4: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 180   Index:  69
+Recruit Tellah                                                                Seed: 180   Index: 101
+Watery Pass-South B1F                                                         Seed: 180   Index: 101
+Watery Pass-South B2F                                                         Seed: 180   Index: 121
+  Step  49: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  66: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  81: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 180   Index: 211
+  Extra Steps: 60
+Watery Pass-South B2F                                                         Seed: 197   Index:  19
+Watery Pass-South B3F                                                         Seed: 197   Index:  58
+Watery Pass-North B2F                                                         Seed: 197   Index:  92
+  Step  11: 7 / Zombie x4 (7.148s)
+  Step  14: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 197   Index: 113
+  Step  22: 9 / Zombie x4 (7.148s)
+  Step  43: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 197   Index: 173
+Waterfalls B1F                                                                Seed: 197   Index: 182
+  Extra Steps: 38
+Waterfalls B2F                                                                Seed: 197   Index: 221
+Waterfalls Lake                                                               Seed: 214   Index:  10
+  Step  12: 11 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 214   Index:  47
+Waterfalls Lake                                                               Seed: 214   Index:  47
+Overworld (Kaipo)                                                             Seed: 214   Index:  48
+Overworld (Damcyan)                                                           Seed: 214   Index:  59
+Damcyan                                                                       Seed: 214   Index:  63
+  Optional Steps: 0
+  Extra Steps: 32
+Overworld (Damcyan)                                                           Seed: 214   Index: 102
+Antlion B1F                                                                   Seed: 214   Index: 102
+  Step  31: 12 / Basilisk x1, Imp x3 (6.775s)
+  Step  37: 13 / Imp x3 (6.649s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 214   Index: 140
+  Antlion B2F                                                                 Seed: 214   Index: 140
+  Antlion B2F Treasure Room                                                   Seed: 214   Index: 173
+    Extra Steps: 34
+  Antlion B2F                                                                 Seed: 214   Index: 207
+    Step  52: 14 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 231   Index:   3
+Battle: Antlion                                                               Seed: 231   Index:  17
+Antlion's Nest                                                                Seed: 231   Index:  17
+Antlion B2F Outward Direct                                                    Seed: 231   Index:  32
+  Antlion B2F                                                                 Seed: 231   Index:  32
+Antlion B1F                                                                   Seed: 231   Index: 112
+  Step  19: 15 / Turtle x2 (7.464s)
+  Step  25: 16 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  38: 17 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed: 231   Index: 150
+Overworld (Kaipo)                                                             Seed: 231   Index: 150
+Kaipo Revisited                                                               Seed: 231   Index: 150
+Overworld (Kaipo)                                                             Seed: 231   Index: 150
+Overworld (Damcyan)                                                           Seed: 231   Index: 150
+Mt.Hobs-West                                                                  Seed: 231   Index: 150
+  Step  13: 18 / GrayBomb x2, Bomb x2 (10.938s)
+Mt.Hobs Summit                                                                Seed: 231   Index: 189
+  Step   1: 19 / Skelton x4 (8.683s)
+  Step   3: 20 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed: 231   Index: 204
+Mt.Hobs Summit                                                                Seed: 231   Index: 204
+Mt.Hobs-East                                                                  Seed: 231   Index: 210
+  Step  18: 21 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 248   Index:   0
+  Step  57: 22 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  65: 23 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 248   Index:  84
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 248   Index: 154
+  Step   7: 24 / SwordRat x3, Needler x3 (7.573s)
+Fabul Boat and Leviatan                                                       Seed: 248   Index: 161
+Overworld (Mysidia)                                                           Seed: 248   Index: 161
+Mysidia                                                                       Seed: 248   Index: 170
+Overworld (Mysidia)                                                           Seed: 248   Index: 170
+  Step   9: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Overworld (Mt.Ordeals)                                                        Seed: 248   Index: 180
+  Step  13: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  14: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  30: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  45: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:   9   Index:  18
+  Step  17: 30 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:   9   Index:  61
+  Step  20: 31 / Ghoul x1, Red Bone x2, Skelton x2 (9.071s)
+Recruit Tellah                                                                Seed:   9   Index:  84
+Mt.Ordeals-3rd station                                                        Seed:   9   Index:  84
+Mt.Ordeals-7th station                                                        Seed:   9   Index:  89
+Mt.Ordeals Summit                                                             Seed:   9   Index: 131
+  Optional Steps: 0
+  Step  15: 32 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:   9   Index: 148
+Mt.Ordeals Summit                                                             Seed:   9   Index: 148
+Paladin                                                                       Seed:   9   Index: 152
+Mt.Ordeals Summit                                                             Seed:   9   Index: 152
+  Optional Steps: 0
+  Step   7: 33 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed:   9   Index: 174
+  Step   8: 34 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+  Step   9: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:   9   Index: 216
+  Step   7: 36 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed:   9   Index: 246
+  Step   9: 37 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  26   Index:  34
+Take Chocobo to Mysidia                                                       Seed:  26   Index:  47
+Overworld (Mysidia)                                                           Seed:  26   Index:  47
+Town of Baron Serpent Road                                                    Seed:  26   Index:  47
+Credit Warp Fight Search                                                      Seed:  26   Index:  51
+  Overworld (Baron)                                                           Seed:  26   Index:  51
+    Extra Steps: 10
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step   9: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  45: 40 / Imp x3)
+   (Step 155: 41 / Eagle x3)
+   (Step 188: 42 / Eagle x3)
+   (Step 200: 43 / Eagle x3)
+   (Step 202: 44 / Imp x3)
+   (Step 231: 45 / Imp x4)
+   (Step 252: 46 / Imp x4)
+
+Encounter Time:      303.618s
+Other Time:          534.486s
+Total Time:          838.105s
+
+Base Total Time:     922.468s
+Time Saved:          84.364s
+
+Optional Steps:      10
+Extra Steps:         174
+Encounters:          39
+
+Base Encounters:     45
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/181.txt
+++ b/data/routes/cw/181.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	181
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49388443
+VARS	FFFFFFFF:34 C307801:1 E000501:10 E302500:1 E302600:10 E307400:12 E307B01:18 E308702:1 E309700:36
+
+Overworld (Kaipo)                                                             Seed: 181   Index:   0
+Overworld (Kaipo)                                                             Seed: 181   Index:   1
+  Step   8: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  20: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 181   Index:  37
+Overworld (Kaipo)                                                             Seed: 181   Index:  37
+  Step   4: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 181   Index:  69
+Recruit Tellah                                                                Seed: 181   Index: 101
+Watery Pass-South B1F                                                         Seed: 181   Index: 101
+Watery Pass-South B2F                                                         Seed: 181   Index: 121
+  Step  66: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  81: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 181   Index: 211
+Watery Pass-South B2F                                                         Seed: 181   Index: 215
+  Step  19: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  37: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed: 181   Index: 254
+  Step  21: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 198   Index:  32
+Watery Pass-North B1F                                                         Seed: 198   Index:  53
+  Step  50: 9 / Zombie x4 (7.148s)
+  Step  53: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  56: 11 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 198   Index: 113
+Waterfalls B1F                                                                Seed: 198   Index: 122
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed: 198   Index: 135
+  Step  21: 12 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed: 198   Index: 180
+  Step   4: 13 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 198   Index: 217
+Waterfalls Lake                                                               Seed: 198   Index: 217
+Overworld (Kaipo)                                                             Seed: 198   Index: 218
+  Step   3: 14 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed: 198   Index: 229
+Damcyan                                                                       Seed: 198   Index: 233
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 198   Index: 241
+Antlion B1F                                                                   Seed: 198   Index: 241
+  Step  37: 15 / Turtle x2 (7.487s)
+Antlion B2F Inward Direct                                                     Seed: 215   Index:  23
+  Antlion B2F                                                                 Seed: 215   Index:  23
+    Step  61: 16 / Basilisk x1, Imp x3 (6.775s)
+    Step  78: 17 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed: 215   Index: 103
+Battle: Antlion                                                               Seed: 215   Index: 117
+Antlion's Nest                                                                Seed: 215   Index: 117
+Antlion B2F Outward Charm Room Steps                                          Seed: 215   Index: 132
+  Antlion B2F                                                                 Seed: 215   Index: 132
+    Step   1: 18 / SandWorm x2 (6.858s)
+    Step   7: 19 / Basilisk x1, Turtle x1 (7.124s)
+  Antlion B2F Treasure Room                                                   Seed: 215   Index: 183
+    Extra Steps: 18
+  Antlion B2F                                                                 Seed: 215   Index: 201
+Antlion B1F                                                                   Seed: 215   Index: 235
+  Step  24: 20 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed: 232   Index:  17
+Overworld (Kaipo)                                                             Seed: 232   Index:  17
+Kaipo Revisited                                                               Seed: 232   Index:  17
+Overworld (Kaipo)                                                             Seed: 232   Index:  17
+Overworld (Damcyan)                                                           Seed: 232   Index:  17
+Mt.Hobs-West                                                                  Seed: 232   Index:  17
+Mt.Hobs Summit                                                                Seed: 232   Index:  56
+Battle: MomBomb                                                               Seed: 232   Index:  71
+Mt.Hobs Summit                                                                Seed: 232   Index:  71
+Mt.Hobs-East                                                                  Seed: 232   Index:  77
+Overworld (Fabul)                                                             Seed: 232   Index: 123
+  Step   8: 21 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  14: 22 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  27: 23 / Cocktric x3 (8.241s)
+  Step  40: 24 / SwordRat x3, Needler x3 (7.663s)
+  Step  67: 25 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  69: 26 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 232   Index: 207
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 249   Index:  21
+Fabul Boat and Leviatan                                                       Seed: 249   Index:  28
+Overworld (Mysidia)                                                           Seed: 249   Index:  28
+Mysidia                                                                       Seed: 249   Index:  37
+Overworld (Mysidia)                                                           Seed: 249   Index:  37
+  Extra Steps: 10
+Overworld (Mt.Ordeals)                                                        Seed: 249   Index:  57
+  Step   8: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  69: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  72: 29 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 249   Index: 151
+  Step  10: 30 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  28: 31 / Red Bone x1, Skelton x3 (8.067s)
+  Step  42: 32 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 249   Index: 194
+Recruit Tellah                                                                Seed: 249   Index: 217
+Mt.Ordeals-3rd station                                                        Seed: 249   Index: 217
+Mt.Ordeals-7th station                                                        Seed: 249   Index: 222
+  Step   3: 33 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed:  10   Index:   8
+  Optional Steps: 0
+  Step   5: 34 / Lilith x2 (9.842s)
+Battle: Milon and Milon Z                                                     Seed:  10   Index:  25
+Mt.Ordeals Summit                                                             Seed:  10   Index:  25
+Paladin                                                                       Seed:  10   Index:  29
+Mt.Ordeals Summit                                                             Seed:  10   Index:  29
+  Optional Steps: 1
+  Step   6: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed:  10   Index:  52
+  Step  29: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  10   Index:  94
+Mt.Ordeals                                                                    Seed:  10   Index: 124
+  Step  35: 37 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  10   Index: 168
+Take Chocobo to Mysidia                                                       Seed:  10   Index: 181
+Overworld (Mysidia)                                                           Seed:  10   Index: 181
+Town of Baron Serpent Road                                                    Seed:  10   Index: 181
+  Extra Steps: 36
+Credit Warp Fight Search                                                      Seed:  10   Index: 221
+  Overworld (Baron)                                                           Seed:  10   Index: 221
+    Extra Steps: 34
+    Step   2: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step  34: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  87: 40 / Imp x3)
+   (Step  95: 41 / Eagle x3)
+   (Step 127: 42 / Eagle x3)
+   (Step 131: 43 / Eagle x3)
+   (Step 241: 44 / Imp x3)
+
+Encounter Time:      297.950s
+Other Time:          523.837s
+Total Time:          821.787s
+
+Base Total Time:     924.726s
+Time Saved:          102.939s
+
+Optional Steps:      12
+Extra Steps:         110
+Encounters:          39
+
+Base Encounters:     45
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/182.txt
+++ b/data/routes/cw/182.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	182
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48360958
+VARS	FFFFFFFF:12 E000501:30 E302600:14 E307400:12 E308702:1 E309700:26
+
+Overworld (Kaipo)                                                             Seed: 182   Index:   0
+Overworld (Kaipo)                                                             Seed: 182   Index:   1
+  Step   8: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  20: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 182   Index:  37
+Overworld (Kaipo)                                                             Seed: 182   Index:  37
+  Step   4: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 182   Index:  69
+Recruit Tellah                                                                Seed: 182   Index: 101
+Watery Pass-South B1F                                                         Seed: 182   Index: 101
+Watery Pass-South B2F                                                         Seed: 182   Index: 121
+  Step  24: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  66: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 182   Index: 211
+Watery Pass-South B2F                                                         Seed: 182   Index: 215
+  Step  19: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  37: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed: 182   Index: 254
+  Step  21: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 199   Index:  32
+Watery Pass-North B1F                                                         Seed: 199   Index:  53
+  Step  50: 9 / Zombie x4 (7.148s)
+  Step  53: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  56: 11 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 199   Index: 113
+Waterfalls B1F                                                                Seed: 199   Index: 122
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed: 199   Index: 135
+  Step  21: 12 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed: 199   Index: 180
+  Step  19: 13 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 199   Index: 217
+Waterfalls Lake                                                               Seed: 199   Index: 217
+Overworld (Kaipo)                                                             Seed: 199   Index: 218
+  Step   3: 14 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed: 199   Index: 229
+Damcyan                                                                       Seed: 199   Index: 233
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 199   Index: 240
+Antlion B1F                                                                   Seed: 199   Index: 240
+  Step  38: 15 / Turtle x2 (7.487s)
+Antlion B2F Inward Direct                                                     Seed: 216   Index:  22
+  Antlion B2F                                                                 Seed: 216   Index:  22
+    Step  79: 16 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 216   Index: 102
+Battle: Antlion                                                               Seed: 216   Index: 116
+Antlion's Nest                                                                Seed: 216   Index: 116
+Antlion B2F Outward Direct                                                    Seed: 216   Index: 131
+  Antlion B2F                                                                 Seed: 216   Index: 131
+    Step   2: 17 / Weeper x2 (7.132s)
+    Step   8: 18 / SandWorm x2 (6.858s)
+    Step  44: 19 / Basilisk x1, Turtle x1 (7.124s)
+    Step  66: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  69: 21 / Cream x4 (7.523s)
+    Step  70: 22 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed: 216   Index: 211
+Overworld (Damcyan)                                                           Seed: 216   Index: 249
+Overworld (Kaipo)                                                             Seed: 216   Index: 249
+Kaipo Revisited                                                               Seed: 216   Index: 249
+Overworld (Kaipo)                                                             Seed: 216   Index: 249
+Overworld (Damcyan)                                                           Seed: 216   Index: 249
+Mt.Hobs-West                                                                  Seed: 216   Index: 249
+Mt.Hobs Summit                                                                Seed: 233   Index:  32
+Battle: MomBomb                                                               Seed: 233   Index:  47
+Mt.Hobs Summit                                                                Seed: 233   Index:  47
+Mt.Hobs-East                                                                  Seed: 233   Index:  53
+Overworld (Fabul)                                                             Seed: 233   Index:  99
+  Step  32: 23 / Cocktric x3 (8.241s)
+  Step  38: 24 / SwordRat x3, Needler x3 (7.663s)
+  Step  51: 25 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  64: 26 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed: 233   Index: 183
+  Optional Steps: 10
+  Extra Steps: 4
+Overworld (Fabul)                                                             Seed: 250   Index:   1
+Fabul Boat and Leviatan                                                       Seed: 250   Index:   8
+Overworld (Mysidia)                                                           Seed: 250   Index:   8
+Mysidia                                                                       Seed: 250   Index:  17
+Overworld (Mysidia)                                                           Seed: 250   Index:  17
+  Extra Steps: 30
+Overworld (Mt.Ordeals)                                                        Seed: 250   Index:  57
+  Step   8: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  69: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  72: 29 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed: 250   Index: 151
+  Step  10: 30 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  29: 31 / Red Bone x1, Skelton x3 (8.067s)
+  Step  42: 32 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed: 250   Index: 194
+Recruit Tellah                                                                Seed: 250   Index: 217
+Mt.Ordeals-3rd station                                                        Seed: 250   Index: 217
+Mt.Ordeals-7th station                                                        Seed: 250   Index: 222
+  Step   3: 33 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed:  11   Index:   8
+  Optional Steps: 0
+  Step   5: 34 / Lilith x2 (9.842s)
+Battle: Milon and Milon Z                                                     Seed:  11   Index:  25
+Mt.Ordeals Summit                                                             Seed:  11   Index:  25
+Paladin                                                                       Seed:  11   Index:  29
+Mt.Ordeals Summit                                                             Seed:  11   Index:  29
+  Optional Steps: 1
+  Step   6: 35 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  11   Index:  52
+  Step  29: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  11   Index:  94
+Mt.Ordeals                                                                    Seed:  11   Index: 124
+  Step  35: 37 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  11   Index: 168
+Take Chocobo to Mysidia                                                       Seed:  11   Index: 181
+Overworld (Mysidia)                                                           Seed:  11   Index: 181
+Town of Baron Serpent Road                                                    Seed:  11   Index: 181
+  Extra Steps: 26
+Credit Warp Fight Search                                                      Seed:  11   Index: 211
+  Overworld (Baron)                                                           Seed:  11   Index: 211
+    Extra Steps: 12
+    Step   1: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step  12: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  44: 40 / Imp x3)
+   (Step  97: 41 / Eagle x3)
+   (Step 105: 42 / Eagle x3)
+   (Step 114: 43 / Eagle x3)
+   (Step 137: 44 / Imp x3)
+   (Step 251: 45 / Imp x4)
+
+Encounter Time:      298.225s
+Other Time:          506.466s
+Total Time:          804.691s
+
+Base Total Time:     895.128s
+Time Saved:          90.437s
+
+Optional Steps:      11
+Extra Steps:         84
+Encounters:          39
+
+Base Encounters:     45
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/183.txt
+++ b/data/routes/cw/183.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	183
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49485511
+VARS	FFFFFFFF:10 C307800:1 E302500:31 E302600:10 E307400:98 E307701:4 E307802:1 E307B00:30
+
+Overworld (Kaipo)                                                             Seed: 183   Index:   0
+Overworld (Kaipo)                                                             Seed: 183   Index:   1
+  Step   8: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  20: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 183   Index:  37
+Overworld (Kaipo)                                                             Seed: 183   Index:  37
+  Step   4: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 183   Index:  69
+Recruit Tellah                                                                Seed: 183   Index: 101
+Watery Pass-South B1F                                                         Seed: 183   Index: 101
+Watery Pass-South B2F                                                         Seed: 183   Index: 121
+  Step  24: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  51: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  66: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 183   Index: 211
+Watery Pass-South B2F                                                         Seed: 183   Index: 215
+  Step  37: 7 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed: 183   Index: 254
+  Step  21: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 200   Index:  32
+Watery Pass-North B1F                                                         Seed: 200   Index:  53
+  Step  50: 9 / Zombie x4 (7.148s)
+  Step  56: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 200   Index: 113
+Waterfalls B1F                                                                Seed: 200   Index: 122
+  Extra Steps: 98
+Waterfalls B2F                                                                Seed: 200   Index: 221
+Waterfalls Lake                                                               Seed: 217   Index:  10
+  Step  12: 11 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 217   Index:  47
+Waterfalls Lake                                                               Seed: 217   Index:  47
+Overworld (Kaipo)                                                             Seed: 217   Index:  48
+Overworld (Damcyan)                                                           Seed: 217   Index:  59
+Damcyan                                                                       Seed: 217   Index:  63
+  Optional Steps: 1
+  Extra Steps: 30
+Overworld (Damcyan)                                                           Seed: 217   Index: 101
+Antlion B1F                                                                   Seed: 217   Index: 101
+  Step  32: 12 / Turtle x2 (7.487s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 217   Index: 139
+  Antlion B2F                                                                 Seed: 217   Index: 139
+  Antlion B2F Treasure Room                                                   Seed: 217   Index: 172
+    Extra Steps: 30
+  Antlion B2F                                                                 Seed: 217   Index: 202
+Antlion's Nest                                                                Seed: 217   Index: 254
+Battle: Antlion                                                               Seed: 234   Index:  12
+Antlion's Nest                                                                Seed: 234   Index:  12
+Antlion B2F Outward Direct                                                    Seed: 234   Index:  27
+  Antlion B2F                                                                 Seed: 234   Index:  27
+    Extra Steps: 1
+    Step   7: 13 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed: 234   Index: 108
+  Extra Steps: 4
+  Step  23: 14 / Turtle x1, Imp x2 (7.009s)
+  Step  29: 15 / Turtle x2 (7.464s)
+  Step  42: 16 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 234   Index: 150
+Overworld (Kaipo)                                                             Seed: 234   Index: 150
+Kaipo Revisited                                                               Seed: 234   Index: 150
+Overworld (Kaipo)                                                             Seed: 234   Index: 150
+Overworld (Damcyan)                                                           Seed: 234   Index: 150
+Mt.Hobs-West                                                                  Seed: 234   Index: 150
+  Step  13: 17 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 234   Index: 189
+  Step   1: 18 / Spirit x3, Skelton x2, Red Bone x1 (10.387s)
+Battle: MomBomb                                                               Seed: 234   Index: 204
+Mt.Hobs Summit                                                                Seed: 234   Index: 204
+Mt.Hobs-East                                                                  Seed: 234   Index: 210
+  Step  17: 19 / Red Bone x1, Skelton x3 (8.007s)
+  Step  44: 20 / Red Bone x1, Skelton x3 (8.007s)
+  Step  46: 21 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 251   Index:   0
+  Step  65: 22 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 251   Index:  84
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed: 251   Index: 154
+  Step   7: 23 / Cocktric x3 (8.218s)
+Fabul Boat and Leviatan                                                       Seed: 251   Index: 161
+Overworld (Mysidia)                                                           Seed: 251   Index: 161
+Mysidia                                                                       Seed: 251   Index: 170
+Overworld (Mysidia)                                                           Seed: 251   Index: 170
+  Step  10: 24 / Raven x1, Cocktric x3 (9.100s)
+Overworld (Mt.Ordeals)                                                        Seed: 251   Index: 180
+  Step  13: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  45: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  89: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  12   Index:  18
+  Step  17: 28 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  12   Index:  61
+  Step   3: 29 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed:  12   Index:  84
+Mt.Ordeals-3rd station                                                        Seed:  12   Index:  84
+Mt.Ordeals-7th station                                                        Seed:  12   Index:  89
+Mt.Ordeals Summit                                                             Seed:  12   Index: 131
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed:  12   Index: 148
+Mt.Ordeals Summit                                                             Seed:  12   Index: 148
+Paladin                                                                       Seed:  12   Index: 152
+Mt.Ordeals Summit                                                             Seed:  12   Index: 152
+  Optional Steps: 0
+  Step   7: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed:  12   Index: 174
+  Step   9: 31 / Revenant x1, Ghoul x3 (8.489s)
+  Step  38: 32 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed:  12   Index: 216
+  Step   7: 33 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed:  12   Index: 246
+  Step   9: 34 / Spirit x2, Skelton x2 (8.065s)
+  Step  17: 35 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  29   Index:  34
+Take Chocobo to Mysidia                                                       Seed:  29   Index:  47
+Overworld (Mysidia)                                                           Seed:  29   Index:  47
+Town of Baron Serpent Road                                                    Seed:  29   Index:  47
+Credit Warp Fight Search                                                      Seed:  29   Index:  51
+  Overworld (Baron)                                                           Seed:  29   Index:  51
+    Extra Steps: 10
+    Step   1: 36 / FloatEye x1, Eagle x2 (7.365s)
+    Step   9: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step  18: 38 / FloatEye x1, Eagle x2)
+   (Step  41: 39 / Imp x3, SwordRat x1)
+   (Step 188: 40 / Imp x3)
+   (Step 202: 41 / Eagle x3)
+   (Step 231: 42 / Eagle x3)
+   (Step 252: 43 / Eagle x3)
+
+Encounter Time:      288.916s
+Other Time:          534.486s
+Total Time:          823.402s
+
+Base Total Time:     897.086s
+Time Saved:          73.683s
+
+Optional Steps:      11
+Extra Steps:         173
+Encounters:          37
+
+Base Encounters:     45
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/184.txt
+++ b/data/routes/cw/184.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	184
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50232135
+VARS	FFFFFFFF:10 C307800:1 E000302:6 E302500:73 E302600:6 E305400:48 E307200:8 E307B00:30 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 184   Index:   0
+Overworld (Kaipo)                                                             Seed: 184   Index:   1
+  Step   8: 1 / Sandpede x1, Sand Man x2 (7.026s)
+  Step  20: 2 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 184   Index:  37
+Overworld (Kaipo)                                                             Seed: 184   Index:  37
+  Step   4: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 184   Index:  69
+Recruit Tellah                                                                Seed: 184   Index: 101
+Watery Pass-South B1F                                                         Seed: 184   Index: 101
+Watery Pass-South B2F                                                         Seed: 184   Index: 121
+  Step  24: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  51: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  66: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 184   Index: 211
+  Extra Steps: 48
+Watery Pass-South B2F                                                         Seed: 201   Index:   7
+Watery Pass-South B3F                                                         Seed: 201   Index:  46
+Watery Pass-North B2F                                                         Seed: 201   Index:  80
+  Extra Steps: 8
+  Step  23: 7 / Zombie x4 (7.148s)
+  Step  29: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 201   Index: 109
+  Step  26: 9 / Zombie x4 (7.148s)
+  Step  42: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 201   Index: 169
+Waterfalls B1F                                                                Seed: 201   Index: 178
+Waterfalls B2F                                                                Seed: 201   Index: 179
+  Step  20: 11 / Jelly x4 (7.324s)
+  Step  42: 12 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed: 201   Index: 224
+Battle: Octomamm                                                              Seed: 218   Index:   5
+Waterfalls Lake                                                               Seed: 218   Index:   5
+Overworld (Kaipo)                                                             Seed: 218   Index:   6
+Overworld (Damcyan)                                                           Seed: 218   Index:  17
+Damcyan                                                                       Seed: 218   Index:  21
+  Optional Steps: 1
+  Extra Steps: 72
+Overworld (Damcyan)                                                           Seed: 218   Index: 101
+Antlion B1F                                                                   Seed: 218   Index: 101
+  Step  32: 13 / Imp x3 (6.649s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 218   Index: 139
+  Antlion B2F                                                                 Seed: 218   Index: 139
+  Antlion B2F Treasure Room                                                   Seed: 218   Index: 172
+    Extra Steps: 30
+  Antlion B2F                                                                 Seed: 218   Index: 202
+Antlion's Nest                                                                Seed: 218   Index: 254
+Battle: Antlion                                                               Seed: 235   Index:  12
+Antlion's Nest                                                                Seed: 235   Index:  12
+Antlion B2F Outward Direct                                                    Seed: 235   Index:  27
+  Antlion B2F                                                                 Seed: 235   Index:  27
+    Step   7: 14 / Turtle x2 (7.464s)
+    Step  39: 15 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 235   Index: 107
+  Step  24: 16 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  30: 17 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 235   Index: 145
+  Extra Steps: 6
+  Step   5: 18 / SandWorm x2 (7.125s)
+Overworld (Kaipo)                                                             Seed: 235   Index: 151
+Kaipo Revisited                                                               Seed: 235   Index: 151
+Overworld (Kaipo)                                                             Seed: 235   Index: 151
+Overworld (Damcyan)                                                           Seed: 235   Index: 151
+Mt.Hobs-West                                                                  Seed: 235   Index: 151
+  Step  12: 19 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 235   Index: 190
+Battle: MomBomb                                                               Seed: 235   Index: 205
+Mt.Hobs Summit                                                                Seed: 235   Index: 205
+Mt.Hobs-East                                                                  Seed: 235   Index: 211
+  Step  16: 20 / Red Bone x1, Skelton x3 (8.007s)
+  Step  43: 21 / Spirit x2, Skelton x2 (8.237s)
+  Step  45: 22 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 252   Index:   1
+  Step  36: 23 / Cocktric x3 (8.241s)
+  Step  64: 24 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed: 252   Index:  85
+  Optional Steps: 6
+Overworld (Fabul)                                                             Seed: 252   Index: 151
+Fabul Boat and Leviatan                                                       Seed: 252   Index: 158
+Overworld (Mysidia)                                                           Seed: 252   Index: 158
+  Step   3: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.462s)
+Mysidia                                                                       Seed: 252   Index: 167
+Overworld (Mysidia)                                                           Seed: 252   Index: 167
+Overworld (Mt.Ordeals)                                                        Seed: 252   Index: 177
+  Step   3: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  16: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  48: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  92: 29 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  13   Index:  15
+  Step  20: 30 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:  13   Index:  58
+  Step   6: 31 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed:  13   Index:  81
+Mt.Ordeals-3rd station                                                        Seed:  13   Index:  81
+Mt.Ordeals-7th station                                                        Seed:  13   Index:  86
+Mt.Ordeals Summit                                                             Seed:  13   Index: 128
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  13   Index: 146
+Mt.Ordeals Summit                                                             Seed:  13   Index: 146
+Paladin                                                                       Seed:  13   Index: 150
+Mt.Ordeals Summit                                                             Seed:  13   Index: 150
+  Optional Steps: 1
+  Step   8: 32 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed:  13   Index: 173
+  Step  10: 33 / Ghoul x2, Soul x2 (8.971s)
+  Step  39: 34 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed:  13   Index: 215
+  Step   8: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:  13   Index: 245
+  Step  10: 36 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+  Step  18: 37 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  30   Index:  33
+Take Chocobo to Mysidia                                                       Seed:  30   Index:  46
+Overworld (Mysidia)                                                           Seed:  30   Index:  46
+Town of Baron Serpent Road                                                    Seed:  30   Index:  46
+Credit Warp Fight Search                                                      Seed:  30   Index:  50
+  Overworld (Baron)                                                           Seed:  30   Index:  50
+    Extra Steps: 10
+    Step   2: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step  10: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  19: 40 / Imp x3)
+   (Step  42: 41 / Eagle x3)
+   (Step 138: 42 / Eagle x3)
+   (Step 203: 43 / Eagle x3)
+   (Step 232: 44 / FloatEye x2)
+   (Step 233: 45 / Imp x4)
+   (Step 253: 46 / Imp x4)
+
+Encounter Time:      301.339s
+Other Time:          534.486s
+Total Time:          835.826s
+
+Base Total Time:     880.493s
+Time Saved:          44.667s
+
+Optional Steps:      9
+Extra Steps:         174
+Encounters:          39
+
+Base Encounters:     45
+Encounters Saved:    6
+
+Number of Variables: 54

--- a/data/routes/cw/185.txt
+++ b/data/routes/cw/185.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	185
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50034812
+VARS	FFFFFFFF:10 C307800:1 E302500:31 E302600:6 E305400:80 E307300:6 E307400:12 E307701:6 E307B00:30 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 185   Index:   0
+Overworld (Kaipo)                                                             Seed: 185   Index:   1
+  Step  20: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed: 185   Index:  37
+Overworld (Kaipo)                                                             Seed: 185   Index:  37
+  Step   4: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step  26: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 185   Index:  69
+Recruit Tellah                                                                Seed: 185   Index: 101
+Watery Pass-South B1F                                                         Seed: 185   Index: 101
+Watery Pass-South B2F                                                         Seed: 185   Index: 121
+  Step  24: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  51: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  66: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 185   Index: 211
+  Extra Steps: 80
+Watery Pass-South B2F                                                         Seed: 202   Index:  39
+Watery Pass-South B3F                                                         Seed: 202   Index:  78
+  Step  25: 7 / Zombie x4 (7.148s)
+  Step  31: 8 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 202   Index: 112
+Watery Pass-North B1F                                                         Seed: 202   Index: 133
+  Extra Steps: 6
+  Step   2: 9 / Zombie x4 (7.148s)
+  Step  18: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  66: 11 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 202   Index: 199
+Waterfalls B1F                                                                Seed: 202   Index: 208
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed: 202   Index: 221
+Waterfalls Lake                                                               Seed: 219   Index:  10
+  Step  26: 12 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 219   Index:  47
+Waterfalls Lake                                                               Seed: 219   Index:  47
+Overworld (Kaipo)                                                             Seed: 219   Index:  48
+Overworld (Damcyan)                                                           Seed: 219   Index:  59
+Damcyan                                                                       Seed: 219   Index:  63
+  Optional Steps: 1
+  Extra Steps: 30
+Overworld (Damcyan)                                                           Seed: 219   Index: 101
+Antlion B1F                                                                   Seed: 219   Index: 101
+  Step  27: 13 / Imp x3 (6.649s)
+  Step  32: 14 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 219   Index: 139
+  Antlion B2F                                                                 Seed: 219   Index: 139
+  Antlion B2F Treasure Room                                                   Seed: 219   Index: 172
+    Extra Steps: 30
+  Antlion B2F                                                                 Seed: 219   Index: 202
+Antlion's Nest                                                                Seed: 219   Index: 254
+Battle: Antlion                                                               Seed: 236   Index:  12
+Antlion's Nest                                                                Seed: 236   Index:  12
+Antlion B2F Outward Direct                                                    Seed: 236   Index:  27
+  Antlion B2F                                                                 Seed: 236   Index:  27
+    Step   7: 15 / Weeper x2 (7.132s)
+    Step  39: 16 / Basilisk x1, Imp x3 (6.783s)
+    Step  71: 17 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 236   Index: 107
+  Extra Steps: 6
+  Step  30: 18 / Imp x3 (6.648s)
+  Step  43: 19 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed: 236   Index: 151
+Overworld (Kaipo)                                                             Seed: 236   Index: 151
+Kaipo Revisited                                                               Seed: 236   Index: 151
+Overworld (Kaipo)                                                             Seed: 236   Index: 151
+Overworld (Damcyan)                                                           Seed: 236   Index: 151
+Mt.Hobs-West                                                                  Seed: 236   Index: 151
+  Step  12: 20 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 236   Index: 190
+Battle: MomBomb                                                               Seed: 236   Index: 205
+Mt.Hobs Summit                                                                Seed: 236   Index: 205
+Mt.Hobs-East                                                                  Seed: 236   Index: 211
+  Step  16: 21 / Spirit x2, Skelton x2 (8.237s)
+  Step  43: 22 / Red Bone x1, Skelton x3 (8.007s)
+  Step  45: 23 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed: 253   Index:   1
+  Step  36: 24 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed: 253   Index:  85
+  Optional Steps: 6
+Overworld (Fabul)                                                             Seed: 253   Index: 151
+Fabul Boat and Leviatan                                                       Seed: 253   Index: 158
+Overworld (Mysidia)                                                           Seed: 253   Index: 158
+  Step   3: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.462s)
+Mysidia                                                                       Seed: 253   Index: 167
+Overworld (Mysidia)                                                           Seed: 253   Index: 167
+Overworld (Mt.Ordeals)                                                        Seed: 253   Index: 177
+  Step   3: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  16: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  48: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  92: 29 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  14   Index:  15
+  Step  14: 30 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  20: 31 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  14   Index:  58
+  Step   6: 32 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed:  14   Index:  81
+Mt.Ordeals-3rd station                                                        Seed:  14   Index:  81
+Mt.Ordeals-7th station                                                        Seed:  14   Index:  86
+Mt.Ordeals Summit                                                             Seed:  14   Index: 128
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  14   Index: 146
+Mt.Ordeals Summit                                                             Seed:  14   Index: 146
+Paladin                                                                       Seed:  14   Index: 150
+Mt.Ordeals Summit                                                             Seed:  14   Index: 150
+  Optional Steps: 1
+  Step   8: 33 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed:  14   Index: 173
+  Step  39: 34 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed:  14   Index: 215
+  Step   8: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:  14   Index: 245
+  Step  10: 36 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+  Step  18: 37 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  31   Index:  33
+Take Chocobo to Mysidia                                                       Seed:  31   Index:  46
+Overworld (Mysidia)                                                           Seed:  31   Index:  46
+Town of Baron Serpent Road                                                    Seed:  31   Index:  46
+Credit Warp Fight Search                                                      Seed:  31   Index:  50
+  Overworld (Baron)                                                           Seed:  31   Index:  50
+    Extra Steps: 10
+    Step   2: 38 / FloatEye x1, Eagle x2 (7.365s)
+    Step  10: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  19: 40 / Imp x3)
+   (Step  42: 41 / Eagle x3)
+   (Step 138: 42 / Eagle x3)
+   (Step 170: 43 / Eagle x3)
+   (Step 233: 44 / FloatEye x2)
+   (Step 253: 45 / Imp x4)
+
+Encounter Time:      298.056s
+Other Time:          534.486s
+Total Time:          832.542s
+
+Base Total Time:     885.947s
+Time Saved:          53.404s
+
+Optional Steps:      9
+Extra Steps:         174
+Encounters:          39
+
+Base Encounters:     46
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/186.txt
+++ b/data/routes/cw/186.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	186
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49173670
+VARS	FFFFFFFF:10 C307800:1 E302500:53 E302600:7 E305400:48 E307100:24 E307400:4 E307802:6 E307B00:30 E308700:1 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed: 186   Index:   0
+Overworld (Kaipo)                                                             Seed: 186   Index:   1
+  Step  20: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed: 186   Index:  37
+Overworld (Kaipo)                                                             Seed: 186   Index:  37
+  Step   3: 2 / SandMoth x2, Larva x2 (7.049s)
+  Step  26: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 186   Index:  69
+Recruit Tellah                                                                Seed: 186   Index: 101
+Watery Pass-South B1F                                                         Seed: 186   Index: 101
+Watery Pass-South B2F                                                         Seed: 186   Index: 121
+  Step  24: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  51: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 186   Index: 211
+  Extra Steps: 48
+Watery Pass-South B2F                                                         Seed: 203   Index:   7
+  Step  31: 6 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 203   Index:  46
+  Extra Steps: 24
+  Step  24: 7 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 203   Index: 104
+  Step   5: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 203   Index: 125
+  Step  10: 9 / Zombie x4 (7.148s)
+  Step  26: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 203   Index: 185
+Waterfalls B1F                                                                Seed: 203   Index: 194
+  Extra Steps: 4
+Waterfalls B2F                                                                Seed: 203   Index: 199
+Waterfalls Lake                                                               Seed: 203   Index: 244
+Battle: Octomamm                                                              Seed: 220   Index:  25
+Waterfalls Lake                                                               Seed: 220   Index:  25
+Overworld (Kaipo)                                                             Seed: 220   Index:  26
+  Step  10: 11 / SandMoth x2, Larva x2 (7.188s)
+Overworld (Damcyan)                                                           Seed: 220   Index:  37
+Damcyan                                                                       Seed: 220   Index:  41
+  Optional Steps: 1
+  Extra Steps: 52
+Overworld (Damcyan)                                                           Seed: 220   Index: 101
+Antlion B1F                                                                   Seed: 220   Index: 101
+  Step  27: 12 / Turtle x2 (7.487s)
+  Step  32: 13 / Imp x3 (6.649s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 220   Index: 139
+  Antlion B2F                                                                 Seed: 220   Index: 139
+  Antlion B2F Treasure Room                                                   Seed: 220   Index: 172
+    Extra Steps: 30
+  Antlion B2F                                                                 Seed: 220   Index: 202
+Antlion's Nest                                                                Seed: 220   Index: 254
+Battle: Antlion                                                               Seed: 237   Index:  12
+Antlion's Nest                                                                Seed: 237   Index:  12
+Antlion B2F Outward Direct                                                    Seed: 237   Index:  27
+  Antlion B2F                                                                 Seed: 237   Index:  27
+    Extra Steps: 6
+    Step   7: 14 / Turtle x2 (7.464s)
+    Step  39: 15 / Weeper x2 (7.132s)
+    Step  71: 16 / Basilisk x1, Imp x3 (6.783s)
+    Step  86: 17 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 237   Index: 113
+  Step  37: 18 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 237   Index: 151
+Overworld (Kaipo)                                                             Seed: 237   Index: 151
+Kaipo Revisited                                                               Seed: 237   Index: 151
+Overworld (Kaipo)                                                             Seed: 237   Index: 151
+Overworld (Damcyan)                                                           Seed: 237   Index: 151
+Mt.Hobs-West                                                                  Seed: 237   Index: 151
+  Step  12: 19 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 237   Index: 190
+Battle: MomBomb                                                               Seed: 237   Index: 205
+Mt.Hobs Summit                                                                Seed: 237   Index: 205
+Mt.Hobs-East                                                                  Seed: 237   Index: 211
+  Step  16: 20 / Red Bone x1, Skelton x3 (8.007s)
+  Step  43: 21 / Spirit x2, Skelton x2 (8.237s)
+  Step  45: 22 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 254   Index:   1
+  Step  36: 23 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 254   Index:  85
+  Optional Steps: 7
+Overworld (Fabul)                                                             Seed: 254   Index: 152
+Fabul Boat and Leviatan                                                       Seed: 254   Index: 159
+Overworld (Mysidia)                                                           Seed: 254   Index: 159
+Mysidia                                                                       Seed: 254   Index: 168
+Overworld (Mysidia)                                                           Seed: 254   Index: 168
+Overworld (Mt.Ordeals)                                                        Seed: 254   Index: 178
+  Step   2: 24 / Raven x1, Cocktric x3 (9.100s)
+  Step  15: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  47: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  91: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  15   Index:  16
+  Step  13: 28 / Red Bone x1, Skelton x3 (8.067s)
+  Step  19: 29 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  15   Index:  59
+  Step   5: 30 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  15   Index:  82
+Mt.Ordeals-3rd station                                                        Seed:  15   Index:  82
+Mt.Ordeals-7th station                                                        Seed:  15   Index:  87
+Mt.Ordeals Summit                                                             Seed:  15   Index: 129
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  15   Index: 147
+Mt.Ordeals Summit                                                             Seed:  15   Index: 147
+Paladin                                                                       Seed:  15   Index: 151
+Mt.Ordeals Summit                                                             Seed:  15   Index: 151
+  Optional Steps: 1
+  Step   7: 31 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed:  15   Index: 174
+  Step  38: 32 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed:  15   Index: 216
+  Step   6: 33 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed:  15   Index: 246
+  Step   9: 34 / Spirit x2, Skelton x2 (8.065s)
+  Step  17: 35 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  32   Index:  34
+Take Chocobo to Mysidia                                                       Seed:  32   Index:  47
+Overworld (Mysidia)                                                           Seed:  32   Index:  47
+Town of Baron Serpent Road                                                    Seed:  32   Index:  47
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed:  32   Index:  59
+  Overworld (Baron)                                                           Seed:  32   Index:  59
+    Extra Steps: 10
+    Step   1: 36 / FloatEye x1, Eagle x2 (7.365s)
+    Step  10: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step  33: 38 / FloatEye x1, Eagle x2)
+   (Step  82: 39 / Imp x3, SwordRat x1)
+   (Step 129: 40 / Imp x3)
+   (Step 161: 41 / Eagle x3)
+   (Step 224: 42 / Eagle x3)
+   (Step 244: 43 / Eagle x3)
+   (Step 255: 44 / FloatEye x2)
+
+Encounter Time:      281.597s
+Other Time:          536.616s
+Total Time:          818.214s
+
+Base Total Time:     889.376s
+Time Saved:          71.162s
+
+Optional Steps:      10
+Extra Steps:         182
+Encounters:          37
+
+Base Encounters:     46
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/187.txt
+++ b/data/routes/cw/187.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	187
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49873017
+VARS	FFFFFFFF:24 C307800:1 E302500:7 E302600:8 E305400:112 E307400:10 E307802:6 E307B00:30 E308400:4 E309700:14
+
+Overworld (Kaipo)                                                             Seed: 187   Index:   0
+Overworld (Kaipo)                                                             Seed: 187   Index:   1
+  Step  20: 1 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed: 187   Index:  37
+Overworld (Kaipo)                                                             Seed: 187   Index:  37
+  Step   3: 2 / Sand Man x4 (7.242s)
+  Step  26: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 187   Index:  69
+Recruit Tellah                                                                Seed: 187   Index: 101
+Watery Pass-South B1F                                                         Seed: 187   Index: 101
+Watery Pass-South B2F                                                         Seed: 187   Index: 121
+  Step  24: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  51: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  70: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 187   Index: 211
+  Extra Steps: 112
+Watery Pass-South B2F                                                         Seed: 204   Index:  71
+  Step  38: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 204   Index: 110
+Watery Pass-North B2F                                                         Seed: 204   Index: 144
+  Step   7: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 204   Index: 165
+  Step  34: 9 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 204   Index: 225
+Waterfalls B1F                                                                Seed: 204   Index: 234
+  Extra Steps: 10
+Waterfalls B2F                                                                Seed: 204   Index: 245
+Waterfalls Lake                                                               Seed: 221   Index:  34
+  Step   2: 10 / Aligator x2 (7.544s)
+Battle: Octomamm                                                              Seed: 221   Index:  71
+Waterfalls Lake                                                               Seed: 221   Index:  71
+Overworld (Kaipo)                                                             Seed: 221   Index:  72
+  Step   2: 11 / SandMoth x2, Larva x2 (7.188s)
+Overworld (Damcyan)                                                           Seed: 221   Index:  83
+Damcyan                                                                       Seed: 221   Index:  87
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed: 221   Index: 101
+Antlion B1F                                                                   Seed: 221   Index: 101
+  Step  27: 12 / Turtle x2 (7.487s)
+  Step  31: 13 / Imp x3 (6.649s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 221   Index: 139
+  Antlion B2F                                                                 Seed: 221   Index: 139
+  Antlion B2F Treasure Room                                                   Seed: 221   Index: 172
+    Extra Steps: 30
+  Antlion B2F                                                                 Seed: 221   Index: 202
+Antlion's Nest                                                                Seed: 221   Index: 254
+Battle: Antlion                                                               Seed: 238   Index:  12
+Antlion's Nest                                                                Seed: 238   Index:  12
+Antlion B2F Outward Direct                                                    Seed: 238   Index:  27
+  Antlion B2F                                                                 Seed: 238   Index:  27
+    Extra Steps: 6
+    Step   7: 14 / Turtle x2 (7.464s)
+    Step  39: 15 / SandWorm x2 (6.858s)
+    Step  71: 16 / Basilisk x1, Imp x3 (6.783s)
+    Step  86: 17 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 238   Index: 113
+  Step  37: 18 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 238   Index: 151
+Overworld (Kaipo)                                                             Seed: 238   Index: 151
+Kaipo Revisited                                                               Seed: 238   Index: 151
+Overworld (Kaipo)                                                             Seed: 238   Index: 151
+Overworld (Damcyan)                                                           Seed: 238   Index: 151
+Mt.Hobs-West                                                                  Seed: 238   Index: 151
+  Step  11: 19 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 238   Index: 190
+Battle: MomBomb                                                               Seed: 238   Index: 205
+Mt.Hobs Summit                                                                Seed: 238   Index: 205
+Mt.Hobs-East                                                                  Seed: 238   Index: 211
+  Step  16: 20 / Red Bone x1, Skelton x3 (8.007s)
+  Step  43: 21 / Spirit x2, Skelton x2 (8.237s)
+  Step  45: 22 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 255   Index:   1
+  Step  36: 23 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed: 255   Index:  85
+  Optional Steps: 8
+Overworld (Fabul)                                                             Seed: 255   Index: 153
+Fabul Boat and Leviatan                                                       Seed: 255   Index: 160
+Overworld (Mysidia)                                                           Seed: 255   Index: 160
+Mysidia                                                                       Seed: 255   Index: 169
+Overworld (Mysidia)                                                           Seed: 255   Index: 169
+Overworld (Mt.Ordeals)                                                        Seed: 255   Index: 179
+  Step   1: 24 / Raven x1, Cocktric x3 (9.100s)
+  Step  14: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  46: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  79: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  90: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  16   Index:  17
+  Extra Steps: 4
+  Step  12: 29 / Red Bone x1, Skelton x3 (8.067s)
+  Step  18: 30 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  47: 31 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  16   Index:  64
+Recruit Tellah                                                                Seed:  16   Index:  87
+Mt.Ordeals-3rd station                                                        Seed:  16   Index:  87
+Mt.Ordeals-7th station                                                        Seed:  16   Index:  92
+Mt.Ordeals Summit                                                             Seed:  16   Index: 134
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed:  16   Index: 151
+Mt.Ordeals Summit                                                             Seed:  16   Index: 151
+Paladin                                                                       Seed:  16   Index: 155
+Mt.Ordeals Summit                                                             Seed:  16   Index: 155
+  Optional Steps: 0
+  Step   3: 32 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed:  16   Index: 177
+  Step  35: 33 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed:  16   Index: 219
+  Step   3: 34 / Ghoul x1, Red Bone x2, Skelton x2 (8.549s)
+Mt.Ordeals                                                                    Seed:  16   Index: 249
+  Step  14: 35 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  33   Index:  37
+Take Chocobo to Mysidia                                                       Seed:  33   Index:  50
+Overworld (Mysidia)                                                           Seed:  33   Index:  50
+Town of Baron Serpent Road                                                    Seed:  33   Index:  50
+  Extra Steps: 14
+Credit Warp Fight Search                                                      Seed:  33   Index:  68
+  Overworld (Baron)                                                           Seed:  33   Index:  68
+    Extra Steps: 24
+    Step   1: 36 / FloatEye x1, Eagle x2 (7.365s)
+    Step  24: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step  73: 38 / FloatEye x1, Eagle x2)
+   (Step 120: 39 / Eagle x3)
+   (Step 152: 40 / Imp x3)
+   (Step 173: 41 / Eagle x3)
+   (Step 215: 42 / Eagle x3)
+   (Step 242: 43 / Imp x4)
+   (Step 246: 44 / FloatEye x2)
+   (Step 249: 45 / Imp x4)
+
+Encounter Time:      283.117s
+Other Time:          546.733s
+Total Time:          829.850s
+
+Base Total Time:     1111.396s
+Time Saved:          281.546s
+
+Optional Steps:      9
+Extra Steps:         206
+Encounters:          37
+
+Base Encounters:     56
+Encounters Saved:    19
+
+Number of Variables: 54

--- a/data/routes/cw/188.txt
+++ b/data/routes/cw/188.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	188
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50205269
+VARS	FFFFFFFF:12 E000202:42 E302600:4 E307000:8 E307400:4 E308000:22 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 188   Index:   0
+Overworld (Kaipo)                                                             Seed: 188   Index:   1
+Kaipo                                                                         Seed: 188   Index:  37
+Overworld (Kaipo)                                                             Seed: 188   Index:  37
+  Step   3: 1 / Sandpede x1, Sand Man x2 (7.096s)
+  Step  26: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 188   Index:  69
+Recruit Tellah                                                                Seed: 188   Index: 101
+Watery Pass-South B1F                                                         Seed: 188   Index: 101
+  Step   3: 3 / CaveToad x3 (7.014s)
+Watery Pass-South B2F                                                         Seed: 188   Index: 121
+  Step  24: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  51: 5 / Pike x3 (7.152s)
+  Step  70: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 188   Index: 211
+Watery Pass-South B2F                                                         Seed: 188   Index: 215
+  Extra Steps: 8
+  Step  18: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  47: 8 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 205   Index:   6
+  Step  32: 9 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed: 205   Index:  40
+Watery Pass-North B1F                                                         Seed: 205   Index:  61
+  Step   9: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  48: 11 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 205   Index: 121
+Waterfalls B1F                                                                Seed: 205   Index: 130
+  Extra Steps: 4
+Waterfalls B2F                                                                Seed: 205   Index: 135
+  Step  16: 12 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed: 205   Index: 180
+  Step  19: 13 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 205   Index: 217
+Waterfalls Lake                                                               Seed: 205   Index: 217
+Overworld (Kaipo)                                                             Seed: 205   Index: 218
+Overworld (Damcyan)                                                           Seed: 205   Index: 229
+Damcyan                                                                       Seed: 205   Index: 233
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 205   Index: 240
+Antlion B1F                                                                   Seed: 205   Index: 240
+  Step   4: 14 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 222   Index:  22
+  Antlion B2F                                                                 Seed: 222   Index:  22
+    Step  14: 15 / SandWorm x2 (6.841s)
+    Step  52: 16 / Basilisk x1, Imp x3 (6.775s)
+    Step  78: 17 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 222   Index: 102
+Battle: Antlion                                                               Seed: 222   Index: 116
+Antlion's Nest                                                                Seed: 222   Index: 116
+  Step  12: 18 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed: 222   Index: 131
+  Antlion B2F                                                                 Seed: 222   Index: 131
+    Step   1: 19 / Basilisk x1, Turtle x1 (7.124s)
+    Step  33: 20 / Basilisk x1, Turtle x1 (7.124s)
+    Step  44: 21 / Cream x4 (7.523s)
+    Step  66: 22 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed: 222   Index: 211
+Overworld (Damcyan)                                                           Seed: 222   Index: 249
+Overworld (Kaipo)                                                             Seed: 222   Index: 249
+  Extra Steps: 42
+  Step  41: 23 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed: 239   Index:  35
+Overworld (Kaipo)                                                             Seed: 239   Index:  35
+Overworld (Damcyan)                                                           Seed: 239   Index:  35
+Mt.Hobs-West                                                                  Seed: 239   Index:  35
+  Step  31: 24 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 239   Index:  74
+Battle: MomBomb                                                               Seed: 239   Index:  89
+Mt.Hobs Summit                                                                Seed: 239   Index:  89
+Mt.Hobs-East                                                                  Seed: 239   Index:  95
+  Extra Steps: 22
+  Step   3: 25 / Gargoyle x2 (7.630s)
+  Step  18: 26 / Turtle x2 (7.432s)
+  Step  67: 27 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 239   Index: 163
+  Step  31: 28 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  64: 29 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 239   Index: 247
+  Optional Steps: 4
+Overworld (Fabul)                                                             Seed:   0   Index:  55
+Fabul Boat and Leviatan                                                       Seed:   0   Index:  62
+Overworld (Mysidia)                                                           Seed:   0   Index:  62
+Mysidia                                                                       Seed:   0   Index:  71
+Overworld (Mysidia)                                                           Seed:   0   Index:  71
+Overworld (Mt.Ordeals)                                                        Seed:   0   Index:  81
+  Step   6: 30 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  16: 31 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  39: 32 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  49: 33 / Raven x1 (8.356s)
+  Step  63: 34 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:   0   Index: 175
+  Step   5: 35 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:   0   Index: 218
+Recruit Tellah                                                                Seed:   0   Index: 241
+Mt.Ordeals-3rd station                                                        Seed:   0   Index: 241
+Mt.Ordeals-7th station                                                        Seed:   0   Index: 246
+  Step  12: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  23: 37 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  39: 38 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  17   Index:  32
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  17   Index:  50
+Mt.Ordeals Summit                                                             Seed:  17   Index:  50
+Paladin                                                                       Seed:  17   Index:  54
+Mt.Ordeals Summit                                                             Seed:  17   Index:  54
+  Optional Steps: 1
+  Step  10: 39 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed:  17   Index:  77
+  Step  16: 40 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed:  17   Index: 119
+Mt.Ordeals                                                                    Seed:  17   Index: 149
+  Step   9: 41 / Soul x2, Red Bone x2 (8.881s)
+Overworld (Mt.Ordeals)                                                        Seed:  17   Index: 193
+Take Chocobo to Mysidia                                                       Seed:  17   Index: 206
+Overworld (Mysidia)                                                           Seed:  17   Index: 206
+Town of Baron Serpent Road                                                    Seed:  17   Index: 206
+Credit Warp Fight Search                                                      Seed:  17   Index: 210
+  Overworld (Baron)                                                           Seed:  17   Index: 210
+    Extra Steps: 12
+    Step   2: 42 / Eagle x3 (7.417s)
+    Step  12: 43 / Imp x4 (7.223s)
+   (Step  53: 44 / FloatEye x2)
+   (Step 115: 45 / Imp x4)
+   (Step 167: 46 / Imp x4)
+   (Step 187: 47 / Imp x3, SwordRat x1)
+   (Step 234: 48 / FloatEye x2)
+
+Encounter Time:      327.848s
+Other Time:          507.531s
+Total Time:          835.379s
+
+Base Total Time:     882.549s
+Time Saved:          47.170s
+
+Optional Steps:      6
+Extra Steps:         88
+Encounters:          43
+
+Base Encounters:     46
+Encounters Saved:    3
+
+Number of Variables: 54

--- a/data/routes/cw/189.txt
+++ b/data/routes/cw/189.txt
@@ -1,0 +1,157 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	189
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49983950
+VARS	FFFFFFFF:4 E302500:2 E302600:10 E307000:8 E307400:4 E307700:12 E307900:34 E308000:16 E308700:1 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed: 189   Index:   0
+Overworld (Kaipo)                                                             Seed: 189   Index:   1
+  Step  17: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 189   Index:  37
+Overworld (Kaipo)                                                             Seed: 189   Index:  37
+  Step   3: 2 / Sand Man x4 (7.242s)
+  Step  26: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 189   Index:  69
+Recruit Tellah                                                                Seed: 189   Index: 101
+Watery Pass-South B1F                                                         Seed: 189   Index: 101
+  Step   3: 4 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F                                                         Seed: 189   Index: 121
+  Step  51: 5 / Pike x3 (7.152s)
+  Step  70: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 189   Index: 211
+Watery Pass-South B2F                                                         Seed: 189   Index: 215
+  Extra Steps: 8
+  Step  18: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  47: 8 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 206   Index:   6
+  Step  32: 9 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed: 206   Index:  40
+Watery Pass-North B1F                                                         Seed: 206   Index:  61
+  Step   9: 10 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 206   Index: 121
+Waterfalls B1F                                                                Seed: 206   Index: 130
+  Extra Steps: 4
+Waterfalls B2F                                                                Seed: 206   Index: 135
+  Step  16: 11 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 206   Index: 180
+  Step  19: 12 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 206   Index: 217
+Waterfalls Lake                                                               Seed: 206   Index: 217
+Overworld (Kaipo)                                                             Seed: 206   Index: 218
+Overworld (Damcyan)                                                           Seed: 206   Index: 229
+Damcyan                                                                       Seed: 206   Index: 233
+  Optional Steps: 0
+  Extra Steps: 2
+Overworld (Damcyan)                                                           Seed: 206   Index: 242
+Antlion B1F                                                                   Seed: 206   Index: 242
+  Extra Steps: 12
+  Step   2: 13 / Imp x3 (6.649s)
+  Step  50: 14 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 223   Index:  36
+  Antlion B2F                                                                 Seed: 223   Index:  36
+    Step  19: 15 / SandWorm x2 (6.841s)
+    Step  38: 16 / Basilisk x1, Imp x3 (6.775s)
+    Step  64: 17 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 223   Index: 116
+  Extra Steps: 34
+  Step  12: 18 / Cream x4 (7.552s)
+  Step  16: 19 / Basilisk x1, Turtle x1 (7.110s)
+  Step  48: 20 / Basilisk x1, Turtle x1 (7.110s)
+Battle: Antlion                                                               Seed: 223   Index: 164
+Antlion's Nest                                                                Seed: 223   Index: 164
+  Step  11: 21 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed: 223   Index: 179
+  Antlion B2F                                                                 Seed: 223   Index: 179
+Antlion B1F                                                                   Seed: 240   Index:   3
+  Step  31: 22 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed: 240   Index:  41
+Overworld (Kaipo)                                                             Seed: 240   Index:  41
+Kaipo Revisited                                                               Seed: 240   Index:  41
+Overworld (Kaipo)                                                             Seed: 240   Index:  41
+Overworld (Damcyan)                                                           Seed: 240   Index:  41
+Mt.Hobs-West                                                                  Seed: 240   Index:  41
+  Step  25: 23 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed: 240   Index:  80
+Battle: MomBomb                                                               Seed: 240   Index:  95
+Mt.Hobs Summit                                                                Seed: 240   Index:  95
+  Step   3: 24 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed: 240   Index: 101
+  Extra Steps: 16
+  Step  12: 25 / Gargoyle x2 (7.630s)
+  Step  61: 26 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 240   Index: 163
+  Step  31: 27 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  47: 28 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  64: 29 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 240   Index: 247
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:   1   Index:  61
+Fabul Boat and Leviatan                                                       Seed:   1   Index:  68
+Overworld (Mysidia)                                                           Seed:   1   Index:  68
+Mysidia                                                                       Seed:   1   Index:  77
+Overworld (Mysidia)                                                           Seed:   1   Index:  77
+  Step  10: 30 / Imp Cap. x3, Needler x1 (7.932s)
+Overworld (Mt.Ordeals)                                                        Seed:   1   Index:  87
+  Step  10: 31 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  33: 32 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  43: 33 / Raven x1 (8.356s)
+  Step  57: 34 / Raven x1 (8.356s)
+  Step  93: 35 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:   1   Index: 181
+Mt.Ordeals-3rd station                                                        Seed:   1   Index: 224
+Recruit Tellah                                                                Seed:   1   Index: 247
+Mt.Ordeals-3rd station                                                        Seed:   1   Index: 247
+Mt.Ordeals-7th station                                                        Seed:   1   Index: 252
+  Step   6: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  33: 37 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  18   Index:  38
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  18   Index:  56
+Mt.Ordeals Summit                                                             Seed:  18   Index:  56
+Paladin                                                                       Seed:  18   Index:  60
+Mt.Ordeals Summit                                                             Seed:  18   Index:  60
+  Optional Steps: 1
+  Step   4: 38 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed:  18   Index:  83
+  Step  10: 39 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  18   Index: 125
+Mt.Ordeals                                                                    Seed:  18   Index: 155
+  Step   3: 40 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed:  18   Index: 199
+  Step  13: 41 / Raven x1 (8.065s)
+Take Chocobo to Mysidia                                                       Seed:  18   Index: 212
+Overworld (Mysidia)                                                           Seed:  18   Index: 212
+Town of Baron Serpent Road                                                    Seed:  18   Index: 212
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed:  18   Index: 220
+  Overworld (Baron)                                                           Seed:  18   Index: 220
+    Extra Steps: 4
+    Step   2: 42 / Eagle x3 (7.417s)
+    Step   4: 43 / Imp x4 (7.223s)
+   (Step  43: 44 / FloatEye x2)
+   (Step  67: 45 / Imp x4)
+   (Step 157: 46 / Imp x4)
+   (Step 177: 47 / Imp x3, SwordRat x1)
+   (Step 224: 48 / FloatEye x2)
+   (Step 256: 49 / FloatEye x2)
+
+Encounter Time:      327.360s
+Other Time:          504.336s
+Total Time:          831.696s
+
+Base Total Time:     880.223s
+Time Saved:          48.527s
+
+Optional Steps:      12
+Extra Steps:         84
+Encounters:          43
+
+Base Encounters:     45
+Encounters Saved:    2
+
+Number of Variables: 54

--- a/data/routes/cw/190.txt
+++ b/data/routes/cw/190.txt
@@ -1,0 +1,158 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	190
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49194827
+VARS	FFFFFFFF:4 C307800:1 C307801:1 E000600:12 E302500:5 E302600:10 E307000:8 E307400:4 E307B00:72 E307B01:58 E307F01:12 E308400:20 E308401:2 E308700:1 E308702:1 E309700:32
+
+Overworld (Kaipo)                                                             Seed: 190   Index:   0
+Overworld (Kaipo)                                                             Seed: 190   Index:   1
+  Step  17: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 190   Index:  37
+Overworld (Kaipo)                                                             Seed: 190   Index:  37
+  Step   3: 2 / Sand Man x4 (7.242s)
+  Step  26: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 190   Index:  69
+Recruit Tellah                                                                Seed: 190   Index: 101
+Watery Pass-South B1F                                                         Seed: 190   Index: 101
+  Step   3: 4 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F                                                         Seed: 190   Index: 121
+  Step  70: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 190   Index: 211
+Watery Pass-South B2F                                                         Seed: 190   Index: 215
+  Extra Steps: 8
+  Step  18: 6 / Pike x3 (7.152s)
+  Step  47: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 207   Index:   6
+  Step  32: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed: 207   Index:  40
+Watery Pass-North B1F                                                         Seed: 207   Index:  61
+  Step   9: 9 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 207   Index: 121
+Waterfalls B1F                                                                Seed: 207   Index: 130
+  Extra Steps: 4
+Waterfalls B2F                                                                Seed: 207   Index: 135
+  Step  16: 10 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed: 207   Index: 180
+  Step  27: 11 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 207   Index: 217
+Waterfalls Lake                                                               Seed: 207   Index: 217
+Overworld (Kaipo)                                                             Seed: 207   Index: 218
+Overworld (Damcyan)                                                           Seed: 207   Index: 229
+Damcyan                                                                       Seed: 207   Index: 233
+  Optional Steps: 1
+  Extra Steps: 4
+Overworld (Damcyan)                                                           Seed: 207   Index: 245
+Antlion B1F                                                                   Seed: 207   Index: 245
+Antlion B2F Inward Charm Room Steps                                           Seed: 224   Index:  27
+  Antlion B2F                                                                 Seed: 224   Index:  27
+    Step   9: 12 / Weeper x2 (7.114s)
+    Step  28: 13 / Cream x4 (7.552s)
+  Antlion B2F Treasure Room                                                   Seed: 224   Index:  60
+    Extra Steps: 72
+  Antlion B2F                                                                 Seed: 224   Index: 132
+    Step  32: 14 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 224   Index: 184
+Battle: Antlion                                                               Seed: 224   Index: 198
+Antlion's Nest                                                                Seed: 224   Index: 198
+Antlion B2F Outward Charm Room Steps                                          Seed: 224   Index: 213
+  Antlion B2F                                                                 Seed: 224   Index: 213
+    Step  15: 15 / SandWorm x2 (6.858s)
+  Antlion B2F Treasure Room                                                   Seed: 241   Index:   8
+    Extra Steps: 58
+  Antlion B2F                                                                 Seed: 241   Index:  66
+    Step  32: 16 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 241   Index: 100
+  Step  13: 17 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 241   Index: 138
+Overworld (Kaipo)                                                             Seed: 241   Index: 138
+Kaipo Revisited                                                               Seed: 241   Index: 138
+Overworld (Kaipo)                                                             Seed: 241   Index: 138
+Overworld (Damcyan)                                                           Seed: 241   Index: 138
+Mt.Hobs-West                                                                  Seed: 241   Index: 138
+  Step  24: 18 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 241   Index: 177
+Battle: MomBomb                                                               Seed: 241   Index: 192
+Mt.Hobs Summit                                                                Seed: 241   Index: 192
+  Extra Steps: 12
+  Step   2: 19 / Cocktric x3 (7.853s)
+  Step  18: 20 / Cocktric x3 (7.853s)
+Mt.Hobs-East                                                                  Seed: 241   Index: 210
+Overworld (Fabul)                                                             Seed:   2   Index:   0
+  Step  37: 21 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  56: 22 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed:   2   Index:  84
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:   2   Index: 154
+Fabul Boat and Leviatan                                                       Seed:   2   Index: 161
+Overworld (Mysidia)                                                           Seed:   2   Index: 161
+Mysidia                                                                       Seed:   2   Index: 170
+Overworld (Mysidia)                                                           Seed:   2   Index: 170
+Overworld (Mt.Ordeals)                                                        Seed:   2   Index: 180
+  Extra Steps: 12
+  Step  78: 23 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  89: 24 / Raven x1 (8.356s)
+  Step 105: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  19   Index:  30
+  Extra Steps: 20
+  Step  34: 26 / Skelton x3, Red Bone x2 (8.244s)
+  Step  37: 27 / Red Bone x1, Skelton x3 (8.067s)
+  Step  63: 28 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  19   Index:  93
+Recruit Tellah                                                                Seed:  19   Index: 116
+Mt.Ordeals-3rd station                                                        Seed:  19   Index: 116
+Mt.Ordeals-7th station                                                        Seed:  19   Index: 121
+  Step  37: 29 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed:  19   Index: 163
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  19   Index: 181
+Mt.Ordeals Summit                                                             Seed:  19   Index: 181
+Paladin                                                                       Seed:  19   Index: 185
+Mt.Ordeals Summit                                                             Seed:  19   Index: 185
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  19   Index: 208
+  Step  14: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  16: 31 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed:  19   Index: 250
+  Step  13: 32 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed:  36   Index:  24
+  Extra Steps: 2
+  Step   7: 33 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed:  36   Index:  70
+Take Chocobo to Mysidia                                                       Seed:  36   Index:  83
+Overworld (Mysidia)                                                           Seed:  36   Index:  83
+Town of Baron Serpent Road                                                    Seed:  36   Index:  83
+  Extra Steps: 32
+Credit Warp Fight Search                                                      Seed:  36   Index: 119
+  Overworld (Baron)                                                           Seed:  36   Index: 119
+    Extra Steps: 4
+    Step   2: 34 / Imp x3 (7.174s)
+    Step   4: 35 / Imp x3, SwordRat x1 (7.227s)
+   (Step  22: 36 / FloatEye x1, Eagle x2)
+   (Step  69: 37 / Imp x3, SwordRat x1)
+   (Step 101: 38 / FloatEye x1, Eagle x2)
+   (Step 122: 39 / Eagle x3)
+   (Step 152: 40 / Imp x3)
+   (Step 164: 41 / Eagle x3)
+   (Step 191: 42 / Eagle x3)
+   (Step 226: 43 / Imp x4)
+
+Encounter Time:      266.708s
+Other Time:          551.858s
+Total Time:          818.566s
+
+Base Total Time:     862.219s
+Time Saved:          43.654s
+
+Optional Steps:      13
+Extra Steps:         228
+Encounters:          35
+
+Base Encounters:     43
+Encounters Saved:    8
+
+Number of Variables: 54

--- a/data/routes/cw/191.txt
+++ b/data/routes/cw/191.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	191
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47720798
+VARS	FFFFFFFF:4 E302500:4 E302600:66 E307400:12 E308700:1 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed: 191   Index:   0
+Overworld (Kaipo)                                                             Seed: 191   Index:   1
+  Step  17: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 191   Index:  37
+Overworld (Kaipo)                                                             Seed: 191   Index:  37
+  Step   3: 2 / Sand Man x4 (7.242s)
+  Step  26: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 191   Index:  69
+Recruit Tellah                                                                Seed: 191   Index: 101
+Watery Pass-South B1F                                                         Seed: 191   Index: 101
+  Step   3: 4 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F                                                         Seed: 191   Index: 121
+  Step  63: 5 / Pike x3 (7.152s)
+  Step  70: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 191   Index: 211
+Watery Pass-South B2F                                                         Seed: 191   Index: 215
+Watery Pass-South B3F                                                         Seed: 191   Index: 254
+Watery Pass-North B2F                                                         Seed: 208   Index:  32
+  Step   6: 7 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B1F                                                         Seed: 208   Index:  53
+  Step  17: 8 / Jelly x4 (7.324s)
+  Step  31: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 208   Index: 113
+Waterfalls B1F                                                                Seed: 208   Index: 122
+  Extra Steps: 12
+Waterfalls B2F                                                                Seed: 208   Index: 135
+Waterfalls Lake                                                               Seed: 208   Index: 180
+  Step  27: 10 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 208   Index: 217
+Waterfalls Lake                                                               Seed: 208   Index: 217
+Overworld (Kaipo)                                                             Seed: 208   Index: 218
+Overworld (Damcyan)                                                           Seed: 208   Index: 229
+Damcyan                                                                       Seed: 208   Index: 233
+  Optional Steps: 0
+  Extra Steps: 4
+Overworld (Damcyan)                                                           Seed: 208   Index: 244
+Antlion B1F                                                                   Seed: 208   Index: 244
+  Step  15: 11 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Direct                                                     Seed: 225   Index:  26
+  Antlion B2F                                                                 Seed: 225   Index:  26
+    Step  10: 12 / Weeper x2 (7.114s)
+    Step  29: 13 / Cream x4 (7.552s)
+    Step  74: 14 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 225   Index: 106
+Battle: Antlion                                                               Seed: 225   Index: 120
+Antlion's Nest                                                                Seed: 225   Index: 120
+  Step   8: 15 / SandWorm x2 (6.858s)
+  Step  12: 16 / Basilisk x1, Imp x3 (6.783s)
+Antlion B2F Outward Direct                                                    Seed: 225   Index: 135
+  Antlion B2F                                                                 Seed: 225   Index: 135
+    Step  29: 17 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 225   Index: 215
+  Step  13: 18 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 225   Index: 253
+Overworld (Kaipo)                                                             Seed: 225   Index: 253
+Kaipo Revisited                                                               Seed: 225   Index: 253
+Overworld (Kaipo)                                                             Seed: 225   Index: 253
+Overworld (Damcyan)                                                           Seed: 225   Index: 253
+Mt.Hobs-West                                                                  Seed: 225   Index: 253
+Mt.Hobs Summit                                                                Seed: 242   Index:  36
+Battle: MomBomb                                                               Seed: 242   Index:  51
+Mt.Hobs Summit                                                                Seed: 242   Index:  51
+  Step   6: 19 / Cocktric x3 (7.853s)
+Mt.Hobs-East                                                                  Seed: 242   Index:  57
+  Step   9: 20 / Red Bone x1, Skelton x3 (8.007s)
+  Step  41: 21 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 242   Index: 103
+  Step  10: 22 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  59: 23 / Cocktric x3 (8.241s)
+  Step  76: 24 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed: 242   Index: 187
+  Optional Steps: 10
+  Extra Steps: 56
+Overworld (Fabul)                                                             Seed:   3   Index:  57
+Fabul Boat and Leviatan                                                       Seed:   3   Index:  64
+Overworld (Mysidia)                                                           Seed:   3   Index:  64
+Mysidia                                                                       Seed:   3   Index:  73
+Overworld (Mysidia)                                                           Seed:   3   Index:  73
+Overworld (Mt.Ordeals)                                                        Seed:   3   Index:  83
+  Step   4: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  14: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  37: 27 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  47: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  61: 29 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  63: 30 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:   3   Index: 177
+  Step   5: 31 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:   3   Index: 220
+Recruit Tellah                                                                Seed:   3   Index: 243
+Mt.Ordeals-3rd station                                                        Seed:   3   Index: 243
+Mt.Ordeals-7th station                                                        Seed:   3   Index: 248
+  Step  10: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  37: 33 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed:  20   Index:  34
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  20   Index:  52
+Mt.Ordeals Summit                                                             Seed:  20   Index:  52
+Paladin                                                                       Seed:  20   Index:  56
+Mt.Ordeals Summit                                                             Seed:  20   Index:  56
+  Optional Steps: 1
+  Step  11: 34 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed:  20   Index:  79
+  Step  14: 35 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed:  20   Index: 121
+Mt.Ordeals                                                                    Seed:  20   Index: 151
+  Step   7: 36 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed:  20   Index: 195
+Take Chocobo to Mysidia                                                       Seed:  20   Index: 208
+Overworld (Mysidia)                                                           Seed:  20   Index: 208
+Town of Baron Serpent Road                                                    Seed:  20   Index: 208
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed:  20   Index: 220
+  Overworld (Baron)                                                           Seed:  20   Index: 220
+    Extra Steps: 4
+    Step   2: 37 / Imp x3, SwordRat x1 (7.227s)
+    Step   4: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  31: 39 / Eagle x3)
+   (Step  67: 40 / Imp x3)
+   (Step 130: 41 / Eagle x3)
+   (Step 157: 42 / Imp x4)
+   (Step 159: 43 / Imp x4)
+   (Step 177: 44 / FloatEye x2)
+   (Step 256: 45 / Imp x4)
+
+Encounter Time:      289.703s
+Other Time:          504.336s
+Total Time:          794.039s
+
+Base Total Time:     886.736s
+Time Saved:          92.698s
+
+Optional Steps:      12
+Extra Steps:         84
+Encounters:          38
+
+Base Encounters:     42
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/192.txt
+++ b/data/routes/cw/192.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	192
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48223506
+VARS	FFFFFFFF:4 C307800:1 E302500:15 E302600:2 E307100:6 E307400:10 E307700:14 E307B00:40
+
+Overworld (Kaipo)                                                             Seed: 192   Index:   0
+Overworld (Kaipo)                                                             Seed: 192   Index:   1
+  Step  17: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 192   Index:  37
+Overworld (Kaipo)                                                             Seed: 192   Index:  37
+  Step   3: 2 / Sand Man x4 (7.242s)
+  Step  26: 3 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 192   Index:  69
+Recruit Tellah                                                                Seed: 192   Index: 101
+Watery Pass-South B1F                                                         Seed: 192   Index: 101
+  Step   3: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step   5: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 192   Index: 121
+  Step  63: 6 / Pike x3 (7.152s)
+  Step  70: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 192   Index: 211
+Watery Pass-South B2F                                                         Seed: 192   Index: 215
+Watery Pass-South B3F                                                         Seed: 192   Index: 254
+  Extra Steps: 6
+Watery Pass-North B2F                                                         Seed: 209   Index:  38
+Watery Pass-North B1F                                                         Seed: 209   Index:  59
+  Step  11: 8 / Jelly x4 (7.324s)
+  Step  25: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 209   Index: 119
+Waterfalls B1F                                                                Seed: 209   Index: 128
+  Extra Steps: 10
+Waterfalls B2F                                                                Seed: 209   Index: 139
+Waterfalls Lake                                                               Seed: 209   Index: 184
+  Step  23: 10 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 209   Index: 221
+Waterfalls Lake                                                               Seed: 209   Index: 221
+Overworld (Kaipo)                                                             Seed: 209   Index: 222
+Overworld (Damcyan)                                                           Seed: 209   Index: 233
+Damcyan                                                                       Seed: 209   Index: 237
+  Optional Steps: 1
+  Extra Steps: 14
+Overworld (Damcyan)                                                           Seed: 226   Index:   3
+Antlion B1F                                                                   Seed: 226   Index:   3
+  Extra Steps: 14
+  Step  52: 11 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 226   Index:  55
+  Antlion B2F                                                                 Seed: 226   Index:  55
+  Antlion B2F Treasure Room                                                   Seed: 226   Index:  88
+    Extra Steps: 40
+  Antlion B2F                                                                 Seed: 226   Index: 128
+    Step   4: 12 / Weeper x2 (7.114s)
+    Step  36: 13 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 226   Index: 180
+  Step  12: 14 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed: 226   Index: 194
+Antlion's Nest                                                                Seed: 226   Index: 194
+Antlion B2F Outward Direct                                                    Seed: 226   Index: 209
+  Antlion B2F                                                                 Seed: 226   Index: 209
+    Step  19: 15 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 243   Index:  33
+  Step  24: 16 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  32: 17 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 243   Index:  71
+Overworld (Kaipo)                                                             Seed: 243   Index:  71
+Kaipo Revisited                                                               Seed: 243   Index:  71
+Overworld (Kaipo)                                                             Seed: 243   Index:  71
+Overworld (Damcyan)                                                           Seed: 243   Index:  71
+Mt.Hobs-West                                                                  Seed: 243   Index:  71
+  Step  27: 18 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 243   Index: 110
+  Step   3: 19 / Cocktric x3 (9.055s)
+Battle: MomBomb                                                               Seed: 243   Index: 125
+Mt.Hobs Summit                                                                Seed: 243   Index: 125
+Mt.Hobs-East                                                                  Seed: 243   Index: 131
+  Step  31: 20 / Red Bone x1, Skelton x3 (8.007s)
+Overworld (Fabul)                                                             Seed: 243   Index: 177
+  Step   2: 21 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  17: 22 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  33: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed:   4   Index:   5
+  Optional Steps: 2
+Overworld (Fabul)                                                             Seed:   4   Index:  67
+Fabul Boat and Leviatan                                                       Seed:   4   Index:  74
+Overworld (Mysidia)                                                           Seed:   4   Index:  74
+  Step   7: 24 / Raven x1 (8.246s)
+Mysidia                                                                       Seed:   4   Index:  83
+Overworld (Mysidia)                                                           Seed:   4   Index:  83
+  Step   4: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Overworld (Mt.Ordeals)                                                        Seed:   4   Index:  93
+  Step   4: 26 / Needler x2, SwordRat x2 (8.097s)
+  Step  27: 27 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  37: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  51: 29 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  53: 30 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  89: 31 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:   4   Index: 187
+Mt.Ordeals-3rd station                                                        Seed:   4   Index: 230
+Recruit Tellah                                                                Seed:   4   Index: 253
+Mt.Ordeals-3rd station                                                        Seed:   4   Index: 253
+  Step   5: 32 / Zombie x2, Ghoul x2 (7.616s)
+Mt.Ordeals-7th station                                                        Seed:  21   Index:   2
+  Step  27: 33 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed:  21   Index:  44
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed:  21   Index:  61
+Mt.Ordeals Summit                                                             Seed:  21   Index:  61
+Paladin                                                                       Seed:  21   Index:  65
+Mt.Ordeals Summit                                                             Seed:  21   Index:  65
+  Optional Steps: 0
+  Step   2: 34 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed:  21   Index:  87
+  Step   6: 35 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step   9: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  21   Index: 129
+Mt.Ordeals                                                                    Seed:  21   Index: 159
+Overworld (Mt.Ordeals)                                                        Seed:  21   Index: 203
+Take Chocobo to Mysidia                                                       Seed:  21   Index: 216
+Overworld (Mysidia)                                                           Seed:  21   Index: 216
+Town of Baron Serpent Road                                                    Seed:  21   Index: 216
+Credit Warp Fight Search                                                      Seed:  21   Index: 220
+  Overworld (Baron)                                                           Seed:  21   Index: 220
+    Extra Steps: 4
+    Step   2: 37 / Imp x3, SwordRat x1 (7.227s)
+    Step   4: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  31: 39 / Eagle x3)
+   (Step  67: 40 / Imp x3)
+   (Step 109: 41 / Eagle x3)
+   (Step 130: 42 / Imp x4)
+   (Step 157: 43 / Imp x4)
+   (Step 159: 44 / FloatEye x2)
+   (Step 177: 45 / Imp x3, SwordRat x1)
+
+Encounter Time:      292.410s
+Other Time:          509.993s
+Total Time:          802.404s
+
+Base Total Time:     893.707s
+Time Saved:          91.303s
+
+Optional Steps:      3
+Extra Steps:         88
+Encounters:          38
+
+Base Encounters:     45
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/193.txt
+++ b/data/routes/cw/193.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	193
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48900844
+VARS	FFFFFFFF:22 C307800:1 E302500:15 E302600:30 E307400:16 E307B00:118 E308601:2 E308700:1 E308702:1 E309700:12
+
+Overworld (Kaipo)                                                             Seed: 193   Index:   0
+Overworld (Kaipo)                                                             Seed: 193   Index:   1
+  Step  17: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 193   Index:  37
+Overworld (Kaipo)                                                             Seed: 193   Index:  37
+  Step   3: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 193   Index:  69
+Recruit Tellah                                                                Seed: 193   Index: 101
+Watery Pass-South B1F                                                         Seed: 193   Index: 101
+  Step   3: 3 / CaveToad x3 (7.014s)
+  Step   5: 4 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F                                                         Seed: 193   Index: 121
+  Step  35: 5 / Pike x3 (7.152s)
+  Step  63: 6 / Pike x3 (7.152s)
+  Step  70: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 193   Index: 211
+Watery Pass-South B2F                                                         Seed: 193   Index: 215
+Watery Pass-South B3F                                                         Seed: 193   Index: 254
+Watery Pass-North B2F                                                         Seed: 210   Index:  32
+Watery Pass-North B1F                                                         Seed: 210   Index:  53
+  Step  17: 8 / Jelly x4 (7.324s)
+  Step  31: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 210   Index: 113
+Waterfalls B1F                                                                Seed: 210   Index: 122
+  Extra Steps: 16
+Waterfalls B2F                                                                Seed: 210   Index: 139
+Waterfalls Lake                                                               Seed: 210   Index: 184
+  Step  16: 10 / Aligator x1, WaterBug x2 (7.292s)
+  Step  23: 11 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 210   Index: 221
+Waterfalls Lake                                                               Seed: 210   Index: 221
+Overworld (Kaipo)                                                             Seed: 210   Index: 222
+Overworld (Damcyan)                                                           Seed: 210   Index: 233
+Damcyan                                                                       Seed: 210   Index: 237
+  Optional Steps: 1
+  Extra Steps: 14
+Overworld (Damcyan)                                                           Seed: 227   Index:   3
+Antlion B1F                                                                   Seed: 227   Index:   3
+Antlion B2F Inward Charm Room Steps                                           Seed: 227   Index:  41
+  Antlion B2F                                                                 Seed: 227   Index:  41
+    Step  14: 12 / Weeper x2 (7.114s)
+  Antlion B2F Treasure Room                                                   Seed: 227   Index:  74
+    Extra Steps: 118
+  Antlion B2F                                                                 Seed: 227   Index: 192
+    Step  36: 13 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 227   Index: 244
+Battle: Antlion                                                               Seed: 244   Index:   2
+Antlion's Nest                                                                Seed: 244   Index:   2
+Antlion B2F Outward Direct                                                    Seed: 244   Index:  17
+  Antlion B2F                                                                 Seed: 244   Index:  17
+    Step  40: 14 / Turtle x2 (7.464s)
+    Step  48: 15 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 244   Index:  97
+  Step  16: 16 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  29: 17 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 244   Index: 135
+Overworld (Kaipo)                                                             Seed: 244   Index: 135
+Kaipo Revisited                                                               Seed: 244   Index: 135
+Overworld (Kaipo)                                                             Seed: 244   Index: 135
+Overworld (Damcyan)                                                           Seed: 244   Index: 135
+Mt.Hobs-West                                                                  Seed: 244   Index: 135
+  Step  27: 18 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 244   Index: 174
+  Step   5: 19 / Cocktric x3 (9.055s)
+Battle: MomBomb                                                               Seed: 244   Index: 189
+Mt.Hobs Summit                                                                Seed: 244   Index: 189
+  Step   5: 20 / Cocktric x3 (7.853s)
+Mt.Hobs-East                                                                  Seed: 244   Index: 195
+  Step  15: 21 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 244   Index: 241
+  Step  52: 22 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  71: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed:   5   Index:  69
+  Optional Steps: 10
+  Extra Steps: 20
+Overworld (Fabul)                                                             Seed:   5   Index: 159
+Fabul Boat and Leviatan                                                       Seed:   5   Index: 166
+Overworld (Mysidia)                                                           Seed:   5   Index: 166
+Mysidia                                                                       Seed:   5   Index: 175
+Overworld (Mysidia)                                                           Seed:   5   Index: 175
+  Step   7: 24 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed:   5   Index: 185
+  Step  73: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  22   Index:  23
+Mt.Ordeals-3rd station                                                        Seed:  22   Index:  66
+  Step   1: 26 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed:  22   Index:  89
+Mt.Ordeals-3rd station                                                        Seed:  22   Index:  89
+  Step   4: 27 / Zombie x2, Ghoul x2 (7.616s)
+Mt.Ordeals-7th station                                                        Seed:  22   Index:  94
+  Step   2: 28 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed:  22   Index: 136
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  22   Index: 154
+Mt.Ordeals Summit                                                             Seed:  22   Index: 154
+Paladin                                                                       Seed:  22   Index: 158
+Mt.Ordeals Summit                                                             Seed:  22   Index: 158
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  22   Index: 181
+  Extra Steps: 2
+  Step  25: 29 / Revenant x1, Ghoul x3 (8.489s)
+  Step  41: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  43: 31 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed:  22   Index: 225
+  Step  26: 32 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed:  22   Index: 255
+  Step  32: 33 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed:  39   Index:  43
+Take Chocobo to Mysidia                                                       Seed:  39   Index:  56
+Overworld (Mysidia)                                                           Seed:  39   Index:  56
+Town of Baron Serpent Road                                                    Seed:  39   Index:  56
+  Extra Steps: 12
+Credit Warp Fight Search                                                      Seed:  39   Index:  72
+  Overworld (Baron)                                                           Seed:  39   Index:  72
+    Extra Steps: 22
+    Step   1: 34 / Imp x3 (7.174s)
+    Step  22: 35 / Imp x3, SwordRat x1 (7.227s)
+   (Step  49: 36 / FloatEye x1, Eagle x2)
+   (Step  51: 37 / Imp x3, SwordRat x1)
+   (Step 131: 38 / Imp x3, SwordRat x1)
+   (Step 169: 39 / Eagle x3)
+   (Step 199: 40 / Imp x3)
+   (Step 237: 41 / Eagle x3)
+   (Step 238: 42 / Imp x4)
+
+Encounter Time:      268.006s
+Other Time:          545.668s
+Total Time:          813.674s
+
+Base Total Time:     893.360s
+Time Saved:          79.686s
+
+Optional Steps:      13
+Extra Steps:         204
+Encounters:          35
+
+Base Encounters:     45
+Encounters Saved:    10
+
+Number of Variables: 54

--- a/data/routes/cw/194.txt
+++ b/data/routes/cw/194.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	194
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48492905
+VARS	FFFFFFFF:20 C307801:1 E302500:1 E302600:10 E307400:16 E307B01:6 E308400:6 E308700:1 E308702:1 E309700:30
+
+Overworld (Kaipo)                                                             Seed: 194   Index:   0
+Overworld (Kaipo)                                                             Seed: 194   Index:   1
+  Step  17: 1 / Imp x4 (6.882s)
+  Step  18: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 194   Index:  37
+Overworld (Kaipo)                                                             Seed: 194   Index:  37
+Watery Pass-South B1F                                                         Seed: 194   Index:  69
+Recruit Tellah                                                                Seed: 194   Index: 101
+Watery Pass-South B1F                                                         Seed: 194   Index: 101
+  Step   3: 3 / CaveToad x3 (7.014s)
+  Step   5: 4 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F                                                         Seed: 194   Index: 121
+  Step  35: 5 / Pike x3 (7.152s)
+  Step  63: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 194   Index: 211
+Watery Pass-South B2F                                                         Seed: 194   Index: 215
+Watery Pass-South B3F                                                         Seed: 194   Index: 254
+  Step  24: 7 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B2F                                                         Seed: 211   Index:  32
+Watery Pass-North B1F                                                         Seed: 211   Index:  53
+  Step  31: 8 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 211   Index: 113
+Waterfalls B1F                                                                Seed: 211   Index: 122
+  Extra Steps: 16
+Waterfalls B2F                                                                Seed: 211   Index: 139
+Waterfalls Lake                                                               Seed: 211   Index: 184
+  Step  16: 9 / Aligator x1, Pike x2 (7.368s)
+  Step  23: 10 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 211   Index: 221
+Waterfalls Lake                                                               Seed: 211   Index: 221
+Overworld (Kaipo)                                                             Seed: 211   Index: 222
+Overworld (Damcyan)                                                           Seed: 211   Index: 233
+Damcyan                                                                       Seed: 211   Index: 237
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 211   Index: 245
+Antlion B1F                                                                   Seed: 211   Index: 245
+  Step  14: 11 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Direct                                                     Seed: 228   Index:  27
+  Antlion B2F                                                                 Seed: 228   Index:  27
+    Step  28: 12 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed: 228   Index: 107
+Battle: Antlion                                                               Seed: 228   Index: 121
+Antlion's Nest                                                                Seed: 228   Index: 121
+  Step  10: 13 / Cream x4 (7.523s)
+  Step  11: 14 / Turtle x2 (7.464s)
+Antlion B2F Outward Charm Room Steps                                          Seed: 228   Index: 136
+  Antlion B2F                                                                 Seed: 228   Index: 136
+    Step  28: 15 / SandWorm x2 (6.858s)
+  Antlion B2F Treasure Room                                                   Seed: 228   Index: 187
+    Extra Steps: 6
+  Antlion B2F                                                                 Seed: 228   Index: 193
+Antlion B1F                                                                   Seed: 228   Index: 227
+  Step   1: 16 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 245   Index:   9
+Overworld (Kaipo)                                                             Seed: 245   Index:   9
+Kaipo Revisited                                                               Seed: 245   Index:   9
+Overworld (Kaipo)                                                             Seed: 245   Index:   9
+Overworld (Damcyan)                                                           Seed: 245   Index:   9
+Mt.Hobs-West                                                                  Seed: 245   Index:   9
+Mt.Hobs Summit                                                                Seed: 245   Index:  48
+  Step   9: 17 / Spirit x2, Skelton x2 (9.087s)
+Battle: MomBomb                                                               Seed: 245   Index:  63
+Mt.Hobs Summit                                                                Seed: 245   Index:  63
+  Step   2: 18 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed: 245   Index:  69
+Overworld (Fabul)                                                             Seed: 245   Index: 115
+  Step  11: 19 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  14: 20 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  47: 21 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  64: 22 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  79: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed: 245   Index: 199
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:   6   Index:  13
+Fabul Boat and Leviatan                                                       Seed:   6   Index:  20
+Overworld (Mysidia)                                                           Seed:   6   Index:  20
+Mysidia                                                                       Seed:   6   Index:  29
+Overworld (Mysidia)                                                           Seed:   6   Index:  29
+Overworld (Mt.Ordeals)                                                        Seed:   6   Index:  39
+  Step  17: 24 / Raven x1 (8.356s)
+  Step  42: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  48: 26 / Raven x1, Cocktric x3 (9.100s)
+  Step  81: 27 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  91: 28 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:   6   Index: 133
+  Extra Steps: 6
+  Step  13: 29 / Red Bone x1, Skelton x3 (8.067s)
+  Step  26: 30 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  49: 31 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:   6   Index: 182
+  Step   1: 32 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:   6   Index: 205
+Mt.Ordeals-3rd station                                                        Seed:   6   Index: 205
+Mt.Ordeals-7th station                                                        Seed:   6   Index: 210
+Mt.Ordeals Summit                                                             Seed:   6   Index: 252
+  Optional Steps: 1
+  Step   6: 33 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:  23   Index:  14
+Mt.Ordeals Summit                                                             Seed:  23   Index:  14
+Paladin                                                                       Seed:  23   Index:  18
+Mt.Ordeals Summit                                                             Seed:  23   Index:  18
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  23   Index:  41
+  Step  26: 34 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed:  23   Index:  83
+  Step  10: 35 / Ghoul x2, Soul x2 (8.971s)
+  Step  13: 36 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed:  23   Index: 113
+Overworld (Mt.Ordeals)                                                        Seed:  23   Index: 157
+Take Chocobo to Mysidia                                                       Seed:  23   Index: 170
+Overworld (Mysidia)                                                           Seed:  23   Index: 170
+Town of Baron Serpent Road                                                    Seed:  23   Index: 170
+  Extra Steps: 30
+Credit Warp Fight Search                                                      Seed:  23   Index: 204
+  Overworld (Baron)                                                           Seed:  23   Index: 204
+    Extra Steps: 20
+    Step   2: 37 / Imp x3, SwordRat x1 (7.227s)
+    Step  20: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  35: 39 / Eagle x3)
+   (Step  47: 40 / Imp x3)
+   (Step  83: 41 / Eagle x3)
+   (Step 125: 42 / Imp x4)
+   (Step 146: 43 / Imp x4)
+   (Step 173: 44 / FloatEye x2)
+   (Step 175: 45 / Imp x3, SwordRat x1)
+   (Step 177: 46 / Imp x3, SwordRat x1)
+   (Step 255: 47 / Imp x3)
+
+Encounter Time:      295.295s
+Other Time:          511.591s
+Total Time:          806.886s
+
+Base Total Time:     865.264s
+Time Saved:          58.378s
+
+Optional Steps:      13
+Extra Steps:         78
+Encounters:          38
+
+Base Encounters:     43
+Encounters Saved:    5
+
+Number of Variables: 54

--- a/data/routes/cw/195.txt
+++ b/data/routes/cw/195.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	195
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48106311
+VARS	FFFFFFFF:4 E302500:67 E302600:20 E305400:6 E307400:10 E307701:2 E307F01:4 E308000:3 E309700:9
+
+Overworld (Kaipo)                                                             Seed: 195   Index:   0
+Overworld (Kaipo)                                                             Seed: 195   Index:   1
+  Step  17: 1 / Imp x4 (6.882s)
+  Step  18: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 195   Index:  37
+Overworld (Kaipo)                                                             Seed: 195   Index:  37
+Watery Pass-South B1F                                                         Seed: 195   Index:  69
+Recruit Tellah                                                                Seed: 195   Index: 101
+Watery Pass-South B1F                                                         Seed: 195   Index: 101
+  Step   5: 3 / CaveToad x3 (7.014s)
+Watery Pass-South B2F                                                         Seed: 195   Index: 121
+  Step  35: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  63: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 195   Index: 211
+  Extra Steps: 6
+Watery Pass-South B2F                                                         Seed: 195   Index: 221
+Watery Pass-South B3F                                                         Seed: 212   Index:   4
+  Step  18: 6 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed: 212   Index:  38
+Watery Pass-North B1F                                                         Seed: 212   Index:  59
+  Step  25: 7 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  42: 8 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 212   Index: 119
+Waterfalls B1F                                                                Seed: 212   Index: 128
+  Extra Steps: 10
+Waterfalls B2F                                                                Seed: 212   Index: 139
+Waterfalls Lake                                                               Seed: 212   Index: 184
+  Step  16: 9 / Aligator x1, Pike x2 (7.368s)
+  Step  23: 10 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 212   Index: 221
+Waterfalls Lake                                                               Seed: 212   Index: 221
+Overworld (Kaipo)                                                             Seed: 212   Index: 222
+Overworld (Damcyan)                                                           Seed: 212   Index: 233
+Damcyan                                                                       Seed: 212   Index: 237
+  Optional Steps: 1
+  Extra Steps: 66
+Overworld (Damcyan)                                                           Seed: 229   Index:  55
+Antlion B1F                                                                   Seed: 229   Index:  55
+Antlion B2F Inward Direct                                                     Seed: 229   Index:  93
+  Antlion B2F                                                                 Seed: 229   Index:  93
+    Step  38: 11 / Basilisk x1, Imp x3 (6.775s)
+    Step  44: 12 / Weeper x2 (7.114s)
+    Step  71: 13 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 229   Index: 173
+Battle: Antlion                                                               Seed: 229   Index: 187
+Antlion's Nest                                                                Seed: 229   Index: 187
+  Step   3: 14 / Turtle x2 (7.464s)
+  Step   5: 15 / SandWorm x1, Sandpede x1 (6.848s)
+Antlion B2F Outward Direct                                                    Seed: 229   Index: 202
+  Antlion B2F                                                                 Seed: 229   Index: 202
+    Step  26: 16 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed: 246   Index:  26
+  Extra Steps: 2
+  Step  31: 17 / Turtle x2 (7.464s)
+  Step  39: 18 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 246   Index:  66
+Overworld (Kaipo)                                                             Seed: 246   Index:  66
+Kaipo Revisited                                                               Seed: 246   Index:  66
+Overworld (Kaipo)                                                             Seed: 246   Index:  66
+Overworld (Damcyan)                                                           Seed: 246   Index:  66
+Mt.Hobs-West                                                                  Seed: 246   Index:  66
+Mt.Hobs Summit                                                                Seed: 246   Index: 105
+Battle: MomBomb                                                               Seed: 246   Index: 120
+Mt.Hobs Summit                                                                Seed: 246   Index: 120
+  Extra Steps: 4
+  Step   6: 19 / Cocktric x3 (7.853s)
+  Step   9: 20 / Cocktric x3 (7.853s)
+Mt.Hobs-East                                                                  Seed: 246   Index: 130
+  Extra Steps: 3
+  Step  31: 21 / Gargoyle x2 (7.630s)
+  Step  49: 22 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 246   Index: 179
+  Step  15: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  31: 24 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:   7   Index:   7
+  Optional Steps: 10
+  Extra Steps: 10
+Overworld (Fabul)                                                             Seed:   7   Index:  87
+Fabul Boat and Leviatan                                                       Seed:   7   Index:  94
+Overworld (Mysidia)                                                           Seed:   7   Index:  94
+Mysidia                                                                       Seed:   7   Index: 103
+Overworld (Mysidia)                                                           Seed:   7   Index: 103
+Overworld (Mt.Ordeals)                                                        Seed:   7   Index: 113
+  Step  17: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  31: 26 / Raven x1, Cocktric x3 (9.100s)
+  Step  33: 27 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  46: 28 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  69: 29 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  70: 30 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:   7   Index: 207
+  Step  16: 31 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:   7   Index: 250
+Recruit Tellah                                                                Seed:  24   Index:  17
+Mt.Ordeals-3rd station                                                        Seed:  24   Index:  17
+Mt.Ordeals-7th station                                                        Seed:  24   Index:  22
+Mt.Ordeals Summit                                                             Seed:  24   Index:  64
+  Optional Steps: 0
+  Step   3: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed:  24   Index:  81
+Mt.Ordeals Summit                                                             Seed:  24   Index:  81
+Paladin                                                                       Seed:  24   Index:  85
+Mt.Ordeals Summit                                                             Seed:  24   Index:  85
+  Optional Steps: 0
+  Step   8: 33 / Revenant x1, Ghoul x3 (8.489s)
+  Step  11: 34 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed:  24   Index: 107
+Mt.Ordeals-3rd station                                                        Seed:  24   Index: 149
+Mt.Ordeals                                                                    Seed:  24   Index: 179
+  Step  27: 35 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  24   Index: 223
+  Step   1: 36 / Imp Cap. x3, Needler x1 (7.897s)
+Take Chocobo to Mysidia                                                       Seed:  24   Index: 236
+Overworld (Mysidia)                                                           Seed:  24   Index: 236
+Town of Baron Serpent Road                                                    Seed:  24   Index: 236
+  Extra Steps: 9
+Credit Warp Fight Search                                                      Seed:  24   Index: 249
+  Overworld (Baron)                                                           Seed:  24   Index: 249
+    Extra Steps: 4
+    Step   2: 37 / Eagle x3 (7.417s)
+    Step   4: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  33: 39 / Eagle x3)
+   (Step  38: 40 / Imp x3)
+   (Step  80: 41 / Imp x4)
+   (Step 101: 42 / Imp x4)
+   (Step 130: 43 / Imp x4)
+   (Step 132: 44 / FloatEye x2)
+   (Step 210: 45 / Imp x3, SwordRat x1)
+
+Encounter Time:      287.598s
+Other Time:          512.855s
+Total Time:          800.454s
+
+Base Total Time:     857.633s
+Time Saved:          57.180s
+
+Optional Steps:      11
+Extra Steps:         114
+Encounters:          38
+
+Base Encounters:     42
+Encounters Saved:    4
+
+Number of Variables: 54

--- a/data/routes/cw/196.txt
+++ b/data/routes/cw/196.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	196
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48555318
+VARS	FFFFFFFF:4 C307800:1 E302500:67 E302600:8 E305400:6 E307400:10 E307B00:12 E307E00:6 E308000:1 E308700:1 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed: 196   Index:   0
+Overworld (Kaipo)                                                             Seed: 196   Index:   1
+  Step  17: 1 / Imp x4 (6.882s)
+  Step  18: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 196   Index:  37
+Overworld (Kaipo)                                                             Seed: 196   Index:  37
+Watery Pass-South B1F                                                         Seed: 196   Index:  69
+Recruit Tellah                                                                Seed: 196   Index: 101
+Watery Pass-South B1F                                                         Seed: 196   Index: 101
+  Step   2: 3 / CaveToad x3 (7.014s)
+  Step   5: 4 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F                                                         Seed: 196   Index: 121
+  Step  35: 5 / Pike x3 (7.152s)
+  Step  63: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 196   Index: 211
+  Extra Steps: 6
+Watery Pass-South B2F                                                         Seed: 196   Index: 221
+Watery Pass-South B3F                                                         Seed: 213   Index:   4
+  Step  18: 7 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B2F                                                         Seed: 213   Index:  38
+Watery Pass-North B1F                                                         Seed: 213   Index:  59
+  Step  25: 8 / Jelly x4 (7.324s)
+  Step  42: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 213   Index: 119
+Waterfalls B1F                                                                Seed: 213   Index: 128
+  Extra Steps: 10
+Waterfalls B2F                                                                Seed: 213   Index: 139
+Waterfalls Lake                                                               Seed: 213   Index: 184
+  Step  16: 10 / Aligator x1, WaterBug x2 (7.292s)
+  Step  23: 11 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 213   Index: 221
+Waterfalls Lake                                                               Seed: 213   Index: 221
+Overworld (Kaipo)                                                             Seed: 213   Index: 222
+Overworld (Damcyan)                                                           Seed: 213   Index: 233
+Damcyan                                                                       Seed: 213   Index: 237
+  Optional Steps: 1
+  Extra Steps: 66
+Overworld (Damcyan)                                                           Seed: 230   Index:  55
+Antlion B1F                                                                   Seed: 230   Index:  55
+Antlion B2F Inward Charm Room Steps                                           Seed: 230   Index:  93
+  Antlion B2F                                                                 Seed: 230   Index:  93
+  Antlion B2F Treasure Room                                                   Seed: 230   Index: 126
+    Extra Steps: 12
+  Antlion B2F                                                                 Seed: 230   Index: 138
+    Step  25: 12 / Weeper x2 (7.114s)
+    Step  52: 13 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 230   Index: 190
+  Step   2: 14 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed: 230   Index: 204
+Antlion's Nest                                                                Seed: 230   Index: 204
+Antlion B2F Outward Direct                                                    Seed: 230   Index: 219
+  Antlion B2F                                                                 Seed: 230   Index: 219
+    Step   9: 15 / SandWorm x1, Sandpede x1 (6.848s)
+Antlion B1F                                                                   Seed: 247   Index:  43
+  Step  14: 16 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  22: 17 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 247   Index:  81
+Overworld (Kaipo)                                                             Seed: 247   Index:  81
+Kaipo Revisited                                                               Seed: 247   Index:  81
+Overworld (Kaipo)                                                             Seed: 247   Index:  81
+Overworld (Damcyan)                                                           Seed: 247   Index:  81
+Mt.Hobs-West                                                                  Seed: 247   Index:  81
+  Extra Steps: 6
+  Step  45: 18 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 247   Index: 126
+  Step   3: 19 / Cocktric x3 (9.055s)
+Battle: MomBomb                                                               Seed: 247   Index: 141
+Mt.Hobs Summit                                                                Seed: 247   Index: 141
+Mt.Hobs-East                                                                  Seed: 247   Index: 147
+  Extra Steps: 1
+  Step  14: 20 / Red Bone x1, Skelton x3 (8.007s)
+  Step  32: 21 / Gargoyle x2 (7.630s)
+  Step  46: 22 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 247   Index: 194
+  Step  16: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed:   8   Index:  22
+  Optional Steps: 8
+Overworld (Fabul)                                                             Seed:   8   Index:  90
+Fabul Boat and Leviatan                                                       Seed:   8   Index:  97
+Overworld (Mysidia)                                                           Seed:   8   Index:  97
+Mysidia                                                                       Seed:   8   Index: 106
+Overworld (Mysidia)                                                           Seed:   8   Index: 106
+Overworld (Mt.Ordeals)                                                        Seed:   8   Index: 116
+  Step  14: 24 / Raven x1 (8.356s)
+  Step  30: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  43: 26 / Raven x1, Cocktric x3 (9.100s)
+  Step  66: 27 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  67: 28 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:   8   Index: 210
+  Step  13: 29 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:   8   Index: 253
+  Step   2: 30 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  25   Index:  20
+Mt.Ordeals-3rd station                                                        Seed:  25   Index:  20
+Mt.Ordeals-7th station                                                        Seed:  25   Index:  25
+  Step  27: 31 / Revenant x1, Ghoul x3 (8.914s)
+  Step  42: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  25   Index:  67
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  25   Index:  85
+Mt.Ordeals Summit                                                             Seed:  25   Index:  85
+Paladin                                                                       Seed:  25   Index:  89
+Mt.Ordeals Summit                                                             Seed:  25   Index:  89
+  Optional Steps: 1
+  Step   7: 33 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed:  25   Index: 112
+Mt.Ordeals-3rd station                                                        Seed:  25   Index: 154
+Mt.Ordeals                                                                    Seed:  25   Index: 184
+  Step  22: 34 / Spirit x2, Skelton x2 (8.065s)
+  Step  40: 35 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  25   Index: 228
+  Step  11: 36 / Imp Cap. x3, Needler x1 (7.897s)
+Take Chocobo to Mysidia                                                       Seed:  25   Index: 241
+Overworld (Mysidia)                                                           Seed:  25   Index: 241
+Town of Baron Serpent Road                                                    Seed:  25   Index: 241
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed:  25   Index: 249
+  Overworld (Baron)                                                           Seed:  25   Index: 249
+    Extra Steps: 4
+    Step   2: 37 / Eagle x3 (7.417s)
+    Step   4: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  33: 39 / Eagle x3)
+   (Step  80: 40 / Imp x3)
+   (Step 101: 41 / Imp x4)
+   (Step 130: 42 / Imp x4)
+   (Step 132: 43 / Imp x4)
+   (Step 210: 44 / FloatEye x2)
+   (Step 243: 45 / Imp x3, SwordRat x1)
+
+Encounter Time:      292.074s
+Other Time:          515.850s
+Total Time:          807.925s
+
+Base Total Time:     872.771s
+Time Saved:          64.846s
+
+Optional Steps:      11
+Extra Steps:         109
+Encounters:          38
+
+Base Encounters:     43
+Encounters Saved:    5
+
+Number of Variables: 54

--- a/data/routes/cw/197.txt
+++ b/data/routes/cw/197.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	197
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47902250
+VARS	FFFFFFFF:4 C307800:1 E302500:1 E305400:6 E307400:78 E307B00:22 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed: 197   Index:   0
+Overworld (Kaipo)                                                             Seed: 197   Index:   1
+  Step  18: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 197   Index:  37
+Overworld (Kaipo)                                                             Seed: 197   Index:  37
+Watery Pass-South B1F                                                         Seed: 197   Index:  69
+Recruit Tellah                                                                Seed: 197   Index: 101
+Watery Pass-South B1F                                                         Seed: 197   Index: 101
+  Step   2: 2 / Pike x3 (7.152s)
+  Step   5: 3 / CaveToad x3 (7.014s)
+Watery Pass-South B2F                                                         Seed: 197   Index: 121
+  Step  14: 4 / Pike x2, EvilShel x2 (7.149s)
+  Step  35: 5 / Pike x3 (7.152s)
+  Step  63: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 197   Index: 211
+  Extra Steps: 6
+Watery Pass-South B2F                                                         Seed: 197   Index: 221
+Watery Pass-South B3F                                                         Seed: 214   Index:   4
+  Step  18: 7 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B2F                                                         Seed: 214   Index:  38
+Watery Pass-North B1F                                                         Seed: 214   Index:  59
+  Step  25: 8 / Jelly x4 (7.324s)
+  Step  42: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 214   Index: 119
+Waterfalls B1F                                                                Seed: 214   Index: 128
+  Extra Steps: 78
+Waterfalls B2F                                                                Seed: 214   Index: 207
+Waterfalls Lake                                                               Seed: 214   Index: 252
+  Step   7: 10 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 231   Index:  33
+Waterfalls Lake                                                               Seed: 231   Index:  33
+Overworld (Kaipo)                                                             Seed: 231   Index:  34
+Overworld (Damcyan)                                                           Seed: 231   Index:  45
+Damcyan                                                                       Seed: 231   Index:  49
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 231   Index:  57
+Antlion B1F                                                                   Seed: 231   Index:  57
+Antlion B2F Inward Charm Room Steps                                           Seed: 231   Index:  95
+  Antlion B2F                                                                 Seed: 231   Index:  95
+  Antlion B2F Treasure Room                                                   Seed: 231   Index: 128
+    Extra Steps: 22
+  Antlion B2F                                                                 Seed: 231   Index: 150
+    Step  13: 11 / Basilisk x1, Imp x3 (6.775s)
+    Step  40: 12 / Weeper x2 (7.114s)
+    Step  42: 13 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 231   Index: 202
+Battle: Antlion                                                               Seed: 231   Index: 216
+Antlion's Nest                                                                Seed: 231   Index: 216
+  Step  12: 14 / Turtle x2 (7.464s)
+Antlion B2F Outward Direct                                                    Seed: 231   Index: 231
+  Antlion B2F                                                                 Seed: 231   Index: 231
+Antlion B1F                                                                   Seed: 248   Index:  55
+  Step   2: 15 / Imp x3 (6.648s)
+  Step  10: 16 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed: 248   Index:  93
+Overworld (Kaipo)                                                             Seed: 248   Index:  93
+Kaipo Revisited                                                               Seed: 248   Index:  93
+Overworld (Kaipo)                                                             Seed: 248   Index:  93
+Overworld (Damcyan)                                                           Seed: 248   Index:  93
+Mt.Hobs-West                                                                  Seed: 248   Index:  93
+  Step  33: 17 / Gargoyle x2 (8.791s)
+  Step  36: 18 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 248   Index: 132
+Battle: MomBomb                                                               Seed: 248   Index: 147
+Mt.Hobs Summit                                                                Seed: 248   Index: 147
+Mt.Hobs-East                                                                  Seed: 248   Index: 153
+  Step   8: 19 / Turtle x2 (7.432s)
+  Step  26: 20 / Red Bone x1, Skelton x3 (8.007s)
+  Step  40: 21 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 248   Index: 199
+  Step  11: 22 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  26: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed:   9   Index:  27
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed:   9   Index:  87
+Fabul Boat and Leviatan                                                       Seed:   9   Index:  94
+Overworld (Mysidia)                                                           Seed:   9   Index:  94
+Mysidia                                                                       Seed:   9   Index: 103
+Overworld (Mysidia)                                                           Seed:   9   Index: 103
+Overworld (Mt.Ordeals)                                                        Seed:   9   Index: 113
+  Step  33: 24 / Raven x1 (8.356s)
+  Step  46: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  69: 26 / Raven x1, Cocktric x3 (9.100s)
+  Step  70: 27 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:   9   Index: 207
+  Step  16: 28 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:   9   Index: 250
+  Step   5: 29 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed:  26   Index:  17
+Mt.Ordeals-3rd station                                                        Seed:  26   Index:  17
+Mt.Ordeals-7th station                                                        Seed:  26   Index:  22
+  Step  30: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  38: 31 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed:  26   Index:  64
+  Optional Steps: 0
+  Step   3: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed:  26   Index:  81
+Mt.Ordeals Summit                                                             Seed:  26   Index:  81
+Paladin                                                                       Seed:  26   Index:  85
+Mt.Ordeals Summit                                                             Seed:  26   Index:  85
+  Optional Steps: 1
+  Step  11: 33 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed:  26   Index: 108
+Mt.Ordeals-3rd station                                                        Seed:  26   Index: 150
+Mt.Ordeals                                                                    Seed:  26   Index: 180
+  Step  26: 34 / Spirit x2, Skelton x2 (8.065s)
+Overworld (Mt.Ordeals)                                                        Seed:  26   Index: 224
+Take Chocobo to Mysidia                                                       Seed:  26   Index: 237
+Overworld (Mysidia)                                                           Seed:  26   Index: 237
+Town of Baron Serpent Road                                                    Seed:  26   Index: 237
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed:  26   Index: 249
+  Overworld (Baron)                                                           Seed:  26   Index: 249
+    Extra Steps: 4
+    Step   2: 35 / Imp x3, SwordRat x1 (7.227s)
+    Step   4: 36 / Imp x3, SwordRat x1 (7.227s)
+   (Step  33: 37 / Eagle x3)
+   (Step  54: 38 / Imp x3, SwordRat x1)
+   (Step  80: 39 / Eagle x3)
+   (Step 101: 40 / FloatEye x2)
+   (Step 132: 41 / Imp x4)
+   (Step 210: 42 / Imp x4)
+   (Step 243: 43 / Imp x4)
+
+Encounter Time:      279.078s
+Other Time:          517.980s
+Total Time:          797.058s
+
+Base Total Time:     897.289s
+Time Saved:          100.230s
+
+Optional Steps:      2
+Extra Steps:         118
+Encounters:          36
+
+Base Encounters:     45
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/198.txt
+++ b/data/routes/cw/198.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	198
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49093032
+VARS	FFFFFFFF:16 C307801:1 E000600:4 E302600:34 E305400:6 E307400:10 E307B01:6 E308700:1 E308702:1 E309700:42
+
+Overworld (Kaipo)                                                             Seed: 198   Index:   0
+Overworld (Kaipo)                                                             Seed: 198   Index:   1
+  Step  18: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 198   Index:  37
+Overworld (Kaipo)                                                             Seed: 198   Index:  37
+Watery Pass-South B1F                                                         Seed: 198   Index:  69
+Recruit Tellah                                                                Seed: 198   Index: 101
+Watery Pass-South B1F                                                         Seed: 198   Index: 101
+  Step   2: 2 / Pike x3 (7.152s)
+  Step   5: 3 / CaveToad x3 (7.014s)
+  Step   8: 4 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F                                                         Seed: 198   Index: 121
+  Step  14: 5 / Pike x3 (7.152s)
+  Step  35: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 198   Index: 211
+  Extra Steps: 6
+Watery Pass-South B2F                                                         Seed: 198   Index: 221
+Watery Pass-South B3F                                                         Seed: 215   Index:   4
+  Step  18: 7 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B2F                                                         Seed: 215   Index:  38
+Watery Pass-North B1F                                                         Seed: 215   Index:  59
+  Step  25: 8 / Jelly x4 (7.324s)
+  Step  42: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 215   Index: 119
+Waterfalls B1F                                                                Seed: 215   Index: 128
+  Extra Steps: 10
+Waterfalls B2F                                                                Seed: 215   Index: 139
+Waterfalls Lake                                                               Seed: 215   Index: 184
+  Step  13: 10 / Aligator x1, WaterBug x2 (7.292s)
+  Step  16: 11 / Aligator x1, Pike x2 (7.368s)
+  Step  17: 12 / Aligator x1, WaterBug x2 (7.292s)
+Battle: Octomamm                                                              Seed: 215   Index: 221
+Waterfalls Lake                                                               Seed: 215   Index: 221
+Overworld (Kaipo)                                                             Seed: 215   Index: 222
+Overworld (Damcyan)                                                           Seed: 215   Index: 233
+Damcyan                                                                       Seed: 215   Index: 237
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 215   Index: 244
+Antlion B1F                                                                   Seed: 215   Index: 244
+  Step  15: 13 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed: 232   Index:  26
+  Antlion B2F                                                                 Seed: 232   Index:  26
+Antlion's Nest                                                                Seed: 232   Index: 106
+Battle: Antlion                                                               Seed: 232   Index: 120
+Antlion's Nest                                                                Seed: 232   Index: 120
+  Step  11: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Charm Room Steps                                          Seed: 232   Index: 135
+  Antlion B2F                                                                 Seed: 232   Index: 135
+    Step   2: 15 / Cream x4 (7.523s)
+    Step  15: 16 / Turtle x2 (7.464s)
+    Step  28: 17 / SandWorm x2 (6.858s)
+  Antlion B2F Treasure Room                                                   Seed: 232   Index: 186
+    Extra Steps: 6
+  Antlion B2F                                                                 Seed: 232   Index: 192
+Antlion B1F                                                                   Seed: 232   Index: 226
+  Step   1: 18 / Imp x3 (6.648s)
+  Step  30: 19 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 249   Index:   8
+Overworld (Kaipo)                                                             Seed: 249   Index:   8
+Kaipo Revisited                                                               Seed: 249   Index:   8
+Overworld (Kaipo)                                                             Seed: 249   Index:   8
+Overworld (Damcyan)                                                           Seed: 249   Index:   8
+Mt.Hobs-West                                                                  Seed: 249   Index:   8
+Mt.Hobs Summit                                                                Seed: 249   Index:  47
+Battle: MomBomb                                                               Seed: 249   Index:  62
+Mt.Hobs Summit                                                                Seed: 249   Index:  62
+  Step   3: 20 / Cocktric x3 (7.853s)
+Mt.Hobs-East                                                                  Seed: 249   Index:  68
+Overworld (Fabul)                                                             Seed: 249   Index: 114
+  Step  12: 21 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  15: 22 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  47: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  65: 24 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  79: 25 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed: 249   Index: 198
+  Optional Steps: 10
+  Extra Steps: 24
+Overworld (Fabul)                                                             Seed:  10   Index:  36
+Fabul Boat and Leviatan                                                       Seed:  10   Index:  43
+Overworld (Mysidia)                                                           Seed:  10   Index:  43
+Mysidia                                                                       Seed:  10   Index:  52
+Overworld (Mysidia)                                                           Seed:  10   Index:  52
+Overworld (Mt.Ordeals)                                                        Seed:  10   Index:  62
+  Extra Steps: 4
+  Step  19: 26 / Raven x1, Cocktric x3 (9.100s)
+  Step  84: 27 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  97: 28 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  10   Index: 160
+  Step  22: 29 / Red Bone x1, Skelton x3 (8.067s)
+  Step  23: 30 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:  10   Index: 203
+  Step  20: 31 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed:  10   Index: 226
+Mt.Ordeals-3rd station                                                        Seed:  10   Index: 226
+Mt.Ordeals-7th station                                                        Seed:  10   Index: 231
+  Step  24: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  27   Index:  17
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  27   Index:  35
+Mt.Ordeals Summit                                                             Seed:  27   Index:  35
+Paladin                                                                       Seed:  27   Index:  39
+Mt.Ordeals Summit                                                             Seed:  27   Index:  39
+  Optional Steps: 1
+  Step  13: 33 / Revenant x1, Ghoul x3 (8.489s)
+  Step  21: 34 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-7th station                                                        Seed:  27   Index:  62
+  Step  30: 35 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  34: 36 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed:  27   Index: 104
+Mt.Ordeals                                                                    Seed:  27   Index: 134
+Overworld (Mt.Ordeals)                                                        Seed:  27   Index: 178
+Take Chocobo to Mysidia                                                       Seed:  27   Index: 191
+Overworld (Mysidia)                                                           Seed:  27   Index: 191
+Town of Baron Serpent Road                                                    Seed:  27   Index: 191
+  Extra Steps: 42
+Credit Warp Fight Search                                                      Seed:  27   Index: 237
+  Overworld (Baron)                                                           Seed:  27   Index: 237
+    Extra Steps: 16
+    Step   2: 37 / Eagle x3 (7.417s)
+    Step  16: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  45: 39 / Eagle x3)
+   (Step  66: 40 / FloatEye x2)
+   (Step  77: 41 / Imp x4)
+   (Step  92: 42 / Imp x4)
+   (Step 144: 43 / Imp x4)
+   (Step 222: 44 / FloatEye x2)
+   (Step 255: 45 / Imp x3, SwordRat x1)
+
+Encounter Time:      298.359s
+Other Time:          518.513s
+Total Time:          816.872s
+
+Base Total Time:     872.713s
+Time Saved:          55.841s
+
+Optional Steps:      12
+Extra Steps:         108
+Encounters:          38
+
+Base Encounters:     43
+Encounters Saved:    5
+
+Number of Variables: 54

--- a/data/routes/cw/199.txt
+++ b/data/routes/cw/199.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	199
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48910745
+VARS	FFFFFFFF:16 C307801:1 E302600:14 E305400:6 E307400:72 E307B01:6 E308000:4 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 199   Index:   0
+Overworld (Kaipo)                                                             Seed: 199   Index:   1
+  Step  18: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 199   Index:  37
+Overworld (Kaipo)                                                             Seed: 199   Index:  37
+Watery Pass-South B1F                                                         Seed: 199   Index:  69
+Recruit Tellah                                                                Seed: 199   Index: 101
+Watery Pass-South B1F                                                         Seed: 199   Index: 101
+  Step   2: 2 / Pike x3 (7.152s)
+  Step   8: 3 / CaveToad x3 (7.014s)
+Watery Pass-South B2F                                                         Seed: 199   Index: 121
+  Step  14: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  35: 5 / Pike x3 (7.152s)
+  Step  78: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 199   Index: 211
+  Extra Steps: 6
+Watery Pass-South B2F                                                         Seed: 199   Index: 221
+Watery Pass-South B3F                                                         Seed: 216   Index:   4
+  Step  18: 7 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B2F                                                         Seed: 216   Index:  38
+Watery Pass-North B1F                                                         Seed: 216   Index:  59
+  Step  42: 8 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 216   Index: 119
+Waterfalls B1F                                                                Seed: 216   Index: 128
+  Extra Steps: 72
+Waterfalls B2F                                                                Seed: 216   Index: 201
+Waterfalls Lake                                                               Seed: 216   Index: 246
+Battle: Octomamm                                                              Seed: 233   Index:  27
+Waterfalls Lake                                                               Seed: 233   Index:  27
+Overworld (Kaipo)                                                             Seed: 233   Index:  28
+Overworld (Damcyan)                                                           Seed: 233   Index:  39
+Damcyan                                                                       Seed: 233   Index:  43
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 233   Index:  50
+Antlion B1F                                                                   Seed: 233   Index:  50
+Antlion B2F Inward Direct                                                     Seed: 233   Index:  88
+  Antlion B2F                                                                 Seed: 233   Index:  88
+    Step  43: 9 / Basilisk x1, Imp x3 (6.775s)
+    Step  49: 10 / Weeper x2 (7.114s)
+    Step  62: 11 / Basilisk x1, Imp x3 (6.775s)
+    Step  75: 12 / SandWorm x2 (6.841s)
+Antlion's Nest                                                                Seed: 233   Index: 168
+Battle: Antlion                                                               Seed: 233   Index: 182
+Antlion's Nest                                                                Seed: 233   Index: 182
+  Step   8: 13 / Cream x4 (7.523s)
+  Step  10: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Charm Room Steps                                          Seed: 233   Index: 197
+  Antlion B2F                                                                 Seed: 233   Index: 197
+    Step  30: 15 / Cream x4 (7.523s)
+  Antlion B2F Treasure Room                                                   Seed: 233   Index: 248
+    Extra Steps: 6
+  Antlion B2F                                                                 Seed: 233   Index: 254
+    Step   2: 16 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed: 250   Index:  32
+  Step  33: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed: 250   Index:  70
+Overworld (Kaipo)                                                             Seed: 250   Index:  70
+Kaipo Revisited                                                               Seed: 250   Index:  70
+Overworld (Kaipo)                                                             Seed: 250   Index:  70
+Overworld (Damcyan)                                                           Seed: 250   Index:  70
+Mt.Hobs-West                                                                  Seed: 250   Index:  70
+Mt.Hobs Summit                                                                Seed: 250   Index: 109
+Battle: MomBomb                                                               Seed: 250   Index: 124
+Mt.Hobs Summit                                                                Seed: 250   Index: 124
+  Step   2: 18 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step   5: 19 / Spirit x2, Skelton x2 (8.237s)
+Mt.Hobs-East                                                                  Seed: 250   Index: 130
+  Extra Steps: 4
+  Step  31: 20 / Turtle x2 (7.432s)
+  Step  50: 21 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed: 250   Index: 180
+  Step  13: 22 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  45: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed:  11   Index:   8
+  Optional Steps: 10
+  Extra Steps: 4
+Overworld (Fabul)                                                             Seed:  11   Index:  82
+Fabul Boat and Leviatan                                                       Seed:  11   Index:  89
+Overworld (Mysidia)                                                           Seed:  11   Index:  89
+Mysidia                                                                       Seed:  11   Index:  98
+Overworld (Mysidia)                                                           Seed:  11   Index:  98
+Overworld (Mt.Ordeals)                                                        Seed:  11   Index: 108
+  Step  38: 24 / Raven x1 (8.356s)
+  Step  51: 25 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  74: 26 / Raven x1, Cocktric x3 (9.100s)
+  Step  75: 27 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  11   Index: 202
+  Step  10: 28 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  21: 29 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  11   Index: 245
+  Step  10: 30 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  28   Index:  12
+Mt.Ordeals-3rd station                                                        Seed:  28   Index:  12
+Mt.Ordeals-7th station                                                        Seed:  28   Index:  17
+  Step  35: 31 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed:  28   Index:  59
+  Optional Steps: 1
+  Step   1: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  10: 33 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:  28   Index:  77
+Mt.Ordeals Summit                                                             Seed:  28   Index:  77
+Paladin                                                                       Seed:  28   Index:  81
+Mt.Ordeals Summit                                                             Seed:  28   Index:  81
+  Optional Steps: 1
+  Step  11: 34 / Ghoul x2, Soul x2 (8.971s)
+  Step  15: 35 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  28   Index: 104
+Mt.Ordeals-3rd station                                                        Seed:  28   Index: 146
+Mt.Ordeals                                                                    Seed:  28   Index: 176
+  Step  30: 36 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  28   Index: 220
+Take Chocobo to Mysidia                                                       Seed:  28   Index: 233
+Overworld (Mysidia)                                                           Seed:  28   Index: 233
+Town of Baron Serpent Road                                                    Seed:  28   Index: 233
+Credit Warp Fight Search                                                      Seed:  28   Index: 237
+  Overworld (Baron)                                                           Seed:  28   Index: 237
+    Extra Steps: 16
+    Step   2: 37 / Eagle x3 (7.417s)
+    Step  16: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  45: 39 / Eagle x3)
+   (Step  66: 40 / FloatEye x2)
+   (Step  77: 41 / Imp x4)
+   (Step  80: 42 / Imp x4)
+   (Step 144: 43 / Imp x4)
+   (Step 222: 44 / FloatEye x2)
+   (Step 255: 45 / Imp x3, SwordRat x1)
+
+Encounter Time:      295.326s
+Other Time:          518.513s
+Total Time:          813.839s
+
+Base Total Time:     874.397s
+Time Saved:          60.558s
+
+Optional Steps:      12
+Extra Steps:         108
+Encounters:          38
+
+Base Encounters:     43
+Encounters Saved:    5
+
+Number of Variables: 54

--- a/data/routes/cw/200.txt
+++ b/data/routes/cw/200.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	200
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49123935
+VARS	FFFFFFFF:16 C307801:1 E302600:14 E305400:6 E307400:72 E307B01:6 E308000:4 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 200   Index:   0
+Overworld (Kaipo)                                                             Seed: 200   Index:   1
+  Step  18: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 200   Index:  37
+Overworld (Kaipo)                                                             Seed: 200   Index:  37
+Watery Pass-South B1F                                                         Seed: 200   Index:  69
+Recruit Tellah                                                                Seed: 200   Index: 101
+Watery Pass-South B1F                                                         Seed: 200   Index: 101
+  Step   2: 2 / Pike x3 (7.152s)
+  Step   8: 3 / CaveToad x3 (7.014s)
+Watery Pass-South B2F                                                         Seed: 200   Index: 121
+  Step  14: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  30: 5 / Pike x3 (7.152s)
+  Step  78: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 200   Index: 211
+  Extra Steps: 6
+Watery Pass-South B2F                                                         Seed: 200   Index: 221
+Watery Pass-South B3F                                                         Seed: 217   Index:   4
+  Step  18: 7 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B2F                                                         Seed: 217   Index:  38
+Watery Pass-North B1F                                                         Seed: 217   Index:  59
+  Step  15: 8 / Jelly x4 (7.324s)
+  Step  42: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 217   Index: 119
+Waterfalls B1F                                                                Seed: 217   Index: 128
+  Extra Steps: 72
+Waterfalls B2F                                                                Seed: 217   Index: 201
+Waterfalls Lake                                                               Seed: 217   Index: 246
+Battle: Octomamm                                                              Seed: 234   Index:  27
+Waterfalls Lake                                                               Seed: 234   Index:  27
+Overworld (Kaipo)                                                             Seed: 234   Index:  28
+  Step   6: 10 / SandMoth x2, Larva x2 (7.188s)
+Overworld (Damcyan)                                                           Seed: 234   Index:  39
+Damcyan                                                                       Seed: 234   Index:  43
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 234   Index:  50
+Antlion B1F                                                                   Seed: 234   Index:  50
+Antlion B2F Inward Direct                                                     Seed: 234   Index:  88
+  Antlion B2F                                                                 Seed: 234   Index:  88
+    Step  43: 11 / Basilisk x1, Imp x3 (6.775s)
+    Step  49: 12 / SandWorm x2 (6.841s)
+    Step  62: 13 / Cream x4 (7.552s)
+    Step  75: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 234   Index: 168
+Battle: Antlion                                                               Seed: 234   Index: 182
+Antlion's Nest                                                                Seed: 234   Index: 182
+  Step   8: 15 / Cream x4 (7.523s)
+Antlion B2F Outward Charm Room Steps                                          Seed: 234   Index: 197
+  Antlion B2F                                                                 Seed: 234   Index: 197
+    Step  30: 16 / Turtle x2 (7.464s)
+  Antlion B2F Treasure Room                                                   Seed: 234   Index: 248
+    Extra Steps: 6
+  Antlion B2F                                                                 Seed: 234   Index: 254
+    Step   2: 17 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 251   Index:  32
+Overworld (Damcyan)                                                           Seed: 251   Index:  70
+Overworld (Kaipo)                                                             Seed: 251   Index:  70
+Kaipo Revisited                                                               Seed: 251   Index:  70
+Overworld (Kaipo)                                                             Seed: 251   Index:  70
+Overworld (Damcyan)                                                           Seed: 251   Index:  70
+Mt.Hobs-West                                                                  Seed: 251   Index:  70
+  Step  27: 18 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed: 251   Index: 109
+Battle: MomBomb                                                               Seed: 251   Index: 124
+Mt.Hobs Summit                                                                Seed: 251   Index: 124
+  Step   2: 19 / Spirit x2, Skelton x2 (8.237s)
+  Step   5: 20 / Spirit x2, Skelton x2 (8.237s)
+Mt.Hobs-East                                                                  Seed: 251   Index: 130
+  Extra Steps: 4
+  Step  31: 21 / Gargoyle x2 (7.630s)
+  Step  50: 22 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 251   Index: 180
+  Step  13: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  45: 24 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  12   Index:   8
+  Optional Steps: 10
+  Extra Steps: 4
+Overworld (Fabul)                                                             Seed:  12   Index:  82
+Fabul Boat and Leviatan                                                       Seed:  12   Index:  89
+Overworld (Mysidia)                                                           Seed:  12   Index:  89
+Mysidia                                                                       Seed:  12   Index:  98
+Overworld (Mysidia)                                                           Seed:  12   Index:  98
+Overworld (Mt.Ordeals)                                                        Seed:  12   Index: 108
+  Step  51: 25 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  74: 26 / Raven x1, Cocktric x3 (9.100s)
+  Step  75: 27 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  12   Index: 202
+  Step  10: 28 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  21: 29 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  12   Index: 245
+  Step  10: 30 / Ghoul x2, Soul x2 (9.357s)
+  Step  18: 31 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed:  29   Index:  12
+Mt.Ordeals-3rd station                                                        Seed:  29   Index:  12
+Mt.Ordeals-7th station                                                        Seed:  29   Index:  17
+  Step  35: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  29   Index:  59
+  Optional Steps: 1
+  Step   1: 33 / Revenant x1, Ghoul x3 (8.914s)
+  Step  10: 34 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed:  29   Index:  77
+Mt.Ordeals Summit                                                             Seed:  29   Index:  77
+Paladin                                                                       Seed:  29   Index:  81
+Mt.Ordeals Summit                                                             Seed:  29   Index:  81
+  Optional Steps: 1
+  Step  11: 35 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  29   Index: 104
+Mt.Ordeals-3rd station                                                        Seed:  29   Index: 146
+Mt.Ordeals                                                                    Seed:  29   Index: 176
+  Step  30: 36 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  29   Index: 220
+Take Chocobo to Mysidia                                                       Seed:  29   Index: 233
+Overworld (Mysidia)                                                           Seed:  29   Index: 233
+Town of Baron Serpent Road                                                    Seed:  29   Index: 233
+Credit Warp Fight Search                                                      Seed:  29   Index: 237
+  Overworld (Baron)                                                           Seed:  29   Index: 237
+    Extra Steps: 16
+    Step   2: 37 / Eagle x3 (7.417s)
+    Step  16: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  45: 39 / Eagle x3)
+   (Step  66: 40 / FloatEye x2)
+   (Step  77: 41 / Imp x4)
+   (Step  80: 42 / Imp x4)
+   (Step 144: 43 / Imp x4)
+   (Step 205: 44 / FloatEye x2)
+   (Step 255: 45 / Imp x6)
+
+Encounter Time:      298.873s
+Other Time:          518.513s
+Total Time:          817.386s
+
+Base Total Time:     917.077s
+Time Saved:          99.691s
+
+Optional Steps:      12
+Extra Steps:         108
+Encounters:          38
+
+Base Encounters:     45
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/201.txt
+++ b/data/routes/cw/201.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	201
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49312788
+VARS	FFFFFFFF:2 C307801:1 E302600:14 E305400:6 E307400:72 E307B01:8 E308000:2 E308700:1 E308702:1 E309700:44
+
+Overworld (Kaipo)                                                             Seed: 201   Index:   0
+Overworld (Kaipo)                                                             Seed: 201   Index:   1
+  Step   5: 1 / Imp x4 (6.882s)
+  Step  18: 2 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 201   Index:  37
+Overworld (Kaipo)                                                             Seed: 201   Index:  37
+Watery Pass-South B1F                                                         Seed: 201   Index:  69
+Recruit Tellah                                                                Seed: 201   Index: 101
+Watery Pass-South B1F                                                         Seed: 201   Index: 101
+  Step   2: 3 / Pike x2, EvilShel x2 (7.149s)
+  Step   8: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 201   Index: 121
+  Step  14: 5 / Pike x3 (7.152s)
+  Step  30: 6 / Zombie x4 (7.148s)
+  Step  78: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 201   Index: 211
+  Extra Steps: 6
+Watery Pass-South B2F                                                         Seed: 201   Index: 221
+Watery Pass-South B3F                                                         Seed: 218   Index:   4
+  Step  32: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B2F                                                         Seed: 218   Index:  38
+Watery Pass-North B1F                                                         Seed: 218   Index:  59
+  Step  15: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  42: 10 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed: 218   Index: 119
+Waterfalls B1F                                                                Seed: 218   Index: 128
+  Extra Steps: 72
+Waterfalls B2F                                                                Seed: 218   Index: 201
+Waterfalls Lake                                                               Seed: 218   Index: 246
+Battle: Octomamm                                                              Seed: 235   Index:  27
+Waterfalls Lake                                                               Seed: 235   Index:  27
+Overworld (Kaipo)                                                             Seed: 235   Index:  28
+  Step   6: 11 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 235   Index:  39
+Damcyan                                                                       Seed: 235   Index:  43
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 235   Index:  50
+Antlion B1F                                                                   Seed: 235   Index:  50
+  Step  16: 12 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Direct                                                     Seed: 235   Index:  88
+  Antlion B2F                                                                 Seed: 235   Index:  88
+    Step  43: 13 / Basilisk x1, Imp x3 (6.775s)
+    Step  49: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  62: 15 / Cream x4 (7.552s)
+    Step  75: 16 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 235   Index: 168
+Battle: Antlion                                                               Seed: 235   Index: 182
+Antlion's Nest                                                                Seed: 235   Index: 182
+Antlion B2F Outward Charm Room Steps                                          Seed: 235   Index: 197
+  Antlion B2F                                                                 Seed: 235   Index: 197
+    Step  30: 17 / SandWorm x2 (6.858s)
+  Antlion B2F Treasure Room                                                   Seed: 235   Index: 248
+    Extra Steps: 8
+  Antlion B2F                                                                 Seed: 252   Index:   0
+Antlion B1F                                                                   Seed: 252   Index:  34
+  Step   3: 18 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 252   Index:  72
+Overworld (Kaipo)                                                             Seed: 252   Index:  72
+Kaipo Revisited                                                               Seed: 252   Index:  72
+Overworld (Kaipo)                                                             Seed: 252   Index:  72
+Overworld (Damcyan)                                                           Seed: 252   Index:  72
+Mt.Hobs-West                                                                  Seed: 252   Index:  72
+  Step  25: 19 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 252   Index: 111
+Battle: MomBomb                                                               Seed: 252   Index: 126
+Mt.Hobs Summit                                                                Seed: 252   Index: 126
+  Step   3: 20 / Spirit x2, Skelton x2 (8.237s)
+Mt.Hobs-East                                                                  Seed: 252   Index: 132
+  Extra Steps: 2
+  Step  29: 21 / Gargoyle x2 (7.630s)
+  Step  48: 22 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 252   Index: 180
+  Step  13: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  45: 24 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  13   Index:   8
+  Optional Steps: 10
+  Extra Steps: 4
+Overworld (Fabul)                                                             Seed:  13   Index:  82
+Fabul Boat and Leviatan                                                       Seed:  13   Index:  89
+Overworld (Mysidia)                                                           Seed:  13   Index:  89
+Mysidia                                                                       Seed:  13   Index:  98
+Overworld (Mysidia)                                                           Seed:  13   Index:  98
+Overworld (Mt.Ordeals)                                                        Seed:  13   Index: 108
+  Step  50: 25 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  51: 26 / Raven x1, Cocktric x3 (9.100s)
+  Step  75: 27 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  13   Index: 202
+  Step  10: 28 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  21: 29 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  13   Index: 245
+  Step  10: 30 / Ghoul x2, Soul x2 (9.357s)
+  Step  18: 31 / Spirit x2, Soul x2, Red Bone x2 (9.938s)
+Recruit Tellah                                                                Seed:  30   Index:  12
+Mt.Ordeals-3rd station                                                        Seed:  30   Index:  12
+Mt.Ordeals-7th station                                                        Seed:  30   Index:  17
+  Step  35: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  30   Index:  59
+  Optional Steps: 1
+  Step   1: 33 / Revenant x1, Ghoul x3 (8.914s)
+  Step  10: 34 / Ghoul x2, Soul x2 (9.197s)
+Battle: Milon and Milon Z                                                     Seed:  30   Index:  77
+Mt.Ordeals Summit                                                             Seed:  30   Index:  77
+Paladin                                                                       Seed:  30   Index:  81
+Mt.Ordeals Summit                                                             Seed:  30   Index:  81
+  Optional Steps: 1
+  Step  11: 35 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  30   Index: 104
+Mt.Ordeals-3rd station                                                        Seed:  30   Index: 146
+Mt.Ordeals                                                                    Seed:  30   Index: 176
+  Step  12: 36 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  30   Index: 220
+Take Chocobo to Mysidia                                                       Seed:  30   Index: 233
+Overworld (Mysidia)                                                           Seed:  30   Index: 233
+Town of Baron Serpent Road                                                    Seed:  30   Index: 233
+  Extra Steps: 44
+Credit Warp Fight Search                                                      Seed:  47   Index:  25
+  Overworld (Baron)                                                           Seed:  47   Index:  25
+    Extra Steps: 2
+    Step   1: 37 / Eagle x3 (7.417s)
+    Step   2: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  22: 39 / Eagle x3)
+   (Step  33: 40 / FloatEye x2)
+   (Step  36: 41 / Imp x4)
+   (Step 161: 42 / Imp x4)
+   (Step 211: 43 / Imp x4)
+
+Encounter Time:      297.756s
+Other Time:          522.772s
+Total Time:          820.528s
+
+Base Total Time:     901.437s
+Time Saved:          80.908s
+
+Optional Steps:      12
+Extra Steps:         138
+Encounters:          38
+
+Base Encounters:     45
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/202.txt
+++ b/data/routes/cw/202.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	202
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50042718
+VARS	FFFFFFFF:34 E302600:12 E307400:10 E307900:24 E308000:8 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 202   Index:   0
+Overworld (Kaipo)                                                             Seed: 202   Index:   1
+  Step   5: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 202   Index:  37
+Overworld (Kaipo)                                                             Seed: 202   Index:  37
+  Step   1: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 202   Index:  69
+Recruit Tellah                                                                Seed: 202   Index: 101
+Watery Pass-South B1F                                                         Seed: 202   Index: 101
+  Step   2: 3 / Pike x2, EvilShel x2 (7.149s)
+  Step   8: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 202   Index: 121
+  Step  14: 5 / Pike x3 (7.152s)
+  Step  30: 6 / Zombie x4 (7.148s)
+  Step  78: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 202   Index: 211
+Watery Pass-South B2F                                                         Seed: 202   Index: 215
+Watery Pass-South B3F                                                         Seed: 202   Index: 254
+Watery Pass-North B2F                                                         Seed: 219   Index:  32
+  Step   4: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 219   Index:  53
+  Step  21: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  48: 10 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed: 219   Index: 113
+Waterfalls B1F                                                                Seed: 219   Index: 122
+  Extra Steps: 10
+Waterfalls B2F                                                                Seed: 219   Index: 133
+  Step  42: 11 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 219   Index: 178
+  Step  19: 12 / Mad Toad x4 (7.317s)
+  Step  23: 13 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 219   Index: 215
+Waterfalls Lake                                                               Seed: 219   Index: 215
+Overworld (Kaipo)                                                             Seed: 219   Index: 216
+Overworld (Damcyan)                                                           Seed: 219   Index: 227
+Damcyan                                                                       Seed: 219   Index: 231
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 219   Index: 238
+Antlion B1F                                                                   Seed: 219   Index: 238
+Antlion B2F Inward Direct                                                     Seed: 236   Index:  20
+  Antlion B2F                                                                 Seed: 236   Index:  20
+    Step  14: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  46: 15 / Cream x4 (7.552s)
+    Step  78: 16 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 236   Index: 100
+  Extra Steps: 24
+  Step  37: 17 / SandWorm x2 (6.841s)
+Battle: Antlion                                                               Seed: 236   Index: 138
+Antlion's Nest                                                                Seed: 236   Index: 138
+  Step  12: 18 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed: 236   Index: 153
+  Antlion B2F                                                                 Seed: 236   Index: 153
+    Step  10: 19 / Weeper x2 (7.132s)
+    Step  74: 20 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 236   Index: 233
+  Step  21: 21 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  23: 22 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 253   Index:  15
+Overworld (Kaipo)                                                             Seed: 253   Index:  15
+Kaipo Revisited                                                               Seed: 253   Index:  15
+Overworld (Kaipo)                                                             Seed: 253   Index:  15
+Overworld (Damcyan)                                                           Seed: 253   Index:  15
+Mt.Hobs-West                                                                  Seed: 253   Index:  15
+  Step  22: 23 / Cocktric x3 (9.055s)
+Mt.Hobs Summit                                                                Seed: 253   Index:  54
+Battle: MomBomb                                                               Seed: 253   Index:  69
+Mt.Hobs Summit                                                                Seed: 253   Index:  69
+Mt.Hobs-East                                                                  Seed: 253   Index:  75
+  Extra Steps: 8
+  Step  22: 24 / Spirit x2, Skelton x2 (8.237s)
+  Step  45: 25 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed: 253   Index: 129
+  Step  32: 26 / SwordRat x3, Needler x3 (7.663s)
+  Step  51: 27 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  64: 28 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 253   Index: 213
+  Optional Steps: 10
+  Extra Steps: 2
+Overworld (Fabul)                                                             Seed:  14   Index:  29
+  Step   6: 29 / Imp Cap. x4, Imp x2 (8.397s)
+Fabul Boat and Leviatan                                                       Seed:  14   Index:  36
+Overworld (Mysidia)                                                           Seed:  14   Index:  36
+Mysidia                                                                       Seed:  14   Index:  45
+Overworld (Mysidia)                                                           Seed:  14   Index:  45
+Overworld (Mt.Ordeals)                                                        Seed:  14   Index:  55
+  Step   9: 30 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  14   Index: 149
+  Step   9: 31 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  14   Index: 192
+  Step  20: 32 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  14   Index: 215
+Mt.Ordeals-3rd station                                                        Seed:  14   Index: 215
+Mt.Ordeals-7th station                                                        Seed:  14   Index: 220
+  Step   3: 33 / Revenant x1, Ghoul x3 (8.914s)
+  Step  35: 34 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals Summit                                                             Seed:  31   Index:   6
+  Optional Steps: 1
+  Step   1: 35 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed:  31   Index:  24
+Mt.Ordeals Summit                                                             Seed:  31   Index:  24
+Paladin                                                                       Seed:  31   Index:  28
+Mt.Ordeals Summit                                                             Seed:  31   Index:  28
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  31   Index:  51
+  Step   1: 36 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step   9: 37 / Lilith x1, Red Bone x2 (8.437s)
+  Step  18: 38 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  41: 39 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  31   Index:  93
+Mt.Ordeals                                                                    Seed:  31   Index: 123
+Overworld (Mt.Ordeals)                                                        Seed:  31   Index: 167
+Take Chocobo to Mysidia                                                       Seed:  31   Index: 180
+Overworld (Mysidia)                                                           Seed:  31   Index: 180
+Town of Baron Serpent Road                                                    Seed:  31   Index: 180
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed:  31   Index: 186
+  Overworld (Baron)                                                           Seed:  31   Index: 186
+    Extra Steps: 34
+    Step   2: 40 / FloatEye x2 (7.230s)
+    Step  34: 41 / Imp x4 (7.223s)
+   (Step  97: 42 / Imp x4)
+   (Step 117: 43 / Imp x4)
+   (Step 128: 44 / FloatEye x2)
+   (Step 131: 45 / Imp x3)
+   (Step 256: 46 / Imp x3)
+
+Encounter Time:      321.416s
+Other Time:          511.258s
+Total Time:          832.674s
+
+Base Total Time:     1190.903s
+Time Saved:          358.229s
+
+Optional Steps:      12
+Extra Steps:         80
+Encounters:          41
+
+Base Encounters:     57
+Encounters Saved:    16
+
+Number of Variables: 54

--- a/data/routes/cw/203.txt
+++ b/data/routes/cw/203.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	203
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49948459
+VARS	FFFFFFFF:4 C307801:1 E307400:78 E307B01:8 E308000:2 E308700:1 E308702:1 E309700:90
+
+Overworld (Kaipo)                                                             Seed: 203   Index:   0
+Overworld (Kaipo)                                                             Seed: 203   Index:   1
+  Step   5: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 203   Index:  37
+Overworld (Kaipo)                                                             Seed: 203   Index:  37
+  Step   1: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 203   Index:  69
+  Step   1: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 203   Index: 101
+Watery Pass-South B1F                                                         Seed: 203   Index: 101
+  Step   8: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 203   Index: 121
+  Step  14: 5 / Pike x3 (7.152s)
+  Step  30: 6 / Zombie x4 (7.148s)
+  Step  78: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 203   Index: 211
+Watery Pass-South B2F                                                         Seed: 203   Index: 215
+Watery Pass-South B3F                                                         Seed: 203   Index: 254
+Watery Pass-North B2F                                                         Seed: 220   Index:  32
+  Step   4: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 220   Index:  53
+  Step  21: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  47: 10 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed: 220   Index: 113
+Waterfalls B1F                                                                Seed: 220   Index: 122
+  Extra Steps: 78
+Waterfalls B2F                                                                Seed: 220   Index: 201
+Waterfalls Lake                                                               Seed: 220   Index: 246
+Battle: Octomamm                                                              Seed: 237   Index:  27
+Waterfalls Lake                                                               Seed: 237   Index:  27
+Overworld (Kaipo)                                                             Seed: 237   Index:  28
+  Step   6: 11 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 237   Index:  39
+Damcyan                                                                       Seed: 237   Index:  43
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 237   Index:  50
+Antlion B1F                                                                   Seed: 237   Index:  50
+  Step  16: 12 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Direct                                                     Seed: 237   Index:  88
+  Antlion B2F                                                                 Seed: 237   Index:  88
+    Step  10: 13 / Basilisk x1, Imp x3 (6.775s)
+    Step  25: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  62: 15 / Cream x4 (7.552s)
+    Step  75: 16 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 237   Index: 168
+Battle: Antlion                                                               Seed: 237   Index: 182
+Antlion's Nest                                                                Seed: 237   Index: 182
+Antlion B2F Outward Charm Room Steps                                          Seed: 237   Index: 197
+  Antlion B2F                                                                 Seed: 237   Index: 197
+    Step  30: 17 / SandWorm x2 (6.858s)
+  Antlion B2F Treasure Room                                                   Seed: 237   Index: 248
+    Extra Steps: 8
+  Antlion B2F                                                                 Seed: 254   Index:   0
+Antlion B1F                                                                   Seed: 254   Index:  34
+  Step   3: 18 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed: 254   Index:  72
+Overworld (Kaipo)                                                             Seed: 254   Index:  72
+Kaipo Revisited                                                               Seed: 254   Index:  72
+Overworld (Kaipo)                                                             Seed: 254   Index:  72
+Overworld (Damcyan)                                                           Seed: 254   Index:  72
+Mt.Hobs-West                                                                  Seed: 254   Index:  72
+  Step  25: 19 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed: 254   Index: 111
+  Step   9: 20 / Spirit x2, Skelton x2 (9.087s)
+Battle: MomBomb                                                               Seed: 254   Index: 126
+Mt.Hobs Summit                                                                Seed: 254   Index: 126
+Mt.Hobs-East                                                                  Seed: 254   Index: 132
+  Extra Steps: 2
+  Step  12: 21 / Gargoyle x2 (7.630s)
+  Step  48: 22 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed: 254   Index: 180
+  Step  13: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  45: 24 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  15   Index:   8
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed:  15   Index:  68
+Fabul Boat and Leviatan                                                       Seed:  15   Index:  75
+Overworld (Mysidia)                                                           Seed:  15   Index:  75
+Mysidia                                                                       Seed:  15   Index:  84
+Overworld (Mysidia)                                                           Seed:  15   Index:  84
+Overworld (Mt.Ordeals)                                                        Seed:  15   Index:  94
+  Step  64: 25 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  89: 26 / Raven x1, Cocktric x3 (9.100s)
+Mt.Ordeals                                                                    Seed:  15   Index: 188
+  Step  24: 27 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  34: 28 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:  15   Index: 231
+Recruit Tellah                                                                Seed:  15   Index: 254
+Mt.Ordeals-3rd station                                                        Seed:  15   Index: 254
+  Step   1: 29 / Zombie x2, Ghoul x2 (7.616s)
+Mt.Ordeals-7th station                                                        Seed:  32   Index:   3
+  Step   4: 30 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  32   Index:  45
+  Optional Steps: 1
+  Step   7: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  15: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed:  32   Index:  63
+Mt.Ordeals Summit                                                             Seed:  32   Index:  63
+Paladin                                                                       Seed:  32   Index:  67
+Mt.Ordeals Summit                                                             Seed:  32   Index:  67
+  Optional Steps: 1
+  Step   2: 33 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed:  32   Index:  90
+  Step   2: 34 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed:  32   Index: 132
+  Step   9: 35 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed:  32   Index: 162
+  Step  26: 36 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  32   Index: 206
+Take Chocobo to Mysidia                                                       Seed:  32   Index: 219
+Overworld (Mysidia)                                                           Seed:  32   Index: 219
+Town of Baron Serpent Road                                                    Seed:  32   Index: 219
+  Extra Steps: 90
+Credit Warp Fight Search                                                      Seed:  49   Index:  57
+  Overworld (Baron)                                                           Seed:  49   Index:  57
+    Extra Steps: 4
+    Step   1: 37 / Eagle x3 (7.417s)
+    Step   4: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step 110: 39 / Imp x4)
+   (Step 129: 40 / FloatEye x2)
+   (Step 189: 41 / Imp x4)
+   (Step 227: 42 / Imp x4)
+   (Step 229: 43 / Imp x3, SwordRat x1)
+   (Step 242: 44 / FloatEye x2)
+
+Encounter Time:      296.087s
+Other Time:          535.019s
+Total Time:          831.106s
+
+Base Total Time:     1161.611s
+Time Saved:          330.505s
+
+Optional Steps:      2
+Extra Steps:         182
+Encounters:          38
+
+Base Encounters:     57
+Encounters Saved:    19
+
+Number of Variables: 54

--- a/data/routes/cw/204.txt
+++ b/data/routes/cw/204.txt
@@ -1,0 +1,147 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	204
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48370457
+VARS	FFFFFFFF:22 E302600:11 E307400:78 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 204   Index:   0
+Overworld (Kaipo)                                                             Seed: 204   Index:   1
+  Step   5: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 204   Index:  37
+Overworld (Kaipo)                                                             Seed: 204   Index:  37
+  Step   1: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 204   Index:  69
+  Step   1: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 204   Index: 101
+Watery Pass-South B1F                                                         Seed: 204   Index: 101
+  Step   8: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 204   Index: 121
+  Step  30: 5 / Zombie x4 (7.148s)
+  Step  78: 6 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed: 204   Index: 211
+Watery Pass-South B2F                                                         Seed: 204   Index: 215
+  Step  29: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 204   Index: 254
+Watery Pass-North B2F                                                         Seed: 221   Index:  32
+  Step   4: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 221   Index:  53
+  Step  21: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  47: 10 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed: 221   Index: 113
+Waterfalls B1F                                                                Seed: 221   Index: 122
+  Extra Steps: 78
+Waterfalls B2F                                                                Seed: 221   Index: 201
+Waterfalls Lake                                                               Seed: 221   Index: 246
+Battle: Octomamm                                                              Seed: 238   Index:  27
+Waterfalls Lake                                                               Seed: 238   Index:  27
+Overworld (Kaipo)                                                             Seed: 238   Index:  28
+  Step   6: 11 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 238   Index:  39
+Damcyan                                                                       Seed: 238   Index:  43
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 238   Index:  50
+Antlion B1F                                                                   Seed: 238   Index:  50
+  Step  16: 12 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Direct                                                     Seed: 238   Index:  88
+  Antlion B2F                                                                 Seed: 238   Index:  88
+    Step  10: 13 / Basilisk x1, Imp x3 (6.775s)
+    Step  25: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  62: 15 / Cream x4 (7.552s)
+    Step  74: 16 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 238   Index: 168
+Battle: Antlion                                                               Seed: 238   Index: 182
+Antlion's Nest                                                                Seed: 238   Index: 182
+Antlion B2F Outward Direct                                                    Seed: 238   Index: 197
+  Antlion B2F                                                                 Seed: 238   Index: 197
+    Step  30: 17 / SandWorm x2 (6.858s)
+    Step  57: 18 / Cream x4 (7.523s)
+    Step  59: 19 / Weeper x2 (7.132s)
+Antlion B1F                                                                   Seed: 255   Index:  21
+  Step  16: 20 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed: 255   Index:  59
+Overworld (Kaipo)                                                             Seed: 255   Index:  59
+Kaipo Revisited                                                               Seed: 255   Index:  59
+Overworld (Kaipo)                                                             Seed: 255   Index:  59
+Overworld (Damcyan)                                                           Seed: 255   Index:  59
+Mt.Hobs-West                                                                  Seed: 255   Index:  59
+  Step  38: 21 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed: 255   Index:  98
+Battle: MomBomb                                                               Seed: 255   Index: 113
+Mt.Hobs Summit                                                                Seed: 255   Index: 113
+Mt.Hobs-East                                                                  Seed: 255   Index: 119
+  Step   1: 22 / Turtle x2 (7.432s)
+  Step  11: 23 / Red Bone x1, Skelton x3 (8.007s)
+  Step  25: 24 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed: 255   Index: 165
+  Step  15: 25 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  28: 26 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  60: 27 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed: 255   Index: 249
+  Optional Steps: 9
+  Extra Steps: 2
+Overworld (Fabul)                                                             Seed:  16   Index:  64
+Fabul Boat and Leviatan                                                       Seed:  16   Index:  71
+Overworld (Mysidia)                                                           Seed:  16   Index:  71
+Mysidia                                                                       Seed:  16   Index:  80
+Overworld (Mysidia)                                                           Seed:  16   Index:  80
+Overworld (Mt.Ordeals)                                                        Seed:  16   Index:  90
+  Step  68: 28 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  16   Index: 184
+  Step  28: 29 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  38: 30 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  16   Index: 227
+Recruit Tellah                                                                Seed:  16   Index: 250
+Mt.Ordeals-3rd station                                                        Seed:  16   Index: 250
+Mt.Ordeals-7th station                                                        Seed:  16   Index: 255
+  Step   8: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  33   Index:  41
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  33   Index:  59
+Mt.Ordeals Summit                                                             Seed:  33   Index:  59
+  Step   1: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.808s)
+Paladin                                                                       Seed:  33   Index:  63
+Mt.Ordeals Summit                                                             Seed:  33   Index:  63
+  Optional Steps: 1
+  Step   6: 33 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed:  33   Index:  86
+  Step   6: 34 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed:  33   Index: 128
+  Step  13: 35 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed:  33   Index: 158
+  Step  30: 36 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  33   Index: 202
+Take Chocobo to Mysidia                                                       Seed:  33   Index: 215
+Overworld (Mysidia)                                                           Seed:  33   Index: 215
+Town of Baron Serpent Road                                                    Seed:  33   Index: 215
+Credit Warp Fight Search                                                      Seed:  33   Index: 219
+  Overworld (Baron)                                                           Seed:  33   Index: 219
+    Extra Steps: 22
+    Step   1: 37 / Eagle x3 (7.417s)
+    Step  22: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  64: 39 / Imp x4)
+   (Step  91: 40 / FloatEye x2)
+   (Step  95: 41 / Imp x4)
+   (Step  98: 42 / Imp x4)
+   (Step 204: 43 / Imp x3, SwordRat x1)
+   (Step 223: 44 / FloatEye x1, Eagle x2)
+
+Encounter Time:      290.928s
+Other Time:          513.920s
+Total Time:          804.849s
+
+Base Total Time:     1164.146s
+Time Saved:          359.297s
+
+Optional Steps:      11
+Extra Steps:         102
+Encounters:          38
+
+Base Encounters:     57
+Encounters Saved:    19
+
+Number of Variables: 54

--- a/data/routes/cw/205.txt
+++ b/data/routes/cw/205.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	205
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49170704
+VARS	FFFFFFFF:22 C307800:1 C307801:1 E302500:1 E307400:52 E307B00:18 E307B01:10
+
+Overworld (Kaipo)                                                             Seed: 205   Index:   0
+Overworld (Kaipo)                                                             Seed: 205   Index:   1
+  Step   5: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 205   Index:  37
+Overworld (Kaipo)                                                             Seed: 205   Index:  37
+  Step   1: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 205   Index:  69
+  Step   1: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 205   Index: 101
+Watery Pass-South B1F                                                         Seed: 205   Index: 101
+Watery Pass-South B2F                                                         Seed: 205   Index: 121
+  Step  13: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  30: 5 / Zombie x4 (7.148s)
+  Step  78: 6 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed: 205   Index: 211
+Watery Pass-South B2F                                                         Seed: 205   Index: 215
+  Step  29: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 205   Index: 254
+Watery Pass-North B2F                                                         Seed: 222   Index:  32
+  Step   4: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 222   Index:  53
+  Step  21: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  47: 10 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed: 222   Index: 113
+Waterfalls B1F                                                                Seed: 222   Index: 122
+  Extra Steps: 52
+Waterfalls B2F                                                                Seed: 222   Index: 175
+  Step  22: 11 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 222   Index: 220
+Battle: Octomamm                                                              Seed: 239   Index:   1
+Waterfalls Lake                                                               Seed: 239   Index:   1
+Overworld (Kaipo)                                                             Seed: 239   Index:   2
+Overworld (Damcyan)                                                           Seed: 239   Index:  13
+Damcyan                                                                       Seed: 239   Index:  17
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 239   Index:  25
+Antlion B1F                                                                   Seed: 239   Index:  25
+  Step   9: 12 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 239   Index:  63
+  Antlion B2F                                                                 Seed: 239   Index:  63
+    Step   3: 13 / Basilisk x1, Imp x3 (6.775s)
+  Antlion B2F Treasure Room                                                   Seed: 239   Index:  96
+    Extra Steps: 18
+  Antlion B2F                                                                 Seed: 239   Index: 114
+    Step  48: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 239   Index: 166
+Battle: Antlion                                                               Seed: 239   Index: 180
+Antlion's Nest                                                                Seed: 239   Index: 180
+  Step  14: 15 / Cream x4 (7.523s)
+Antlion B2F Outward Charm Room Steps                                          Seed: 239   Index: 195
+  Antlion B2F                                                                 Seed: 239   Index: 195
+    Step  32: 16 / Turtle x2 (7.464s)
+  Antlion B2F Treasure Room                                                   Seed: 239   Index: 246
+    Extra Steps: 10
+  Antlion B2F                                                                 Seed:   0   Index:   0
+Antlion B1F                                                                   Seed:   0   Index:  34
+  Step   3: 17 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Overworld (Damcyan)                                                           Seed:   0   Index:  72
+Overworld (Kaipo)                                                             Seed:   0   Index:  72
+Kaipo Revisited                                                               Seed:   0   Index:  72
+Overworld (Kaipo)                                                             Seed:   0   Index:  72
+Overworld (Damcyan)                                                           Seed:   0   Index:  72
+Mt.Hobs-West                                                                  Seed:   0   Index:  72
+  Step  15: 18 / Skelton x4 (8.683s)
+  Step  25: 19 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed:   0   Index: 111
+  Step   9: 20 / Spirit x2, Skelton x2 (9.087s)
+Battle: MomBomb                                                               Seed:   0   Index: 126
+Mt.Hobs Summit                                                                Seed:   0   Index: 126
+  Step   4: 21 / Spirit x2 (7.652s)
+Mt.Hobs-East                                                                  Seed:   0   Index: 132
+  Step  12: 22 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:   0   Index: 178
+  Step   2: 23 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  15: 24 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  47: 25 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  80: 26 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  17   Index:   6
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed:  17   Index:  66
+Fabul Boat and Leviatan                                                       Seed:  17   Index:  73
+Overworld (Mysidia)                                                           Seed:  17   Index:  73
+Mysidia                                                                       Seed:  17   Index:  82
+Overworld (Mysidia)                                                           Seed:  17   Index:  82
+Overworld (Mt.Ordeals)                                                        Seed:  17   Index:  92
+  Step   1: 27 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  66: 28 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  17   Index: 186
+  Step  26: 29 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  36: 30 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  17   Index: 229
+Recruit Tellah                                                                Seed:  17   Index: 252
+Mt.Ordeals-3rd station                                                        Seed:  17   Index: 252
+Mt.Ordeals-7th station                                                        Seed:  34   Index:   1
+  Step   6: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  34   Index:  43
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed:  34   Index:  60
+Mt.Ordeals Summit                                                             Seed:  34   Index:  60
+Paladin                                                                       Seed:  34   Index:  64
+Mt.Ordeals Summit                                                             Seed:  34   Index:  64
+  Optional Steps: 0
+  Step   5: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed:  34   Index:  86
+  Step   6: 33 / Revenant x1, Ghoul x3 (8.489s)
+  Step  35: 34 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed:  34   Index: 128
+  Step  13: 35 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed:  34   Index: 158
+  Step  30: 36 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  34   Index: 202
+Take Chocobo to Mysidia                                                       Seed:  34   Index: 215
+Overworld (Mysidia)                                                           Seed:  34   Index: 215
+Town of Baron Serpent Road                                                    Seed:  34   Index: 215
+Credit Warp Fight Search                                                      Seed:  34   Index: 219
+  Overworld (Baron)                                                           Seed:  34   Index: 219
+    Extra Steps: 22
+    Step   1: 37 / Eagle x3 (7.417s)
+    Step  22: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  64: 39 / Imp x4)
+   (Step  91: 40 / FloatEye x2)
+   (Step  98: 41 / Imp x4)
+   (Step 126: 42 / Imp x4)
+   (Step 204: 43 / Imp x3, SwordRat x1)
+   (Step 223: 44 / FloatEye x1, Eagle x2)
+
+Encounter Time:      295.059s
+Other Time:          523.105s
+Total Time:          818.164s
+
+Base Total Time:     1055.795s
+Time Saved:          237.630s
+
+Optional Steps:      1
+Extra Steps:         102
+Encounters:          38
+
+Base Encounters:     53
+Encounters Saved:    15
+
+Number of Variables: 54

--- a/data/routes/cw/206.txt
+++ b/data/routes/cw/206.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	206
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49204506
+VARS	FFFFFFFF:22 C307800:1 E302600:14 E307200:2 E307400:50 E307B00:18 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 206   Index:   0
+Overworld (Kaipo)                                                             Seed: 206   Index:   1
+  Step   5: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 206   Index:  37
+Overworld (Kaipo)                                                             Seed: 206   Index:  37
+  Step   1: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 206   Index:  69
+  Step   1: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 206   Index: 101
+Watery Pass-South B1F                                                         Seed: 206   Index: 101
+Watery Pass-South B2F                                                         Seed: 206   Index: 121
+  Step  13: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  30: 5 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed: 206   Index: 211
+Watery Pass-South B2F                                                         Seed: 206   Index: 215
+  Step  27: 6 / Zombie x4 (7.148s)
+  Step  29: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 206   Index: 254
+Watery Pass-North B2F                                                         Seed: 223   Index:  32
+  Extra Steps: 2
+  Step   4: 8 / Pike x2, EvilShel x2 (7.149s)
+  Step  23: 9 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 223   Index:  55
+  Step  19: 10 / Aligator x1, Pike x2 (7.368s)
+  Step  45: 11 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 223   Index: 115
+Waterfalls B1F                                                                Seed: 223   Index: 124
+  Extra Steps: 50
+Waterfalls B2F                                                                Seed: 223   Index: 175
+Waterfalls Lake                                                               Seed: 223   Index: 220
+Battle: Octomamm                                                              Seed: 240   Index:   1
+Waterfalls Lake                                                               Seed: 240   Index:   1
+Overworld (Kaipo)                                                             Seed: 240   Index:   2
+Overworld (Damcyan)                                                           Seed: 240   Index:  13
+Damcyan                                                                       Seed: 240   Index:  17
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 240   Index:  24
+Antlion B1F                                                                   Seed: 240   Index:  24
+  Step  10: 12 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 240   Index:  62
+  Antlion B2F                                                                 Seed: 240   Index:  62
+    Step   4: 13 / Basilisk x1, Imp x3 (6.775s)
+  Antlion B2F Treasure Room                                                   Seed: 240   Index:  95
+    Extra Steps: 18
+  Antlion B2F                                                                 Seed: 240   Index: 113
+    Step  49: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 240   Index: 165
+Battle: Antlion                                                               Seed: 240   Index: 179
+Antlion's Nest                                                                Seed: 240   Index: 179
+  Step  15: 15 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed: 240   Index: 194
+  Antlion B2F                                                                 Seed: 240   Index: 194
+    Step  16: 16 / Turtle x2 (7.464s)
+    Step  60: 17 / SandWorm x1, Sandpede x1 (6.848s)
+Antlion B1F                                                                   Seed:   1   Index:  18
+  Step  19: 18 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  38: 19 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed:   1   Index:  56
+Overworld (Kaipo)                                                             Seed:   1   Index:  56
+Kaipo Revisited                                                               Seed:   1   Index:  56
+Overworld (Kaipo)                                                             Seed:   1   Index:  56
+Overworld (Damcyan)                                                           Seed:   1   Index:  56
+Mt.Hobs-West                                                                  Seed:   1   Index:  56
+  Step  31: 20 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed:   1   Index:  95
+  Step   2: 21 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:   1   Index: 110
+Mt.Hobs Summit                                                                Seed:   1   Index: 110
+Mt.Hobs-East                                                                  Seed:   1   Index: 116
+  Step   4: 22 / Turtle x2 (7.432s)
+  Step  14: 23 / Red Bone x1, Skelton x3 (8.007s)
+  Step  28: 24 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:   1   Index: 162
+  Step  18: 25 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  63: 26 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:   1   Index: 246
+  Optional Steps: 10
+  Extra Steps: 4
+Overworld (Fabul)                                                             Seed:  18   Index:  64
+Fabul Boat and Leviatan                                                       Seed:  18   Index:  71
+Overworld (Mysidia)                                                           Seed:  18   Index:  71
+Mysidia                                                                       Seed:  18   Index:  80
+Overworld (Mysidia)                                                           Seed:  18   Index:  80
+Overworld (Mt.Ordeals)                                                        Seed:  18   Index:  90
+  Step   3: 27 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  68: 28 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  18   Index: 184
+  Step  28: 29 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  38: 30 / Spirit x3, Soul x1 (8.687s)
+  Step  40: 31 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:  18   Index: 227
+Recruit Tellah                                                                Seed:  18   Index: 250
+Mt.Ordeals-3rd station                                                        Seed:  18   Index: 250
+Mt.Ordeals-7th station                                                        Seed:  18   Index: 255
+  Step   8: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  32: 33 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed:  35   Index:  41
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  35   Index:  59
+Mt.Ordeals Summit                                                             Seed:  35   Index:  59
+Paladin                                                                       Seed:  35   Index:  63
+Mt.Ordeals Summit                                                             Seed:  35   Index:  63
+  Optional Steps: 1
+  Step   6: 34 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed:  35   Index:  86
+  Step  35: 35 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  35   Index: 128
+  Step  13: 36 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:  35   Index: 158
+  Step  30: 37 / Soul x2, Red Bone x2 (8.881s)
+Overworld (Mt.Ordeals)                                                        Seed:  35   Index: 202
+Take Chocobo to Mysidia                                                       Seed:  35   Index: 215
+Overworld (Mysidia)                                                           Seed:  35   Index: 215
+Town of Baron Serpent Road                                                    Seed:  35   Index: 215
+Credit Warp Fight Search                                                      Seed:  35   Index: 219
+  Overworld (Baron)                                                           Seed:  35   Index: 219
+    Extra Steps: 22
+    Step   1: 38 / Imp x3, SwordRat x1 (7.227s)
+    Step  22: 39 / Imp x4 (7.223s)
+   (Step  64: 40 / FloatEye x2)
+   (Step  91: 41 / Imp x4)
+   (Step 126: 42 / Imp x4)
+   (Step 180: 43 / Imp x3, SwordRat x1)
+   (Step 204: 44 / FloatEye x1, Eagle x2)
+   (Step 223: 45 / Imp x3)
+
+Encounter Time:      301.811s
+Other Time:          516.915s
+Total Time:          818.727s
+
+Base Total Time:     1046.240s
+Time Saved:          227.513s
+
+Optional Steps:      12
+Extra Steps:         96
+Encounters:          39
+
+Base Encounters:     53
+Encounters Saved:    14
+
+Number of Variables: 54

--- a/data/routes/cw/207.txt
+++ b/data/routes/cw/207.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	207
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49185080
+VARS	FFFFFFFF:14 C307800:1 E000201:2 E302600:18 E307200:2 E307400:8 E307B00:58 E308700:1 E308702:1 E309700:46
+
+Overworld (Kaipo)                                                             Seed: 207   Index:   0
+Overworld (Kaipo)                                                             Seed: 207   Index:   1
+  Step   5: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 207   Index:  37
+Overworld (Kaipo)                                                             Seed: 207   Index:  37
+  Step   1: 2 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 207   Index:  69
+  Step   1: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 207   Index: 101
+Watery Pass-South B1F                                                         Seed: 207   Index: 101
+Watery Pass-South B2F                                                         Seed: 207   Index: 121
+  Step  13: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  86: 5 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed: 207   Index: 211
+Watery Pass-South B2F                                                         Seed: 207   Index: 215
+  Step  27: 6 / Zombie x4 (7.148s)
+  Step  29: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 207   Index: 254
+Watery Pass-North B2F                                                         Seed: 224   Index:  32
+  Extra Steps: 2
+  Step   4: 8 / Zombie x4 (7.148s)
+  Step  23: 9 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 224   Index:  55
+  Step  19: 10 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  45: 11 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 224   Index: 115
+Waterfalls B1F                                                                Seed: 224   Index: 124
+  Extra Steps: 8
+Waterfalls B2F                                                                Seed: 224   Index: 133
+  Step  31: 12 / TinyMage x4 (7.558s)
+Waterfalls Lake                                                               Seed: 224   Index: 178
+Battle: Octomamm                                                              Seed: 224   Index: 215
+Waterfalls Lake                                                               Seed: 224   Index: 215
+Overworld (Kaipo)                                                             Seed: 224   Index: 216
+  Extra Steps: 2
+  Step  12: 13 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 224   Index: 229
+Damcyan                                                                       Seed: 224   Index: 233
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 224   Index: 240
+Antlion B1F                                                                   Seed: 224   Index: 240
+Antlion B2F Inward Charm Room Steps                                           Seed: 241   Index:  22
+  Antlion B2F                                                                 Seed: 241   Index:  22
+    Step  12: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+  Antlion B2F Treasure Room                                                   Seed: 241   Index:  55
+    Extra Steps: 58
+  Antlion B2F                                                                 Seed: 241   Index: 113
+    Step  49: 15 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 241   Index: 165
+Battle: Antlion                                                               Seed: 241   Index: 179
+Antlion's Nest                                                                Seed: 241   Index: 179
+  Step  15: 16 / Turtle x2 (7.464s)
+Antlion B2F Outward Direct                                                    Seed: 241   Index: 194
+  Antlion B2F                                                                 Seed: 241   Index: 194
+    Step  16: 17 / SandWorm x1, Sandpede x1 (6.848s)
+Antlion B1F                                                                   Seed:   2   Index:  18
+  Step  19: 18 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  38: 19 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed:   2   Index:  56
+Overworld (Kaipo)                                                             Seed:   2   Index:  56
+Kaipo Revisited                                                               Seed:   2   Index:  56
+Overworld (Kaipo)                                                             Seed:   2   Index:  56
+Overworld (Damcyan)                                                           Seed:   2   Index:  56
+Mt.Hobs-West                                                                  Seed:   2   Index:  56
+  Step  31: 20 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed:   2   Index:  95
+  Step   2: 21 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:   2   Index: 110
+Mt.Hobs Summit                                                                Seed:   2   Index: 110
+Mt.Hobs-East                                                                  Seed:   2   Index: 116
+  Step   4: 22 / Turtle x2 (7.432s)
+  Step  14: 23 / Red Bone x1, Skelton x3 (8.007s)
+  Step  28: 24 / Spirit x2, Skelton x2 (8.237s)
+  Step  30: 25 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed:   2   Index: 162
+  Step  18: 26 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:   2   Index: 246
+  Optional Steps: 10
+  Extra Steps: 8
+Overworld (Fabul)                                                             Seed:  19   Index:  68
+Fabul Boat and Leviatan                                                       Seed:  19   Index:  75
+Overworld (Mysidia)                                                           Seed:  19   Index:  75
+Mysidia                                                                       Seed:  19   Index:  84
+Overworld (Mysidia)                                                           Seed:  19   Index:  84
+  Step   9: 27 / Imp Cap. x3, Needler x1 (7.932s)
+Overworld (Mt.Ordeals)                                                        Seed:  19   Index:  94
+  Step  64: 28 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  19   Index: 188
+  Step  34: 29 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  36: 30 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  19   Index: 231
+Recruit Tellah                                                                Seed:  19   Index: 254
+Mt.Ordeals-3rd station                                                        Seed:  19   Index: 254
+Mt.Ordeals-7th station                                                        Seed:  36   Index:   3
+  Step   4: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  28: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  36   Index:  45
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  36   Index:  63
+Mt.Ordeals Summit                                                             Seed:  36   Index:  63
+Paladin                                                                       Seed:  36   Index:  67
+Mt.Ordeals Summit                                                             Seed:  36   Index:  67
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  36   Index:  90
+  Step  31: 33 / Revenant x1, Ghoul x3 (8.489s)
+  Step  33: 34 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed:  36   Index: 132
+  Step   9: 35 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed:  36   Index: 162
+  Step  26: 36 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  36   Index: 206
+Take Chocobo to Mysidia                                                       Seed:  36   Index: 219
+Overworld (Mysidia)                                                           Seed:  36   Index: 219
+Town of Baron Serpent Road                                                    Seed:  36   Index: 219
+  Extra Steps: 46
+Credit Warp Fight Search                                                      Seed:  53   Index:  13
+  Overworld (Baron)                                                           Seed:  53   Index:  13
+    Extra Steps: 14
+    Step   2: 37 / Eagle x3 (7.417s)
+    Step  14: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  41: 39 / Imp x4)
+   (Step  76: 40 / FloatEye x2)
+   (Step 130: 41 / Imp x4)
+   (Step 154: 42 / Imp x3, SwordRat x1)
+   (Step 233: 43 / Imp x3, SwordRat x1)
+
+Encounter Time:      292.436s
+Other Time:          525.967s
+Total Time:          818.404s
+
+Base Total Time:     1046.092s
+Time Saved:          227.689s
+
+Optional Steps:      12
+Extra Steps:         138
+Encounters:          38
+
+Base Encounters:     53
+Encounters Saved:    15
+
+Number of Variables: 54

--- a/data/routes/cw/208.txt
+++ b/data/routes/cw/208.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	208
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49794555
+VARS	FFFFFFFF:32 C307800:1 E000201:2 E302600:18 E307100:4 E307400:6 E307B00:58 E308700:1 E308702:1 E309700:16
+
+Overworld (Kaipo)                                                             Seed: 208   Index:   0
+Overworld (Kaipo)                                                             Seed: 208   Index:   1
+  Step   5: 1 / Imp x4 (6.882s)
+Kaipo                                                                         Seed: 208   Index:  37
+Overworld (Kaipo)                                                             Seed: 208   Index:  37
+  Step   1: 2 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 208   Index:  69
+  Step   1: 3 / Pike x2, EvilShel x2 (6.952s)
+  Step  15: 4 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 208   Index: 101
+Watery Pass-South B1F                                                         Seed: 208   Index: 101
+Watery Pass-South B2F                                                         Seed: 208   Index: 121
+  Step  13: 5 / Zombie x4 (7.148s)
+  Step  86: 6 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed: 208   Index: 211
+Watery Pass-South B2F                                                         Seed: 208   Index: 215
+  Step  27: 7 / Pike x3 (7.152s)
+  Step  29: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed: 208   Index: 254
+  Extra Steps: 4
+  Step   5: 9 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 225   Index:  36
+  Step  19: 10 / TinyMage x2, WaterHag x4 (8.120s)
+Watery Pass-North B1F                                                         Seed: 225   Index:  57
+  Step  43: 11 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 225   Index: 117
+Waterfalls B1F                                                                Seed: 225   Index: 126
+  Extra Steps: 6
+Waterfalls B2F                                                                Seed: 225   Index: 133
+  Step  31: 12 / TinyMage x4 (7.558s)
+Waterfalls Lake                                                               Seed: 225   Index: 178
+Battle: Octomamm                                                              Seed: 225   Index: 215
+Waterfalls Lake                                                               Seed: 225   Index: 215
+Overworld (Kaipo)                                                             Seed: 225   Index: 216
+  Extra Steps: 2
+  Step  12: 13 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed: 225   Index: 229
+Damcyan                                                                       Seed: 225   Index: 233
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 225   Index: 240
+Antlion B1F                                                                   Seed: 225   Index: 240
+Antlion B2F Inward Charm Room Steps                                           Seed: 242   Index:  22
+  Antlion B2F                                                                 Seed: 242   Index:  22
+  Antlion B2F Treasure Room                                                   Seed: 242   Index:  55
+    Extra Steps: 58
+  Antlion B2F                                                                 Seed: 242   Index: 113
+    Step  49: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 242   Index: 165
+  Step  14: 15 / Cream x4 (7.552s)
+Battle: Antlion                                                               Seed: 242   Index: 179
+Antlion's Nest                                                                Seed: 242   Index: 179
+  Step  15: 16 / Turtle x2 (7.464s)
+Antlion B2F Outward Direct                                                    Seed: 242   Index: 194
+  Antlion B2F                                                                 Seed: 242   Index: 194
+    Step  16: 17 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed:   3   Index:  18
+  Step  19: 18 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  38: 19 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed:   3   Index:  56
+Overworld (Kaipo)                                                             Seed:   3   Index:  56
+Kaipo Revisited                                                               Seed:   3   Index:  56
+Overworld (Kaipo)                                                             Seed:   3   Index:  56
+Overworld (Damcyan)                                                           Seed:   3   Index:  56
+Mt.Hobs-West                                                                  Seed:   3   Index:  56
+  Step  31: 20 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed:   3   Index:  95
+Battle: MomBomb                                                               Seed:   3   Index: 110
+Mt.Hobs Summit                                                                Seed:   3   Index: 110
+Mt.Hobs-East                                                                  Seed:   3   Index: 116
+  Step   4: 21 / Gargoyle x2 (7.630s)
+  Step  14: 22 / Gargoyle x2 (7.630s)
+  Step  28: 23 / Turtle x2 (7.432s)
+  Step  30: 24 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:   3   Index: 162
+  Step  18: 25 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  20: 26 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:   3   Index: 246
+  Optional Steps: 10
+  Extra Steps: 8
+Overworld (Fabul)                                                             Seed:  20   Index:  68
+Fabul Boat and Leviatan                                                       Seed:  20   Index:  75
+Overworld (Mysidia)                                                           Seed:  20   Index:  75
+Mysidia                                                                       Seed:  20   Index:  84
+Overworld (Mysidia)                                                           Seed:  20   Index:  84
+  Step   9: 27 / Imp Cap. x3, Needler x1 (7.932s)
+Overworld (Mt.Ordeals)                                                        Seed:  20   Index:  94
+  Step  64: 28 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  20   Index: 188
+  Step  34: 29 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  36: 30 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  20   Index: 231
+  Step  20: 31 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  20   Index: 254
+Mt.Ordeals-3rd station                                                        Seed:  20   Index: 254
+Mt.Ordeals-7th station                                                        Seed:  37   Index:   3
+  Step  28: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  37   Index:  45
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  37   Index:  63
+Mt.Ordeals Summit                                                             Seed:  37   Index:  63
+Paladin                                                                       Seed:  37   Index:  67
+Mt.Ordeals Summit                                                             Seed:  37   Index:  67
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  37   Index:  90
+  Step   4: 33 / Revenant x1, Ghoul x3 (8.489s)
+  Step  31: 34 / Revenant x1, Ghoul x3 (8.489s)
+  Step  33: 35 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  37   Index: 132
+  Step   9: 36 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:  37   Index: 162
+  Step  26: 37 / Soul x2, Red Bone x2 (8.881s)
+Overworld (Mt.Ordeals)                                                        Seed:  37   Index: 206
+Take Chocobo to Mysidia                                                       Seed:  37   Index: 219
+Overworld (Mysidia)                                                           Seed:  37   Index: 219
+Town of Baron Serpent Road                                                    Seed:  37   Index: 219
+  Extra Steps: 16
+Credit Warp Fight Search                                                      Seed:  37   Index: 239
+  Overworld (Baron)                                                           Seed:  37   Index: 239
+    Extra Steps: 32
+    Step   2: 38 / Imp x3, SwordRat x1 (7.227s)
+    Step  32: 39 / Imp x4 (7.223s)
+   (Step  70: 40 / FloatEye x2)
+   (Step  71: 41 / Imp x4)
+   (Step 106: 42 / Imp x3, SwordRat x1)
+   (Step 160: 43 / Imp x3, SwordRat x1)
+   (Step 184: 44 / FloatEye x1, Eagle x2)
+
+Encounter Time:      300.980s
+Other Time:          527.564s
+Total Time:          828.545s
+
+Base Total Time:     1046.100s
+Time Saved:          217.555s
+
+Optional Steps:      12
+Extra Steps:         126
+Encounters:          39
+
+Base Encounters:     53
+Encounters Saved:    14
+
+Number of Variables: 54

--- a/data/routes/cw/209.txt
+++ b/data/routes/cw/209.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	209
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50246200
+VARS	FFFFFFFF:2 C307801:1 E302500:71 E302600:10 E307400:70 E307B01:2 E308401:6 E308501:6 E308700:1 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed: 209   Index:   0
+Overworld (Kaipo)                                                             Seed: 209   Index:   1
+Kaipo                                                                         Seed: 209   Index:  37
+Overworld (Kaipo)                                                             Seed: 209   Index:  37
+  Step   1: 1 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 209   Index:  69
+  Step   1: 2 / CaveToad x3 (6.825s)
+  Step  15: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 209   Index: 101
+Watery Pass-South B1F                                                         Seed: 209   Index: 101
+Watery Pass-South B2F                                                         Seed: 209   Index: 121
+  Step  13: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  18: 5 / Zombie x4 (7.148s)
+  Step  86: 6 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed: 209   Index: 211
+Watery Pass-South B2F                                                         Seed: 209   Index: 215
+  Step  27: 7 / Pike x3 (7.152s)
+  Step  29: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B3F                                                         Seed: 209   Index: 254
+  Step   5: 9 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed: 226   Index:  32
+Watery Pass-North B1F                                                         Seed: 226   Index:  53
+  Step   2: 10 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  47: 11 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 226   Index: 113
+Waterfalls B1F                                                                Seed: 226   Index: 122
+  Extra Steps: 70
+Waterfalls B2F                                                                Seed: 226   Index: 193
+  Step  35: 12 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 226   Index: 238
+Battle: Octomamm                                                              Seed: 243   Index:  19
+Waterfalls Lake                                                               Seed: 243   Index:  19
+Overworld (Kaipo)                                                             Seed: 243   Index:  20
+Overworld (Damcyan)                                                           Seed: 243   Index:  31
+Damcyan                                                                       Seed: 243   Index:  35
+  Optional Steps: 1
+  Extra Steps: 70
+Overworld (Damcyan)                                                           Seed: 243   Index: 113
+Antlion B1F                                                                   Seed: 243   Index: 113
+Antlion B2F Inward Direct                                                     Seed: 243   Index: 151
+  Antlion B2F                                                                 Seed: 243   Index: 151
+    Step  11: 13 / Basilisk x1, Imp x3 (6.775s)
+    Step  28: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  43: 15 / Cream x4 (7.552s)
+    Step  59: 16 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed: 243   Index: 231
+Battle: Antlion                                                               Seed: 243   Index: 245
+Antlion's Nest                                                                Seed: 243   Index: 245
+Antlion B2F Outward Charm Room Steps                                          Seed:   4   Index:   4
+  Antlion B2F                                                                 Seed:   4   Index:   4
+  Antlion B2F Treasure Room                                                   Seed:   4   Index:  55
+    Extra Steps: 2
+  Antlion B2F                                                                 Seed:   4   Index:  57
+    Step  24: 17 / Cream x4 (7.523s)
+    Step  30: 18 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:   4   Index:  91
+  Step  29: 19 / Turtle x2 (7.464s)
+Overworld (Damcyan)                                                           Seed:   4   Index: 129
+Overworld (Kaipo)                                                             Seed:   4   Index: 129
+Kaipo Revisited                                                               Seed:   4   Index: 129
+Overworld (Kaipo)                                                             Seed:   4   Index: 129
+Overworld (Damcyan)                                                           Seed:   4   Index: 129
+Mt.Hobs-West                                                                  Seed:   4   Index: 129
+  Step   1: 20 / Gargoyle x2 (8.791s)
+  Step  15: 21 / Spirit x2 (8.028s)
+  Step  17: 22 / GrayBomb x2, Bomb x2 (10.938s)
+Mt.Hobs Summit                                                                Seed:   4   Index: 168
+  Step  14: 23 / Spirit x2, Skelton x2 (9.087s)
+Battle: MomBomb                                                               Seed:   4   Index: 183
+Mt.Hobs Summit                                                                Seed:   4   Index: 183
+Mt.Hobs-East                                                                  Seed:   4   Index: 189
+Overworld (Fabul)                                                             Seed:   4   Index: 235
+  Step  23: 24 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  50: 25 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed:  21   Index:  63
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  21   Index: 133
+Fabul Boat and Leviatan                                                       Seed:  21   Index: 140
+Overworld (Mysidia)                                                           Seed:  21   Index: 140
+Mysidia                                                                       Seed:  21   Index: 149
+Overworld (Mysidia)                                                           Seed:  21   Index: 149
+Overworld (Mt.Ordeals)                                                        Seed:  21   Index: 159
+  Step  63: 26 / Raven x1 (8.356s)
+  Step  65: 27 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  92: 28 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  21   Index: 253
+  Step  34: 29 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:  38   Index:  40
+Recruit Tellah                                                                Seed:  38   Index:  63
+Mt.Ordeals-3rd station                                                        Seed:  38   Index:  63
+  Extra Steps: 6
+  Step  10: 30 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed:  38   Index:  74
+  Step  20: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  38   Index: 116
+  Optional Steps: 1
+  Step   5: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step   7: 33 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:  38   Index: 134
+Mt.Ordeals Summit                                                             Seed:  38   Index: 134
+Paladin                                                                       Seed:  38   Index: 138
+Mt.Ordeals Summit                                                             Seed:  38   Index: 138
+  Optional Steps: 1
+  Step   3: 34 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed:  38   Index: 161
+Mt.Ordeals-3rd station                                                        Seed:  38   Index: 203
+  Step  17: 35 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed:  38   Index: 233
+  Extra Steps: 6
+  Step   8: 36 / Spirit x3, Soul x1 (8.429s)
+  Step  38: 37 / Soul x2, Red Bone x2 (8.881s)
+Overworld (Mt.Ordeals)                                                        Seed:  55   Index:  27
+Take Chocobo to Mysidia                                                       Seed:  55   Index:  40
+Overworld (Mysidia)                                                           Seed:  55   Index:  40
+Town of Baron Serpent Road                                                    Seed:  55   Index:  40
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed:  55   Index:  52
+  Overworld (Baron)                                                           Seed:  55   Index:  52
+    Extra Steps: 2
+    Step   1: 38 / Imp x3, SwordRat x1 (7.227s)
+    Step   2: 39 / Imp x4 (7.223s)
+   (Step  37: 40 / FloatEye x2)
+   (Step  47: 41 / Imp x4)
+   (Step  91: 42 / Imp x3, SwordRat x1)
+   (Step 115: 43 / Imp x3, SwordRat x1)
+   (Step 247: 44 / FloatEye x1, Eagle x2)
+
+Encounter Time:      306.365s
+Other Time:          529.694s
+Total Time:          836.060s
+
+Base Total Time:     1034.245s
+Time Saved:          198.186s
+
+Optional Steps:      13
+Extra Steps:         164
+Encounters:          39
+
+Base Encounters:     53
+Encounters Saved:    14
+
+Number of Variables: 54

--- a/data/routes/cw/210.txt
+++ b/data/routes/cw/210.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	210
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49689679
+VARS	FFFFFFFF:2 C307800:1 E302500:23 E302600:2 E305400:30 E307400:40 E307700:24 E307B00:50 E308700:1 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed: 210   Index:   0
+Overworld (Kaipo)                                                             Seed: 210   Index:   1
+Kaipo                                                                         Seed: 210   Index:  37
+Overworld (Kaipo)                                                             Seed: 210   Index:  37
+Watery Pass-South B1F                                                         Seed: 210   Index:  69
+  Step  15: 1 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 210   Index: 101
+Watery Pass-South B1F                                                         Seed: 210   Index: 101
+Watery Pass-South B2F                                                         Seed: 210   Index: 121
+  Step  13: 2 / CaveToad x3 (7.014s)
+  Step  18: 3 / Pike x2, EvilShel x2 (7.149s)
+  Step  79: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  86: 5 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed: 210   Index: 211
+  Extra Steps: 30
+Watery Pass-South B2F                                                         Seed: 210   Index: 245
+  Step  14: 6 / Zombie x4 (7.148s)
+Watery Pass-South B3F                                                         Seed: 227   Index:  28
+  Step  27: 7 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed: 227   Index:  62
+Watery Pass-North B1F                                                         Seed: 227   Index:  83
+  Step  17: 8 / CaveToad x4 (7.163s)
+  Step  49: 9 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 227   Index: 143
+Waterfalls B1F                                                                Seed: 227   Index: 152
+  Extra Steps: 40
+Waterfalls B2F                                                                Seed: 227   Index: 193
+  Step  35: 10 / Mad Toad x4 (7.317s)
+Waterfalls Lake                                                               Seed: 227   Index: 238
+Battle: Octomamm                                                              Seed: 244   Index:  19
+Waterfalls Lake                                                               Seed: 244   Index:  19
+Overworld (Kaipo)                                                             Seed: 244   Index:  20
+Overworld (Damcyan)                                                           Seed: 244   Index:  31
+Damcyan                                                                       Seed: 244   Index:  35
+  Optional Steps: 1
+  Extra Steps: 22
+Overworld (Damcyan)                                                           Seed: 244   Index:  65
+Antlion B1F                                                                   Seed: 244   Index:  65
+  Extra Steps: 24
+  Step  48: 11 / Turtle x1, Imp x2 (7.044s)
+  Step  61: 12 / Imp x3 (6.649s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 244   Index: 127
+  Antlion B2F                                                                 Seed: 244   Index: 127
+  Antlion B2F Treasure Room                                                   Seed: 244   Index: 160
+    Extra Steps: 50
+  Antlion B2F                                                                 Seed: 244   Index: 210
+Antlion's Nest                                                                Seed:   5   Index:   6
+Battle: Antlion                                                               Seed:   5   Index:  20
+Antlion's Nest                                                                Seed:   5   Index:  20
+Antlion B2F Outward Direct                                                    Seed:   5   Index:  35
+  Antlion B2F                                                                 Seed:   5   Index:  35
+    Step  21: 13 / Basilisk x1, Imp x3 (6.783s)
+    Step  46: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  52: 15 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed:   5   Index: 115
+  Step  15: 16 / Turtle x1, Imp x2 (7.009s)
+  Step  29: 17 / Imp x3 (6.648s)
+  Step  31: 18 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:   5   Index: 153
+Overworld (Kaipo)                                                             Seed:   5   Index: 153
+Kaipo Revisited                                                               Seed:   5   Index: 153
+Overworld (Kaipo)                                                             Seed:   5   Index: 153
+Overworld (Damcyan)                                                           Seed:   5   Index: 153
+Mt.Hobs-West                                                                  Seed:   5   Index: 153
+  Step   6: 19 / Gargoyle x2 (8.791s)
+  Step  29: 20 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed:   5   Index: 192
+Battle: MomBomb                                                               Seed:   5   Index: 207
+Mt.Hobs Summit                                                                Seed:   5   Index: 207
+Mt.Hobs-East                                                                  Seed:   5   Index: 213
+  Step  45: 21 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  22   Index:   3
+  Step  26: 22 / SwordRat x3, Needler x3 (7.663s)
+  Step  64: 23 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed:  22   Index:  87
+  Optional Steps: 2
+Overworld (Fabul)                                                             Seed:  22   Index: 149
+Fabul Boat and Leviatan                                                       Seed:  22   Index: 156
+Overworld (Mysidia)                                                           Seed:  22   Index: 156
+Mysidia                                                                       Seed:  22   Index: 165
+Overworld (Mysidia)                                                           Seed:  22   Index: 165
+Overworld (Mt.Ordeals)                                                        Seed:  22   Index: 175
+  Step  31: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  47: 25 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  49: 26 / Raven x1 (8.356s)
+  Step  76: 27 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  39   Index:  13
+  Step  18: 28 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:  39   Index:  56
+  Step  17: 29 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  39   Index:  79
+Mt.Ordeals-3rd station                                                        Seed:  39   Index:  79
+Mt.Ordeals-7th station                                                        Seed:  39   Index:  84
+  Step  10: 30 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  37: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  39: 32 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  39   Index: 126
+  Optional Steps: 1
+  Step  15: 33 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:  39   Index: 144
+Mt.Ordeals Summit                                                             Seed:  39   Index: 144
+Paladin                                                                       Seed:  39   Index: 148
+Mt.Ordeals Summit                                                             Seed:  39   Index: 148
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  39   Index: 171
+  Step  32: 34 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed:  39   Index: 213
+  Step  28: 35 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed:  39   Index: 243
+  Step  28: 36 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  56   Index:  31
+Take Chocobo to Mysidia                                                       Seed:  56   Index:  44
+Overworld (Mysidia)                                                           Seed:  56   Index:  44
+Town of Baron Serpent Road                                                    Seed:  56   Index:  44
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed:  56   Index:  52
+  Overworld (Baron)                                                           Seed:  56   Index:  52
+    Extra Steps: 2
+    Step   1: 37 / Eagle x3 (7.417s)
+    Step   2: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  37: 39 / Imp x4)
+   (Step  47: 40 / FloatEye x2)
+   (Step  91: 41 / Imp x4)
+   (Step 197: 42 / Imp x3, SwordRat x1)
+
+Encounter Time:      294.976s
+Other Time:          531.824s
+Total Time:          826.800s
+
+Base Total Time:     1093.191s
+Time Saved:          266.392s
+
+Optional Steps:      5
+Extra Steps:         172
+Encounters:          38
+
+Base Encounters:     53
+Encounters Saved:    15
+
+Number of Variables: 54

--- a/data/routes/cw/211.txt
+++ b/data/routes/cw/211.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	211
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49487450
+VARS	FFFFFFFF:10 E000202:6 E302500:23 E302600:12 E307200:2 E307400:68 E307701:8 E307E00:3 E308401:6 E308700:1 E308702:1 E309700:12
+
+Overworld (Kaipo)                                                             Seed: 211   Index:   0
+Overworld (Kaipo)                                                             Seed: 211   Index:   1
+  Step  21: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 211   Index:  37
+Overworld (Kaipo)                                                             Seed: 211   Index:  37
+Watery Pass-South B1F                                                         Seed: 211   Index:  69
+  Step  15: 2 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed: 211   Index: 101
+Watery Pass-South B1F                                                         Seed: 211   Index: 101
+Watery Pass-South B2F                                                         Seed: 211   Index: 121
+  Step  13: 3 / Pike x2, EvilShel x2 (7.149s)
+  Step  18: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  79: 5 / Zombie x4 (7.148s)
+  Step  86: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 211   Index: 211
+Watery Pass-South B2F                                                         Seed: 211   Index: 215
+  Step  27: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 211   Index: 254
+  Step   5: 8 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 228   Index:  32
+  Extra Steps: 2
+  Step  23: 9 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed: 228   Index:  55
+Overworld (Kaipo)                                                             Seed: 228   Index: 115
+Waterfalls B1F                                                                Seed: 228   Index: 124
+  Extra Steps: 68
+Waterfalls B2F                                                                Seed: 228   Index: 193
+  Step  35: 10 / Mad Toad x4 (7.317s)
+Waterfalls Lake                                                               Seed: 228   Index: 238
+Battle: Octomamm                                                              Seed: 245   Index:  19
+Waterfalls Lake                                                               Seed: 245   Index:  19
+Overworld (Kaipo)                                                             Seed: 245   Index:  20
+Overworld (Damcyan)                                                           Seed: 245   Index:  31
+Damcyan                                                                       Seed: 245   Index:  35
+  Optional Steps: 1
+  Extra Steps: 22
+Overworld (Damcyan)                                                           Seed: 245   Index:  65
+Antlion B1F                                                                   Seed: 245   Index:  65
+Antlion B2F Inward Direct                                                     Seed: 245   Index: 103
+  Antlion B2F                                                                 Seed: 245   Index: 103
+    Step  23: 11 / Turtle x2 (7.487s)
+    Step  26: 12 / Cream x4 (7.552s)
+    Step  59: 13 / Basilisk x1, Imp x3 (6.775s)
+    Step  76: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 245   Index: 183
+  Step  11: 15 / Cream x4 (7.552s)
+Battle: Antlion                                                               Seed: 245   Index: 197
+Antlion's Nest                                                                Seed: 245   Index: 197
+  Step  13: 16 / Turtle x2 (7.464s)
+Antlion B2F Outward Direct                                                    Seed: 245   Index: 212
+  Antlion B2F                                                                 Seed: 245   Index: 212
+Antlion B1F                                                                   Seed:   6   Index:  36
+  Extra Steps: 8
+  Step  20: 17 / Imp x3 (6.648s)
+  Step  45: 18 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:   6   Index:  82
+Overworld (Kaipo)                                                             Seed:   6   Index:  82
+  Extra Steps: 6
+  Step   5: 19 / SandMoth x2, Larva x2 (7.135s)
+Kaipo Revisited                                                               Seed:   6   Index:  88
+Overworld (Kaipo)                                                             Seed:   6   Index:  88
+Overworld (Damcyan)                                                           Seed:   6   Index:  88
+Mt.Hobs-West                                                                  Seed:   6   Index:  88
+  Extra Steps: 3
+  Step  42: 20 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed:   6   Index: 130
+Battle: MomBomb                                                               Seed:   6   Index: 145
+Mt.Hobs Summit                                                                Seed:   6   Index: 145
+  Step   1: 21 / Spirit x2 (7.652s)
+Mt.Hobs-East                                                                  Seed:   6   Index: 151
+  Step   8: 22 / Gargoyle x2 (7.630s)
+  Step  31: 23 / Turtle x2 (7.432s)
+  Step  32: 24 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:   6   Index: 197
+  Step  61: 25 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed:  23   Index:  25
+  Optional Steps: 10
+  Extra Steps: 2
+Overworld (Fabul)                                                             Seed:  23   Index:  97
+Fabul Boat and Leviatan                                                       Seed:  23   Index: 104
+Overworld (Mysidia)                                                           Seed:  23   Index: 104
+Mysidia                                                                       Seed:  23   Index: 113
+Overworld (Mysidia)                                                           Seed:  23   Index: 113
+Overworld (Mt.Ordeals)                                                        Seed:  23   Index: 123
+  Step  83: 26 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  23   Index: 217
+  Step   7: 27 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  22: 28 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  34: 29 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:  40   Index:   4
+Recruit Tellah                                                                Seed:  40   Index:  27
+Mt.Ordeals-3rd station                                                        Seed:  40   Index:  27
+  Step   4: 30 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed:  40   Index:  32
+  Step  41: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  40   Index:  74
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  40   Index:  92
+Mt.Ordeals Summit                                                             Seed:  40   Index:  92
+  Step   2: 32 / Soul x2, Ghoul x2, Revenant x2 (10.046s)
+Paladin                                                                       Seed:  40   Index:  96
+Mt.Ordeals Summit                                                             Seed:  40   Index:  96
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  40   Index: 119
+  Step   2: 33 / Revenant x1, Ghoul x3 (8.489s)
+  Step   4: 34 / Revenant x1, Ghoul x3 (8.489s)
+  Step   6: 35 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  40   Index: 161
+Mt.Ordeals                                                                    Seed:  40   Index: 191
+  Extra Steps: 6
+  Step  12: 36 / Spirit x3, Soul x1 (8.429s)
+  Step  50: 37 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  40   Index: 241
+Take Chocobo to Mysidia                                                       Seed:  40   Index: 254
+Overworld (Mysidia)                                                           Seed:  40   Index: 254
+Town of Baron Serpent Road                                                    Seed:  40   Index: 254
+  Extra Steps: 12
+Credit Warp Fight Search                                                      Seed:  57   Index:  14
+  Overworld (Baron)                                                           Seed:  57   Index:  14
+    Extra Steps: 10
+    Step   1: 38 / Imp x3, SwordRat x1 (7.227s)
+    Step  10: 39 / Imp x4 (7.223s)
+   (Step  39: 40 / FloatEye x2)
+   (Step  75: 41 / Imp x3, SwordRat x1)
+   (Step  85: 42 / Imp x3, SwordRat x1)
+   (Step 129: 43 / Imp x6)
+   (Step 235: 44 / FloatEye x1, Eagle x2)
+   (Step 243: 45 / Imp x3)
+
+Encounter Time:      302.592s
+Other Time:          520.842s
+Total Time:          823.435s
+
+Base Total Time:     1096.508s
+Time Saved:          273.074s
+
+Optional Steps:      13
+Extra Steps:         139
+Encounters:          39
+
+Base Encounters:     53
+Encounters Saved:    14
+
+Number of Variables: 54

--- a/data/routes/cw/212.txt
+++ b/data/routes/cw/212.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	212
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49878473
+VARS	FFFFFFFF:10 C307801:1 E000300:2 E000500:4 E302500:150 E302600:80 E307200:2 E307400:68 E307B01:48 E308700:1 E308702:1 E309700:14
+
+Overworld (Kaipo)                                                             Seed: 212   Index:   0
+Overworld (Kaipo)                                                             Seed: 212   Index:   1
+  Step  21: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 212   Index:  37
+Overworld (Kaipo)                                                             Seed: 212   Index:  37
+Watery Pass-South B1F                                                         Seed: 212   Index:  69
+  Step  15: 2 / CaveToad x3 (6.825s)
+  Step  32: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 212   Index: 101
+Watery Pass-South B1F                                                         Seed: 212   Index: 101
+Watery Pass-South B2F                                                         Seed: 212   Index: 121
+  Step  18: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  79: 5 / Zombie x4 (7.148s)
+  Step  86: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 212   Index: 211
+Watery Pass-South B2F                                                         Seed: 212   Index: 215
+  Step  27: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 212   Index: 254
+  Step   5: 8 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 229   Index:  32
+  Extra Steps: 2
+  Step  23: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 229   Index:  55
+Overworld (Kaipo)                                                             Seed: 229   Index: 115
+Waterfalls B1F                                                                Seed: 229   Index: 124
+  Extra Steps: 68
+Waterfalls B2F                                                                Seed: 229   Index: 193
+  Step  35: 10 / Mad Toad x4 (7.317s)
+Waterfalls Lake                                                               Seed: 229   Index: 238
+Battle: Octomamm                                                              Seed: 246   Index:  19
+Waterfalls Lake                                                               Seed: 246   Index:  19
+Overworld (Kaipo)                                                             Seed: 246   Index:  20
+Overworld (Damcyan)                                                           Seed: 246   Index:  31
+  Extra Steps: 2
+Damcyan                                                                       Seed: 246   Index:  37
+  Optional Steps: 0
+  Extra Steps: 150
+Overworld (Damcyan)                                                           Seed: 246   Index: 194
+Antlion B1F                                                                   Seed: 246   Index: 194
+  Step  16: 11 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed: 246   Index: 232
+  Antlion B2F                                                                 Seed: 246   Index: 232
+    Step  80: 12 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed:   7   Index:  56
+Battle: Antlion                                                               Seed:   7   Index:  70
+Antlion's Nest                                                                Seed:   7   Index:  70
+  Step  11: 13 / Basilisk x1, Imp x3 (6.783s)
+Antlion B2F Outward Charm Room Steps                                          Seed:   7   Index:  85
+  Antlion B2F                                                                 Seed:   7   Index:  85
+    Step   2: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Antlion B2F Treasure Room                                                   Seed:   7   Index: 136
+    Extra Steps: 48
+  Antlion B2F                                                                 Seed:   7   Index: 184
+Antlion B1F                                                                   Seed:   7   Index: 218
+  Step   5: 15 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  24   Index:   0
+Overworld (Kaipo)                                                             Seed:  24   Index:   0
+Kaipo Revisited                                                               Seed:  24   Index:   0
+Overworld (Kaipo)                                                             Seed:  24   Index:   0
+Overworld (Damcyan)                                                           Seed:  24   Index:   0
+Mt.Hobs-West                                                                  Seed:  24   Index:   0
+Mt.Hobs Summit                                                                Seed:  24   Index:  39
+Battle: MomBomb                                                               Seed:  24   Index:  54
+Mt.Hobs Summit                                                                Seed:  24   Index:  54
+Mt.Hobs-East                                                                  Seed:  24   Index:  60
+  Step   7: 16 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  33: 17 / Spirit x2, Skelton x2 (8.237s)
+  Step  36: 18 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  24   Index: 106
+Fabul                                                                         Seed:  24   Index: 190
+  Optional Steps: 10
+  Extra Steps: 70
+Overworld (Fabul)                                                             Seed:  41   Index:  74
+Fabul Boat and Leviatan                                                       Seed:  41   Index:  81
+Overworld (Mysidia)                                                           Seed:  41   Index:  81
+  Extra Steps: 4
+  Step  13: 19 / Needler x2, SwordRat x2 (8.011s)
+Mysidia                                                                       Seed:  41   Index:  94
+Overworld (Mysidia)                                                           Seed:  41   Index:  94
+Overworld (Mt.Ordeals)                                                        Seed:  41   Index: 104
+  Step  17: 20 / Needler x2, SwordRat x2 (8.097s)
+  Step  19: 21 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  21: 22 / Raven x1, Cocktric x3 (9.100s)
+  Step  37: 23 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed:  41   Index: 198
+  Step   5: 24 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  41   Index: 241
+Recruit Tellah                                                                Seed:  58   Index:   8
+Mt.Ordeals-3rd station                                                        Seed:  58   Index:   8
+Mt.Ordeals-7th station                                                        Seed:  58   Index:  13
+  Step   2: 25 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  11: 26 / Ghoul x2, Soul x2 (9.197s)
+  Step  40: 27 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  58   Index:  55
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  58   Index:  73
+Mt.Ordeals Summit                                                             Seed:  58   Index:  73
+Paladin                                                                       Seed:  58   Index:  77
+Mt.Ordeals Summit                                                             Seed:  58   Index:  77
+  Optional Steps: 1
+  Step  12: 28 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  22: 29 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed:  58   Index: 100
+Mt.Ordeals-3rd station                                                        Seed:  58   Index: 142
+  Step   1: 30 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:  58   Index: 172
+Overworld (Mt.Ordeals)                                                        Seed:  58   Index: 216
+Take Chocobo to Mysidia                                                       Seed:  58   Index: 229
+Overworld (Mysidia)                                                           Seed:  58   Index: 229
+Town of Baron Serpent Road                                                    Seed:  58   Index: 229
+  Extra Steps: 14
+Credit Warp Fight Search                                                      Seed:  58   Index: 247
+  Overworld (Baron)                                                           Seed:  58   Index: 247
+    Extra Steps: 10
+    Step   2: 31 / FloatEye x1, Eagle x2 (7.365s)
+    Step  10: 32 / Imp x3, SwordRat x1 (7.227s)
+   (Step  57: 33 / FloatEye x2)
+   (Step  81: 34 / FloatEye x2)
+   (Step  86: 35 / Eagle x3)
+   (Step 136: 36 / Imp x3, SwordRat x1)
+   (Step 240: 37 / Imp x4)
+   (Step 256: 38 / Eagle x3)
+
+Encounter Time:      243.806s
+Other Time:          586.135s
+Total Time:          829.941s
+
+Base Total Time:     1095.868s
+Time Saved:          265.927s
+
+Optional Steps:      12
+Extra Steps:         368
+Encounters:          32
+
+Base Encounters:     53
+Encounters Saved:    21
+
+Number of Variables: 54

--- a/data/routes/cw/213.txt
+++ b/data/routes/cw/213.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	213
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49773125
+VARS	FFFFFFFF:10 C307800:1 E302600:9 E307200:2 E307400:68 E307B00:48 E308700:1 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed: 213   Index:   0
+Overworld (Kaipo)                                                             Seed: 213   Index:   1
+  Step  21: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 213   Index:  37
+Overworld (Kaipo)                                                             Seed: 213   Index:  37
+Watery Pass-South B1F                                                         Seed: 213   Index:  69
+  Step  15: 2 / CaveToad x3 (6.825s)
+  Step  32: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 213   Index: 101
+Watery Pass-South B1F                                                         Seed: 213   Index: 101
+Watery Pass-South B2F                                                         Seed: 213   Index: 121
+  Step  12: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  18: 5 / Zombie x4 (7.148s)
+  Step  79: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  86: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 213   Index: 211
+Watery Pass-South B2F                                                         Seed: 213   Index: 215
+Watery Pass-South B3F                                                         Seed: 213   Index: 254
+  Step   5: 8 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 230   Index:  32
+  Extra Steps: 2
+  Step  23: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 230   Index:  55
+Overworld (Kaipo)                                                             Seed: 230   Index: 115
+Waterfalls B1F                                                                Seed: 230   Index: 124
+  Extra Steps: 68
+Waterfalls B2F                                                                Seed: 230   Index: 193
+  Step  35: 10 / Mad Toad x4 (7.317s)
+Waterfalls Lake                                                               Seed: 230   Index: 238
+Battle: Octomamm                                                              Seed: 247   Index:  19
+Waterfalls Lake                                                               Seed: 247   Index:  19
+Overworld (Kaipo)                                                             Seed: 247   Index:  20
+Overworld (Damcyan)                                                           Seed: 247   Index:  31
+Damcyan                                                                       Seed: 247   Index:  35
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 247   Index:  42
+Antlion B1F                                                                   Seed: 247   Index:  42
+  Step  15: 11 / Turtle x1, Imp x2 (7.044s)
+  Step  23: 12 / Imp x3 (6.649s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 247   Index:  80
+  Antlion B2F                                                                 Seed: 247   Index:  80
+  Antlion B2F Treasure Room                                                   Seed: 247   Index: 113
+    Extra Steps: 48
+  Antlion B2F                                                                 Seed: 247   Index: 161
+    Step  18: 13 / Basilisk x1, Imp x3 (6.775s)
+    Step  32: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  49: 15 / Cream x4 (7.552s)
+Antlion's Nest                                                                Seed: 247   Index: 213
+Battle: Antlion                                                               Seed: 247   Index: 227
+Antlion's Nest                                                                Seed: 247   Index: 227
+Antlion B2F Outward Direct                                                    Seed: 247   Index: 242
+  Antlion B2F                                                                 Seed: 247   Index: 242
+    Step  70: 16 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:   8   Index:  66
+  Step  15: 17 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:   8   Index: 104
+Overworld (Kaipo)                                                             Seed:   8   Index: 104
+Kaipo Revisited                                                               Seed:   8   Index: 104
+Overworld (Kaipo)                                                             Seed:   8   Index: 104
+Overworld (Damcyan)                                                           Seed:   8   Index: 104
+Mt.Hobs-West                                                                  Seed:   8   Index: 104
+Mt.Hobs Summit                                                                Seed:   8   Index: 143
+  Step   3: 18 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:   8   Index: 158
+Mt.Hobs Summit                                                                Seed:   8   Index: 158
+  Step   1: 19 / Gargoyle x2 (7.630s)
+Mt.Hobs-East                                                                  Seed:   8   Index: 164
+  Step  18: 20 / Turtle x2 (7.432s)
+  Step  19: 21 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:   8   Index: 210
+  Step  13: 22 / SwordRat x3, Needler x3 (7.663s)
+  Step  45: 23 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  48: 24 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed:  25   Index:  38
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed:  25   Index: 107
+Fabul Boat and Leviatan                                                       Seed:  25   Index: 114
+Overworld (Mysidia)                                                           Seed:  25   Index: 114
+Mysidia                                                                       Seed:  25   Index: 123
+Overworld (Mysidia)                                                           Seed:  25   Index: 123
+Overworld (Mt.Ordeals)                                                        Seed:  25   Index: 133
+  Step  73: 25 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  91: 26 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  25   Index: 227
+  Step  12: 27 / Spirit x3, Soul x1 (8.687s)
+  Step  24: 28 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  26: 29 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:  42   Index:  14
+  Step  12: 30 / Ghoul x2, Soul x2 (9.357s)
+  Step  17: 31 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  42   Index:  37
+Mt.Ordeals-3rd station                                                        Seed:  42   Index:  37
+Mt.Ordeals-7th station                                                        Seed:  42   Index:  42
+  Step  31: 32 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  42   Index:  84
+  Optional Steps: 1
+  Step  10: 33 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:  42   Index: 102
+Mt.Ordeals Summit                                                             Seed:  42   Index: 102
+Paladin                                                                       Seed:  42   Index: 106
+Mt.Ordeals Summit                                                             Seed:  42   Index: 106
+  Optional Steps: 1
+  Step  17: 34 / Revenant x1, Ghoul x3 (8.489s)
+  Step  19: 35 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed:  42   Index: 129
+Mt.Ordeals-3rd station                                                        Seed:  42   Index: 171
+Mt.Ordeals                                                                    Seed:  42   Index: 201
+  Step   2: 36 / Spirit x3, Soul x1 (8.429s)
+  Step  35: 37 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  42   Index: 245
+Take Chocobo to Mysidia                                                       Seed:  59   Index:   2
+Overworld (Mysidia)                                                           Seed:  59   Index:   2
+Town of Baron Serpent Road                                                    Seed:  59   Index:   2
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed:  59   Index:  14
+  Overworld (Baron)                                                           Seed:  59   Index:  14
+    Extra Steps: 10
+    Step   1: 38 / Eagle x3 (7.417s)
+    Step  10: 39 / Imp x4 (7.223s)
+   (Step  39: 40 / FloatEye x2)
+   (Step  85: 41 / Imp x3, SwordRat x1)
+   (Step 110: 42 / Imp x3, SwordRat x1)
+   (Step 218: 43 / Imp x3)
+   (Step 235: 44 / FloatEye x1, Eagle x2)
+   (Step 243: 45 / Imp x3)
+
+Encounter Time:      303.818s
+Other Time:          524.370s
+Total Time:          828.188s
+
+Base Total Time:     1089.351s
+Time Saved:          261.163s
+
+Optional Steps:      11
+Extra Steps:         136
+Encounters:          39
+
+Base Encounters:     53
+Encounters Saved:    14
+
+Number of Variables: 54

--- a/data/routes/cw/214.txt
+++ b/data/routes/cw/214.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	214
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49171905
+VARS	FFFFFFFF:30 E302500:23 E302600:20 E307400:70 E307701:8 E308700:1 E308702:1 E309700:28
+
+Overworld (Kaipo)                                                             Seed: 214   Index:   0
+Overworld (Kaipo)                                                             Seed: 214   Index:   1
+  Step  21: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 214   Index:  37
+Overworld (Kaipo)                                                             Seed: 214   Index:  37
+Watery Pass-South B1F                                                         Seed: 214   Index:  69
+  Step  15: 2 / CaveToad x3 (6.825s)
+  Step  32: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 214   Index: 101
+Watery Pass-South B1F                                                         Seed: 214   Index: 101
+Watery Pass-South B2F                                                         Seed: 214   Index: 121
+  Step  12: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  18: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  79: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  80: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 214   Index: 211
+Watery Pass-South B2F                                                         Seed: 214   Index: 215
+Watery Pass-South B3F                                                         Seed: 214   Index: 254
+  Step   5: 8 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 231   Index:  32
+Watery Pass-North B1F                                                         Seed: 231   Index:  53
+Overworld (Kaipo)                                                             Seed: 231   Index: 113
+Waterfalls B1F                                                                Seed: 231   Index: 122
+  Extra Steps: 70
+Waterfalls B2F                                                                Seed: 231   Index: 193
+  Step  35: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 231   Index: 238
+Battle: Octomamm                                                              Seed: 248   Index:  19
+Waterfalls Lake                                                               Seed: 248   Index:  19
+Overworld (Kaipo)                                                             Seed: 248   Index:  20
+Overworld (Damcyan)                                                           Seed: 248   Index:  31
+Damcyan                                                                       Seed: 248   Index:  35
+  Optional Steps: 1
+  Extra Steps: 22
+Overworld (Damcyan)                                                           Seed: 248   Index:  65
+Antlion B1F                                                                   Seed: 248   Index:  65
+Antlion B2F Inward Direct                                                     Seed: 248   Index: 103
+  Antlion B2F                                                                 Seed: 248   Index: 103
+    Step  23: 10 / SandWorm x2 (6.841s)
+    Step  26: 11 / Turtle x2 (7.487s)
+    Step  58: 12 / Cream x4 (7.552s)
+    Step  76: 13 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 248   Index: 183
+  Step  10: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 248   Index: 197
+Antlion's Nest                                                                Seed: 248   Index: 197
+Antlion B2F Outward Direct                                                    Seed: 248   Index: 212
+  Antlion B2F                                                                 Seed: 248   Index: 212
+    Step  13: 15 / Cream x4 (7.523s)
+    Step  79: 16 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:   9   Index:  36
+  Extra Steps: 8
+  Step  45: 17 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:   9   Index:  82
+Overworld (Kaipo)                                                             Seed:   9   Index:  82
+Kaipo Revisited                                                               Seed:   9   Index:  82
+Overworld (Kaipo)                                                             Seed:   9   Index:  82
+Overworld (Damcyan)                                                           Seed:   9   Index:  82
+Mt.Hobs-West                                                                  Seed:   9   Index:  82
+Mt.Hobs Summit                                                                Seed:   9   Index: 121
+Battle: MomBomb                                                               Seed:   9   Index: 136
+Mt.Hobs Summit                                                                Seed:   9   Index: 136
+Mt.Hobs-East                                                                  Seed:   9   Index: 142
+  Step   4: 18 / Gargoyle x2 (7.630s)
+  Step  17: 19 / Gargoyle x2 (7.630s)
+  Step  40: 20 / Turtle x2 (7.432s)
+  Step  41: 21 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:   9   Index: 188
+  Step  35: 22 / SwordRat x3, Needler x3 (7.663s)
+  Step  67: 23 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed:  26   Index:  16
+  Optional Steps: 10
+  Extra Steps: 10
+Overworld (Fabul)                                                             Seed:  26   Index:  96
+Fabul Boat and Leviatan                                                       Seed:  26   Index: 103
+Overworld (Mysidia)                                                           Seed:  26   Index: 103
+Mysidia                                                                       Seed:  26   Index: 112
+Overworld (Mysidia)                                                           Seed:  26   Index: 112
+Overworld (Mt.Ordeals)                                                        Seed:  26   Index: 122
+  Step  84: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  26   Index: 216
+  Step  23: 25 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  35: 26 / Spirit x2, Skelton x2 (8.285s)
+  Step  37: 27 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  43   Index:   3
+  Step  23: 28 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  43   Index:  26
+Mt.Ordeals-3rd station                                                        Seed:  43   Index:  26
+Mt.Ordeals-7th station                                                        Seed:  43   Index:  31
+  Step  16: 29 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  42: 30 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  43   Index:  73
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  43   Index:  91
+Mt.Ordeals Summit                                                             Seed:  43   Index:  91
+  Step   3: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.808s)
+Paladin                                                                       Seed:  43   Index:  95
+Mt.Ordeals Summit                                                             Seed:  43   Index:  95
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  43   Index: 118
+  Step   5: 32 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step   7: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  43   Index: 160
+Mt.Ordeals                                                                    Seed:  43   Index: 190
+  Step  13: 34 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed:  43   Index: 234
+  Step   2: 35 / Raven x1 (8.065s)
+Take Chocobo to Mysidia                                                       Seed:  43   Index: 247
+Overworld (Mysidia)                                                           Seed:  43   Index: 247
+Town of Baron Serpent Road                                                    Seed:  43   Index: 247
+  Extra Steps: 28
+Credit Warp Fight Search                                                      Seed:  60   Index:  23
+  Overworld (Baron)                                                           Seed:  60   Index:  23
+    Extra Steps: 30
+    Step   1: 36 / Imp x3, SwordRat x1 (7.227s)
+    Step  30: 37 / Imp x4 (7.223s)
+   (Step  45: 38 / Eagle x3)
+   (Step  76: 39 / Imp x4)
+   (Step 101: 40 / FloatEye x2)
+   (Step 209: 41 / Imp x3, SwordRat x1)
+   (Step 226: 42 / Imp x3, SwordRat x1)
+   (Step 234: 43 / Imp x3)
+
+Encounter Time:      284.563s
+Other Time:          533.621s
+Total Time:          818.184s
+
+Base Total Time:     972.976s
+Time Saved:          154.792s
+
+Optional Steps:      13
+Extra Steps:         168
+Encounters:          37
+
+Base Encounters:     48
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/215.txt
+++ b/data/routes/cw/215.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	215
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49088844
+VARS	FFFFFFFF:12 C307801:1 E302500:23 E302600:18 E307400:70 E307B01:6 E308400:22 E308700:1 E308702:1 E309700:48
+
+Overworld (Kaipo)                                                             Seed: 215   Index:   0
+Overworld (Kaipo)                                                             Seed: 215   Index:   1
+  Step  21: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 215   Index:  37
+Overworld (Kaipo)                                                             Seed: 215   Index:  37
+Watery Pass-South B1F                                                         Seed: 215   Index:  69
+  Step  32: 2 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed: 215   Index: 101
+Watery Pass-South B1F                                                         Seed: 215   Index: 101
+Watery Pass-South B2F                                                         Seed: 215   Index: 121
+  Step  12: 3 / Pike x2, EvilShel x2 (7.149s)
+  Step  18: 4 / Pike x3 (7.152s)
+  Step  76: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  79: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  80: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 215   Index: 211
+Watery Pass-South B2F                                                         Seed: 215   Index: 215
+Watery Pass-South B3F                                                         Seed: 215   Index: 254
+Watery Pass-North B2F                                                         Seed: 232   Index:  32
+Watery Pass-North B1F                                                         Seed: 232   Index:  53
+Overworld (Kaipo)                                                             Seed: 232   Index: 113
+Waterfalls B1F                                                                Seed: 232   Index: 122
+  Extra Steps: 70
+Waterfalls B2F                                                                Seed: 232   Index: 193
+  Step  34: 8 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 232   Index: 238
+  Step  18: 9 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed: 249   Index:  19
+Waterfalls Lake                                                               Seed: 249   Index:  19
+Overworld (Kaipo)                                                             Seed: 249   Index:  20
+Overworld (Damcyan)                                                           Seed: 249   Index:  31
+Damcyan                                                                       Seed: 249   Index:  35
+  Optional Steps: 1
+  Extra Steps: 22
+Overworld (Damcyan)                                                           Seed: 249   Index:  65
+Antlion B1F                                                                   Seed: 249   Index:  65
+Antlion B2F Inward Direct                                                     Seed: 249   Index: 103
+  Antlion B2F                                                                 Seed: 249   Index: 103
+    Step  23: 10 / SandWorm x1, Sandpede x1 (6.829s)
+    Step  26: 11 / Turtle x2 (7.487s)
+    Step  58: 12 / Cream x4 (7.552s)
+    Step  76: 13 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 249   Index: 183
+  Step  10: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 249   Index: 197
+Antlion's Nest                                                                Seed: 249   Index: 197
+Antlion B2F Outward Charm Room Steps                                          Seed: 249   Index: 212
+  Antlion B2F                                                                 Seed: 249   Index: 212
+    Step  13: 15 / Cream x4 (7.523s)
+  Antlion B2F Treasure Room                                                   Seed:  10   Index:   7
+    Extra Steps: 6
+  Antlion B2F                                                                 Seed:  10   Index:  13
+    Step  22: 16 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  10   Index:  47
+  Step  34: 17 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  10   Index:  85
+Overworld (Kaipo)                                                             Seed:  10   Index:  85
+Kaipo Revisited                                                               Seed:  10   Index:  85
+Overworld (Kaipo)                                                             Seed:  10   Index:  85
+Overworld (Damcyan)                                                           Seed:  10   Index:  85
+Mt.Hobs-West                                                                  Seed:  10   Index:  85
+Mt.Hobs Summit                                                                Seed:  10   Index: 124
+Battle: MomBomb                                                               Seed:  10   Index: 139
+Mt.Hobs Summit                                                                Seed:  10   Index: 139
+Mt.Hobs-East                                                                  Seed:  10   Index: 145
+  Step  14: 18 / Gargoyle x2 (7.630s)
+  Step  37: 19 / Gargoyle x2 (7.630s)
+  Step  38: 20 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  10   Index: 191
+  Step  32: 21 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  64: 22 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed:  27   Index:  19
+  Optional Steps: 10
+  Extra Steps: 8
+Overworld (Fabul)                                                             Seed:  27   Index:  97
+Fabul Boat and Leviatan                                                       Seed:  27   Index: 104
+Overworld (Mysidia)                                                           Seed:  27   Index: 104
+Mysidia                                                                       Seed:  27   Index: 113
+Overworld (Mysidia)                                                           Seed:  27   Index: 113
+Overworld (Mt.Ordeals)                                                        Seed:  27   Index: 123
+  Step  83: 23 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed:  27   Index: 217
+  Extra Steps: 22
+  Step  22: 24 / Red Bone x1, Skelton x3 (8.067s)
+  Step  34: 25 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  36: 26 / Spirit x2, Skelton x2 (8.285s)
+  Step  65: 27 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  44   Index:  26
+  Step  21: 28 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  44   Index:  49
+Mt.Ordeals-3rd station                                                        Seed:  44   Index:  49
+Mt.Ordeals-7th station                                                        Seed:  44   Index:  54
+  Step   4: 29 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  19: 30 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  40: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  44   Index:  96
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  44   Index: 114
+Mt.Ordeals Summit                                                             Seed:  44   Index: 114
+Paladin                                                                       Seed:  44   Index: 118
+Mt.Ordeals Summit                                                             Seed:  44   Index: 118
+  Optional Steps: 1
+  Step   7: 32 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  44   Index: 141
+Mt.Ordeals-3rd station                                                        Seed:  44   Index: 183
+  Step  20: 33 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed:  44   Index: 213
+  Step  23: 34 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed:  61   Index:   1
+Take Chocobo to Mysidia                                                       Seed:  61   Index:  14
+Overworld (Mysidia)                                                           Seed:  61   Index:  14
+Town of Baron Serpent Road                                                    Seed:  61   Index:  14
+  Extra Steps: 48
+Credit Warp Fight Search                                                      Seed:  61   Index:  66
+  Overworld (Baron)                                                           Seed:  61   Index:  66
+    Extra Steps: 12
+    Step   2: 35 / Eagle x3 (7.417s)
+    Step  12: 36 / Imp x3, SwordRat x1 (7.227s)
+   (Step  33: 37 / Imp x4)
+   (Step  58: 38 / Eagle x3)
+   (Step 166: 39 / Imp x4)
+   (Step 183: 40 / FloatEye x2)
+   (Step 191: 41 / Imp x3, SwordRat x1)
+   (Step 200: 42 / Imp x6)
+   (Step 238: 43 / Imp x3)
+
+Encounter Time:      278.056s
+Other Time:          538.746s
+Total Time:          816.802s
+
+Base Total Time:     976.733s
+Time Saved:          159.931s
+
+Optional Steps:      13
+Extra Steps:         188
+Encounters:          36
+
+Base Encounters:     48
+Encounters Saved:    12
+
+Number of Variables: 54

--- a/data/routes/cw/216.txt
+++ b/data/routes/cw/216.txt
@@ -1,0 +1,147 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	216
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48062516
+VARS	FFFFFFFF:6 E302500:1 E302600:7 E307400:134 E308000:2 E308700:1 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed: 216   Index:   0
+Overworld (Kaipo)                                                             Seed: 216   Index:   1
+  Step  21: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 216   Index:  37
+Overworld (Kaipo)                                                             Seed: 216   Index:  37
+Watery Pass-South B1F                                                         Seed: 216   Index:  69
+  Step  32: 2 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed: 216   Index: 101
+Watery Pass-South B1F                                                         Seed: 216   Index: 101
+Watery Pass-South B2F                                                         Seed: 216   Index: 121
+  Step  12: 3 / Pike x2, EvilShel x2 (7.149s)
+  Step  54: 4 / Pike x3 (7.152s)
+  Step  76: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  79: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  80: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 216   Index: 211
+Watery Pass-South B2F                                                         Seed: 216   Index: 215
+Watery Pass-South B3F                                                         Seed: 216   Index: 254
+Watery Pass-North B2F                                                         Seed: 233   Index:  32
+Watery Pass-North B1F                                                         Seed: 233   Index:  53
+Overworld (Kaipo)                                                             Seed: 233   Index: 113
+Waterfalls B1F                                                                Seed: 233   Index: 122
+  Extra Steps: 134
+Waterfalls B2F                                                                Seed: 250   Index:   1
+Waterfalls Lake                                                               Seed: 250   Index:  46
+  Step  19: 8 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed: 250   Index:  83
+Waterfalls Lake                                                               Seed: 250   Index:  83
+Overworld (Kaipo)                                                             Seed: 250   Index:  84
+Overworld (Damcyan)                                                           Seed: 250   Index:  95
+Damcyan                                                                       Seed: 250   Index:  99
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 250   Index: 107
+Antlion B1F                                                                   Seed: 250   Index: 107
+  Step  19: 9 / Turtle x1, Imp x2 (7.044s)
+  Step  22: 10 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Direct                                                     Seed: 250   Index: 145
+  Antlion B2F                                                                 Seed: 250   Index: 145
+    Step  16: 11 / Turtle x2 (7.487s)
+    Step  35: 12 / Cream x4 (7.552s)
+    Step  48: 13 / Basilisk x1, Imp x3 (6.775s)
+    Step  80: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed: 250   Index: 225
+Battle: Antlion                                                               Seed: 250   Index: 239
+Antlion's Nest                                                                Seed: 250   Index: 239
+Antlion B2F Outward Direct                                                    Seed: 250   Index: 254
+  Antlion B2F                                                                 Seed: 250   Index: 254
+    Step  15: 15 / Cream x4 (7.523s)
+    Step  37: 16 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  11   Index:  78
+  Step   3: 17 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  11   Index: 116
+Overworld (Kaipo)                                                             Seed:  11   Index: 116
+Kaipo Revisited                                                               Seed:  11   Index: 116
+Overworld (Kaipo)                                                             Seed:  11   Index: 116
+Overworld (Damcyan)                                                           Seed:  11   Index: 116
+Mt.Hobs-West                                                                  Seed:  11   Index: 116
+Mt.Hobs Summit                                                                Seed:  11   Index: 155
+  Step   4: 18 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:  11   Index: 170
+Mt.Hobs Summit                                                                Seed:  11   Index: 170
+Mt.Hobs-East                                                                  Seed:  11   Index: 176
+  Extra Steps: 2
+  Step   7: 19 / Gargoyle x2 (7.630s)
+  Step  36: 20 / Gargoyle x2 (7.630s)
+  Step  47: 21 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed:  11   Index: 224
+  Step  31: 22 / SwordRat x3, Needler x3 (7.663s)
+  Step  84: 23 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed:  28   Index:  52
+  Optional Steps: 7
+Overworld (Fabul)                                                             Seed:  28   Index: 119
+Fabul Boat and Leviatan                                                       Seed:  28   Index: 126
+Overworld (Mysidia)                                                           Seed:  28   Index: 126
+Mysidia                                                                       Seed:  28   Index: 135
+Overworld (Mysidia)                                                           Seed:  28   Index: 135
+Overworld (Mt.Ordeals)                                                        Seed:  28   Index: 145
+  Step  61: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  94: 25 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  28   Index: 239
+  Step  14: 26 / Spirit x2, Skelton x2 (8.285s)
+  Step  43: 27 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  45   Index:  26
+  Step  21: 28 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed:  45   Index:  49
+Mt.Ordeals-3rd station                                                        Seed:  45   Index:  49
+Mt.Ordeals-7th station                                                        Seed:  45   Index:  54
+  Step   4: 29 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step   7: 30 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  19: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  45   Index:  96
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  45   Index: 114
+Mt.Ordeals Summit                                                             Seed:  45   Index: 114
+Paladin                                                                       Seed:  45   Index: 118
+Mt.Ordeals Summit                                                             Seed:  45   Index: 118
+  Optional Steps: 1
+  Step   7: 32 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  45   Index: 141
+Mt.Ordeals-3rd station                                                        Seed:  45   Index: 183
+  Step  20: 33 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed:  45   Index: 213
+  Step  23: 34 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed:  62   Index:   1
+Take Chocobo to Mysidia                                                       Seed:  62   Index:  14
+Overworld (Mysidia)                                                           Seed:  62   Index:  14
+Town of Baron Serpent Road                                                    Seed:  62   Index:  14
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed:  62   Index:  22
+  Overworld (Baron)                                                           Seed:  62   Index:  22
+    Extra Steps: 6
+    Step   2: 35 / Eagle x3 (7.417s)
+    Step   6: 36 / Imp x3, SwordRat x1 (7.227s)
+   (Step  46: 37 / Imp x4)
+   (Step  56: 38 / Eagle x3)
+   (Step 102: 39 / Imp x4)
+   (Step 210: 40 / FloatEye x2)
+   (Step 227: 41 / Imp x3, SwordRat x1)
+   (Step 235: 42 / Imp x6)
+   (Step 244: 43 / Imp x3)
+
+Encounter Time:      278.350s
+Other Time:          521.375s
+Total Time:          799.725s
+
+Base Total Time:     958.186s
+Time Saved:          158.461s
+
+Optional Steps:      10
+Extra Steps:         146
+Encounters:          36
+
+Base Encounters:     48
+Encounters Saved:    12
+
+Number of Variables: 54

--- a/data/routes/cw/217.txt
+++ b/data/routes/cw/217.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	217
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48240657
+VARS	FFFFFFFF:4 C307800:1 E302500:1 E302600:10 E307400:28 E307B00:90 E308000:12 E308501:6 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 217   Index:   0
+Overworld (Kaipo)                                                             Seed: 217   Index:   1
+  Step  21: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 217   Index:  37
+Overworld (Kaipo)                                                             Seed: 217   Index:  37
+Watery Pass-South B1F                                                         Seed: 217   Index:  69
+  Step   5: 2 / CaveToad x3 (6.825s)
+  Step  32: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 217   Index: 101
+Watery Pass-South B1F                                                         Seed: 217   Index: 101
+Watery Pass-South B2F                                                         Seed: 217   Index: 121
+  Step  12: 4 / Pike x3 (7.152s)
+  Step  54: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  76: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  80: 7 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 217   Index: 211
+Watery Pass-South B2F                                                         Seed: 217   Index: 215
+Watery Pass-South B3F                                                         Seed: 217   Index: 254
+Watery Pass-North B2F                                                         Seed: 234   Index:  32
+  Step   2: 8 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 234   Index:  53
+Overworld (Kaipo)                                                             Seed: 234   Index: 113
+Waterfalls B1F                                                                Seed: 234   Index: 122
+  Extra Steps: 28
+Waterfalls B2F                                                                Seed: 234   Index: 151
+  Step  12: 9 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  39: 10 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 234   Index: 196
+  Step  31: 11 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed: 234   Index: 233
+Waterfalls Lake                                                               Seed: 234   Index: 233
+Overworld (Kaipo)                                                             Seed: 234   Index: 234
+Overworld (Damcyan)                                                           Seed: 234   Index: 245
+Damcyan                                                                       Seed: 234   Index: 249
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 251   Index:   1
+Antlion B1F                                                                   Seed: 251   Index:   1
+Antlion B2F Inward Charm Room Steps                                           Seed: 251   Index:  39
+  Antlion B2F                                                                 Seed: 251   Index:  39
+  Antlion B2F Treasure Room                                                   Seed: 251   Index:  72
+    Extra Steps: 90
+  Antlion B2F                                                                 Seed: 251   Index: 162
+    Step  18: 12 / Cream x4 (7.552s)
+    Step  31: 13 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 251   Index: 214
+  Step  11: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 251   Index: 228
+Antlion's Nest                                                                Seed: 251   Index: 228
+Antlion B2F Outward Direct                                                    Seed: 251   Index: 243
+  Antlion B2F                                                                 Seed: 251   Index: 243
+    Step  26: 15 / Cream x4 (7.523s)
+    Step  48: 16 / Turtle x2 (7.464s)
+    Step  77: 17 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed:  12   Index:  67
+Overworld (Damcyan)                                                           Seed:  12   Index: 105
+Overworld (Kaipo)                                                             Seed:  12   Index: 105
+Kaipo Revisited                                                               Seed:  12   Index: 105
+Overworld (Kaipo)                                                             Seed:  12   Index: 105
+Overworld (Damcyan)                                                           Seed:  12   Index: 105
+Mt.Hobs-West                                                                  Seed:  12   Index: 105
+Mt.Hobs Summit                                                                Seed:  12   Index: 144
+  Step  15: 18 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:  12   Index: 159
+Mt.Hobs Summit                                                                Seed:  12   Index: 159
+Mt.Hobs-East                                                                  Seed:  12   Index: 165
+  Extra Steps: 12
+  Step  18: 19 / Gargoyle x2 (7.630s)
+  Step  47: 20 / Gargoyle x2 (7.630s)
+  Step  58: 21 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed:  12   Index: 223
+  Step  32: 22 / SwordRat x3, Needler x3 (7.663s)
+  Step  40: 23 / GrayBomb x2, Bomb x2 (8.808s)
+Fabul                                                                         Seed:  29   Index:  51
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  29   Index: 121
+Fabul Boat and Leviatan                                                       Seed:  29   Index: 128
+Overworld (Mysidia)                                                           Seed:  29   Index: 128
+Mysidia                                                                       Seed:  29   Index: 137
+Overworld (Mysidia)                                                           Seed:  29   Index: 137
+Overworld (Mt.Ordeals)                                                        Seed:  29   Index: 147
+  Step  59: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  92: 25 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  29   Index: 241
+  Step  12: 26 / Spirit x2, Skelton x2 (8.285s)
+  Step  41: 27 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  46   Index:  28
+  Step  19: 28 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed:  46   Index:  51
+Mt.Ordeals-3rd station                                                        Seed:  46   Index:  51
+  Extra Steps: 6
+  Step   7: 29 / Zombie x2, Ghoul x2 (7.616s)
+  Step  10: 30 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed:  46   Index:  62
+Mt.Ordeals Summit                                                             Seed:  46   Index: 104
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  46   Index: 122
+Mt.Ordeals Summit                                                             Seed:  46   Index: 122
+  Step   3: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.808s)
+Paladin                                                                       Seed:  46   Index: 126
+Mt.Ordeals Summit                                                             Seed:  46   Index: 126
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  46   Index: 149
+  Step  37: 32 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed:  46   Index: 191
+  Step  12: 33 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed:  46   Index: 221
+  Step  15: 34 / Red Bone x1, Skelton x3 (7.844s)
+Overworld (Mt.Ordeals)                                                        Seed:  63   Index:   9
+Take Chocobo to Mysidia                                                       Seed:  63   Index:  22
+Overworld (Mysidia)                                                           Seed:  63   Index:  22
+Town of Baron Serpent Road                                                    Seed:  63   Index:  22
+Credit Warp Fight Search                                                      Seed:  63   Index:  26
+  Overworld (Baron)                                                           Seed:  63   Index:  26
+    Extra Steps: 4
+    Step   2: 35 / Eagle x3 (7.417s)
+    Step   4: 36 / Imp x3, SwordRat x1 (7.227s)
+   (Step  42: 37 / Imp x4)
+   (Step  52: 38 / Eagle x3)
+   (Step  98: 39 / Imp x4)
+   (Step 206: 40 / FloatEye x2)
+   (Step 231: 41 / Imp x3, SwordRat x1)
+   (Step 240: 42 / Imp x3)
+
+Encounter Time:      278.852s
+Other Time:          523.837s
+Total Time:          802.689s
+
+Base Total Time:     853.835s
+Time Saved:          51.146s
+
+Optional Steps:      13
+Extra Steps:         140
+Encounters:          36
+
+Base Encounters:     41
+Encounters Saved:    5
+
+Number of Variables: 54

--- a/data/routes/cw/218.txt
+++ b/data/routes/cw/218.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	218
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49259257
+VARS	FFFFFFFF:4 E000200:10 E000501:2 E302500:37 E302600:11 E307400:18 E307701:12 E307802:6 E308700:1 E308702:1 E309700:56
+
+Overworld (Kaipo)                                                             Seed: 218   Index:   0
+Overworld (Kaipo)                                                             Seed: 218   Index:   1
+  Step  21: 1 / Sand Man x4 (7.172s)
+  Step  35: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed: 218   Index:  37
+Overworld (Kaipo)                                                             Seed: 218   Index:  37
+Watery Pass-South B1F                                                         Seed: 218   Index:  69
+  Step   5: 3 / Pike x2, EvilShel x2 (6.952s)
+  Step  32: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 218   Index: 101
+Watery Pass-South B1F                                                         Seed: 218   Index: 101
+Watery Pass-South B2F                                                         Seed: 218   Index: 121
+  Step  12: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  54: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  76: 7 / Pike x3 (7.152s)
+  Step  80: 8 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-South B2F Save Room                                               Seed: 218   Index: 211
+Watery Pass-South B2F                                                         Seed: 218   Index: 215
+Watery Pass-South B3F                                                         Seed: 218   Index: 254
+Watery Pass-North B2F                                                         Seed: 235   Index:  32
+  Step   2: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 235   Index:  53
+  Step  13: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 235   Index: 113
+  Extra Steps: 10
+  Step  18: 11 / Sandpede x1, Sand Man x2 (7.188s)
+Waterfalls B1F                                                                Seed: 235   Index: 132
+  Extra Steps: 18
+Waterfalls B2F                                                                Seed: 235   Index: 151
+  Step  12: 12 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 235   Index: 196
+  Step  31: 13 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 235   Index: 233
+Waterfalls Lake                                                               Seed: 235   Index: 233
+Overworld (Kaipo)                                                             Seed: 235   Index: 234
+Overworld (Damcyan)                                                           Seed: 235   Index: 245
+Damcyan                                                                       Seed: 235   Index: 249
+  Optional Steps: 1
+  Extra Steps: 36
+Overworld (Damcyan)                                                           Seed: 252   Index:  37
+Antlion B1F                                                                   Seed: 252   Index:  37
+Antlion B2F Inward Direct                                                     Seed: 252   Index:  75
+  Antlion B2F                                                                 Seed: 252   Index:  75
+    Step  22: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  54: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 252   Index: 155
+  Step   6: 16 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed: 252   Index: 169
+Antlion's Nest                                                                Seed: 252   Index: 169
+  Step  11: 17 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed: 252   Index: 184
+  Antlion B2F                                                                 Seed: 252   Index: 184
+    Extra Steps: 6
+    Step   9: 18 / Basilisk x1, Imp x3 (6.783s)
+    Step  41: 19 / SandWorm x2 (6.858s)
+    Step  85: 20 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed:  13   Index:  14
+  Extra Steps: 12
+  Step  21: 21 / Turtle x1, Imp x2 (7.009s)
+  Step  50: 22 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  13   Index:  64
+Overworld (Kaipo)                                                             Seed:  13   Index:  64
+Kaipo Revisited                                                               Seed:  13   Index:  64
+Overworld (Kaipo)                                                             Seed:  13   Index:  64
+Overworld (Damcyan)                                                           Seed:  13   Index:  64
+Mt.Hobs-West                                                                  Seed:  13   Index:  64
+Mt.Hobs Summit                                                                Seed:  13   Index: 103
+Battle: MomBomb                                                               Seed:  13   Index: 118
+Mt.Hobs Summit                                                                Seed:  13   Index: 118
+Mt.Hobs-East                                                                  Seed:  13   Index: 124
+  Step  34: 23 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  13   Index: 170
+  Step  13: 24 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  42: 25 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  53: 26 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  13   Index: 254
+  Optional Steps: 9
+  Extra Steps: 2
+Overworld (Fabul)                                                             Seed:  30   Index:  69
+Fabul Boat and Leviatan                                                       Seed:  30   Index:  76
+Overworld (Mysidia)                                                           Seed:  30   Index:  76
+Mysidia                                                                       Seed:  30   Index:  85
+Overworld (Mysidia)                                                           Seed:  30   Index:  85
+  Extra Steps: 2
+  Step   7: 27 / Imp Cap. x4, Imp x2 (8.344s)
+Overworld (Mt.Ordeals)                                                        Seed:  30   Index:  97
+  Step  91: 28 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  30   Index: 191
+Mt.Ordeals-3rd station                                                        Seed:  30   Index: 234
+  Step   5: 29 / Zombie x2, Ghoul x2 (7.661s)
+  Step  19: 30 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed:  47   Index:   1
+Mt.Ordeals-3rd station                                                        Seed:  47   Index:   1
+Mt.Ordeals-7th station                                                        Seed:  47   Index:   6
+  Step  20: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  21: 32 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  41: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  47   Index:  48
+  Optional Steps: 1
+  Step  10: 34 / Revenant x1, Ghoul x3 (8.914s)
+  Step  13: 35 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed:  47   Index:  66
+Mt.Ordeals Summit                                                             Seed:  47   Index:  66
+Paladin                                                                       Seed:  47   Index:  70
+Mt.Ordeals Summit                                                             Seed:  47   Index:  70
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  47   Index:  93
+  Step  32: 36 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed:  47   Index: 135
+Mt.Ordeals                                                                    Seed:  47   Index: 165
+  Step  21: 37 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  47   Index: 209
+Take Chocobo to Mysidia                                                       Seed:  47   Index: 222
+Overworld (Mysidia)                                                           Seed:  47   Index: 222
+Town of Baron Serpent Road                                                    Seed:  47   Index: 222
+  Extra Steps: 56
+Credit Warp Fight Search                                                      Seed:  64   Index:  26
+  Overworld (Baron)                                                           Seed:  64   Index:  26
+    Extra Steps: 4
+    Step   2: 38 / Eagle x3 (7.417s)
+    Step   4: 39 / Imp x4 (7.223s)
+   (Step  42: 40 / FloatEye x2)
+   (Step  52: 41 / Imp x3, SwordRat x1)
+   (Step  98: 42 / Imp x3)
+   (Step 206: 43 / Imp x3)
+   (Step 224: 44 / FloatEye x1, Eagle x2)
+   (Step 240: 45 / Imp x3)
+
+Encounter Time:      298.796s
+Other Time:          520.842s
+Total Time:          819.638s
+
+Base Total Time:     961.868s
+Time Saved:          142.230s
+
+Optional Steps:      12
+Extra Steps:         146
+Encounters:          39
+
+Base Encounters:     48
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/219.txt
+++ b/data/routes/cw/219.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	219
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48160240
+VARS	FFFFFFFF:12 C307800:1 E000500:8 E302600:11 E307200:14 E307400:14 E307B00:50 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 219   Index:   0
+Overworld (Kaipo)                                                             Seed: 219   Index:   1
+  Step  35: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 219   Index:  37
+Overworld (Kaipo)                                                             Seed: 219   Index:  37
+Watery Pass-South B1F                                                         Seed: 219   Index:  69
+  Step   5: 2 / CaveToad x3 (6.825s)
+Recruit Tellah                                                                Seed: 219   Index: 101
+Watery Pass-South B1F                                                         Seed: 219   Index: 101
+Watery Pass-South B2F                                                         Seed: 219   Index: 121
+  Step   7: 3 / Pike x2, EvilShel x2 (7.149s)
+  Step  12: 4 / Pike x3 (7.152s)
+  Step  54: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  76: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  80: 7 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed: 219   Index: 211
+Watery Pass-South B2F                                                         Seed: 219   Index: 215
+Watery Pass-South B3F                                                         Seed: 219   Index: 254
+Watery Pass-North B2F                                                         Seed: 236   Index:  32
+  Extra Steps: 14
+  Step   2: 8 / Zombie x4 (7.148s)
+  Step  34: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 236   Index:  67
+  Step  31: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 236   Index: 127
+Waterfalls B1F                                                                Seed: 236   Index: 136
+  Extra Steps: 14
+Waterfalls B2F                                                                Seed: 236   Index: 151
+  Step  12: 11 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 236   Index: 196
+  Step  31: 12 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed: 236   Index: 233
+Waterfalls Lake                                                               Seed: 236   Index: 233
+Overworld (Kaipo)                                                             Seed: 236   Index: 234
+Overworld (Damcyan)                                                           Seed: 236   Index: 245
+Damcyan                                                                       Seed: 236   Index: 249
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 253   Index:   0
+Antlion B1F                                                                   Seed: 253   Index:   0
+  Step  37: 13 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Charm Room Steps                                           Seed: 253   Index:  38
+  Antlion B2F                                                                 Seed: 253   Index:  38
+  Antlion B2F Treasure Room                                                   Seed: 253   Index:  71
+    Extra Steps: 50
+  Antlion B2F                                                                 Seed: 253   Index: 121
+    Step  40: 14 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed: 253   Index: 173
+  Step   7: 15 / Basilisk x1, Imp x3 (6.775s)
+Battle: Antlion                                                               Seed: 253   Index: 187
+Antlion's Nest                                                                Seed: 253   Index: 187
+  Step   6: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed: 253   Index: 202
+  Antlion B2F                                                                 Seed: 253   Index: 202
+    Step  23: 17 / Cream x4 (7.523s)
+    Step  67: 18 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  14   Index:  26
+  Step   3: 19 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Step   9: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Step  38: 21 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  14   Index:  64
+Overworld (Kaipo)                                                             Seed:  14   Index:  64
+Kaipo Revisited                                                               Seed:  14   Index:  64
+Overworld (Kaipo)                                                             Seed:  14   Index:  64
+Overworld (Damcyan)                                                           Seed:  14   Index:  64
+Mt.Hobs-West                                                                  Seed:  14   Index:  64
+Mt.Hobs Summit                                                                Seed:  14   Index: 103
+Battle: MomBomb                                                               Seed:  14   Index: 118
+Mt.Hobs Summit                                                                Seed:  14   Index: 118
+Mt.Hobs-East                                                                  Seed:  14   Index: 124
+  Step  34: 22 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:  14   Index: 170
+  Step  13: 23 / GrayBomb x2, Bomb x2 (8.808s)
+  Step  42: 24 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  53: 25 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed:  14   Index: 254
+  Optional Steps: 9
+  Extra Steps: 2
+Overworld (Fabul)                                                             Seed:  31   Index:  69
+Fabul Boat and Leviatan                                                       Seed:  31   Index:  76
+Overworld (Mysidia)                                                           Seed:  31   Index:  76
+  Extra Steps: 8
+  Step  16: 26 / Raven x1 (8.246s)
+Mysidia                                                                       Seed:  31   Index:  93
+Overworld (Mysidia)                                                           Seed:  31   Index:  93
+Overworld (Mt.Ordeals)                                                        Seed:  31   Index: 103
+  Step  85: 27 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  31   Index: 197
+  Step  23: 28 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  31   Index: 240
+  Step  13: 29 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  48   Index:   7
+Mt.Ordeals-3rd station                                                        Seed:  48   Index:   7
+Mt.Ordeals-7th station                                                        Seed:  48   Index:  12
+  Step  14: 30 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  15: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  35: 32 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  48   Index:  54
+  Optional Steps: 1
+  Step   4: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step   7: 34 / Revenant x1, Ghoul x3 (8.914s)
+Battle: Milon and Milon Z                                                     Seed:  48   Index:  72
+Mt.Ordeals Summit                                                             Seed:  48   Index:  72
+Paladin                                                                       Seed:  48   Index:  76
+Mt.Ordeals Summit                                                             Seed:  48   Index:  76
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  48   Index:  99
+Mt.Ordeals-3rd station                                                        Seed:  48   Index: 141
+Mt.Ordeals                                                                    Seed:  48   Index: 171
+  Step  15: 35 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  48   Index: 215
+Take Chocobo to Mysidia                                                       Seed:  48   Index: 228
+Overworld (Mysidia)                                                           Seed:  48   Index: 228
+Town of Baron Serpent Road                                                    Seed:  48   Index: 228
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed:  48   Index: 234
+  Overworld (Baron)                                                           Seed:  48   Index: 234
+    Extra Steps: 12
+    Step   2: 36 / Eagle x3 (7.417s)
+    Step  12: 37 / Imp x4 (7.223s)
+   (Step  50: 38 / Eagle x3)
+   (Step  52: 39 / Imp x3, SwordRat x1)
+   (Step  90: 40 / FloatEye x1, Eagle x2)
+   (Step 100: 41 / Imp x6)
+   (Step 146: 42 / Imp x3)
+   (Step 200: 43 / Imp x3)
+
+Encounter Time:      285.500s
+Other Time:          515.850s
+Total Time:          801.351s
+
+Base Total Time:     954.906s
+Time Saved:          153.555s
+
+Optional Steps:      11
+Extra Steps:         102
+Encounters:          37
+
+Base Encounters:     48
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/220.txt
+++ b/data/routes/cw/220.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	220
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48014428
+VARS	FFFFFFFF:20 E302600:4 E307200:14 E307400:14 E307701:4 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 220   Index:   0
+Overworld (Kaipo)                                                             Seed: 220   Index:   1
+  Step  35: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 220   Index:  37
+Overworld (Kaipo)                                                             Seed: 220   Index:  37
+Watery Pass-South B1F                                                         Seed: 220   Index:  69
+  Step   5: 2 / CaveToad x3 (6.825s)
+  Step  31: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 220   Index: 101
+Watery Pass-South B1F                                                         Seed: 220   Index: 101
+Watery Pass-South B2F                                                         Seed: 220   Index: 121
+  Step   7: 4 / Pike x3 (7.152s)
+  Step  54: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  76: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  80: 7 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed: 220   Index: 211
+Watery Pass-South B2F                                                         Seed: 220   Index: 215
+Watery Pass-South B3F                                                         Seed: 220   Index: 254
+Watery Pass-North B2F                                                         Seed: 237   Index:  32
+  Extra Steps: 14
+  Step   2: 8 / Zombie x4 (7.148s)
+  Step  34: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 237   Index:  67
+  Step  31: 10 / Zombie x4 (7.148s)
+  Step  46: 11 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 237   Index: 127
+Waterfalls B1F                                                                Seed: 237   Index: 136
+  Extra Steps: 14
+Waterfalls B2F                                                                Seed: 237   Index: 151
+  Step  12: 12 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 237   Index: 196
+  Step  31: 13 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 237   Index: 233
+Waterfalls Lake                                                               Seed: 237   Index: 233
+Overworld (Kaipo)                                                             Seed: 237   Index: 234
+Overworld (Damcyan)                                                           Seed: 237   Index: 245
+Damcyan                                                                       Seed: 237   Index: 249
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 254   Index:   0
+Antlion B1F                                                                   Seed: 254   Index:   0
+  Step  37: 14 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed: 254   Index:  38
+  Antlion B2F                                                                 Seed: 254   Index:  38
+    Step  59: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 254   Index: 118
+  Step   2: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed: 254   Index: 132
+Antlion's Nest                                                                Seed: 254   Index: 132
+  Step  12: 17 / Cream x4 (7.523s)
+Antlion B2F Outward Direct                                                    Seed: 254   Index: 147
+  Antlion B2F                                                                 Seed: 254   Index: 147
+    Step  33: 18 / Basilisk x1, Imp x3 (6.783s)
+    Step  46: 19 / SandWorm x2 (6.858s)
+    Step  78: 20 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed: 254   Index: 227
+  Extra Steps: 4
+  Step  42: 21 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  15   Index:  13
+Overworld (Kaipo)                                                             Seed:  15   Index:  13
+Kaipo Revisited                                                               Seed:  15   Index:  13
+Overworld (Kaipo)                                                             Seed:  15   Index:  13
+Overworld (Damcyan)                                                           Seed:  15   Index:  13
+Mt.Hobs-West                                                                  Seed:  15   Index:  13
+  Step  16: 22 / Skelton x4 (8.683s)
+  Step  22: 23 / Gargoyle x2 (8.791s)
+Mt.Hobs Summit                                                                Seed:  15   Index:  52
+  Step  12: 24 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:  15   Index:  67
+Mt.Hobs Summit                                                                Seed:  15   Index:  67
+Mt.Hobs-East                                                                  Seed:  15   Index:  73
+Overworld (Fabul)                                                             Seed:  15   Index: 119
+  Step  39: 25 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  64: 26 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  15   Index: 203
+  Optional Steps: 4
+Overworld (Fabul)                                                             Seed:  32   Index:  11
+Fabul Boat and Leviatan                                                       Seed:  32   Index:  18
+Overworld (Mysidia)                                                           Seed:  32   Index:  18
+Mysidia                                                                       Seed:  32   Index:  27
+Overworld (Mysidia)                                                           Seed:  32   Index:  27
+Overworld (Mt.Ordeals)                                                        Seed:  32   Index:  37
+  Step  15: 27 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  23: 28 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  32: 29 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  55: 30 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  32   Index: 131
+  Step  10: 31 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:  32   Index: 174
+  Step  14: 32 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed:  32   Index: 197
+Mt.Ordeals-3rd station                                                        Seed:  32   Index: 197
+Mt.Ordeals-7th station                                                        Seed:  32   Index: 202
+  Step  18: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  32   Index: 244
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  49   Index:   6
+Mt.Ordeals Summit                                                             Seed:  49   Index:   6
+Paladin                                                                       Seed:  49   Index:  10
+Mt.Ordeals Summit                                                             Seed:  49   Index:  10
+  Optional Steps: 1
+  Step  17: 34 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-7th station                                                        Seed:  49   Index:  33
+  Step  14: 35 / Lilith x1 (8.563s)
+  Step  25: 36 / Lilith x1, Red Bone x2 (8.437s)
+  Step  28: 37 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed:  49   Index:  75
+Mt.Ordeals                                                                    Seed:  49   Index: 105
+Overworld (Mt.Ordeals)                                                        Seed:  49   Index: 149
+Take Chocobo to Mysidia                                                       Seed:  49   Index: 162
+Overworld (Mysidia)                                                           Seed:  49   Index: 162
+Town of Baron Serpent Road                                                    Seed:  49   Index: 162
+Credit Warp Fight Search                                                      Seed:  49   Index: 166
+  Overworld (Baron)                                                           Seed:  49   Index: 166
+    Extra Steps: 20
+    Step   1: 38 / Eagle x3 (7.417s)
+    Step  20: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  80: 40 / FloatEye x1, Eagle x2)
+   (Step 118: 41 / Imp x6)
+   (Step 120: 42 / Imp x3)
+   (Step 133: 43 / Imp x3)
+   (Step 158: 44 / FloatEye x1, Eagle x2)
+   (Step 168: 45 / Imp x3)
+
+Encounter Time:      298.848s
+Other Time:          500.076s
+Total Time:          798.925s
+
+Base Total Time:     958.025s
+Time Saved:          159.100s
+
+Optional Steps:      6
+Extra Steps:         52
+Encounters:          39
+
+Base Encounters:     48
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/221.txt
+++ b/data/routes/cw/221.txt
@@ -1,0 +1,156 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	221
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49561780
+VARS	FFFFFFFF:4 C307801:1 E302500:1 E302600:10 E307200:14 E307400:14 E307900:12 E307B01:80 E308000:10 E308501:2 E308700:1 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed: 221   Index:   0
+Overworld (Kaipo)                                                             Seed: 221   Index:   1
+  Step  35: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 221   Index:  37
+Overworld (Kaipo)                                                             Seed: 221   Index:  37
+Watery Pass-South B1F                                                         Seed: 221   Index:  69
+  Step   5: 2 / CaveToad x3 (6.825s)
+  Step  31: 3 / Pike x2, EvilShel x2 (6.952s)
+Recruit Tellah                                                                Seed: 221   Index: 101
+Watery Pass-South B1F                                                         Seed: 221   Index: 101
+Watery Pass-South B2F                                                         Seed: 221   Index: 121
+  Step   7: 4 / Pike x3 (7.152s)
+  Step  11: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  54: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  76: 7 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed: 221   Index: 211
+Watery Pass-South B2F                                                         Seed: 221   Index: 215
+Watery Pass-South B3F                                                         Seed: 221   Index: 254
+Watery Pass-North B2F                                                         Seed: 238   Index:  32
+  Extra Steps: 14
+  Step   2: 8 / Zombie x4 (7.148s)
+  Step  34: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 238   Index:  67
+  Step  31: 10 / Zombie x4 (7.148s)
+  Step  46: 11 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 238   Index: 127
+Waterfalls B1F                                                                Seed: 238   Index: 136
+  Extra Steps: 14
+Waterfalls B2F                                                                Seed: 238   Index: 151
+  Step  11: 12 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 238   Index: 196
+  Step  31: 13 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 238   Index: 233
+Waterfalls Lake                                                               Seed: 238   Index: 233
+Overworld (Kaipo)                                                             Seed: 238   Index: 234
+Overworld (Damcyan)                                                           Seed: 238   Index: 245
+Damcyan                                                                       Seed: 238   Index: 249
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed: 255   Index:   1
+Antlion B1F                                                                   Seed: 255   Index:   1
+  Step  36: 14 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed: 255   Index:  39
+  Antlion B2F                                                                 Seed: 255   Index:  39
+    Step  58: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed: 255   Index: 119
+  Extra Steps: 12
+  Step   1: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+  Step  11: 17 / Cream x4 (7.552s)
+  Step  25: 18 / Basilisk x1, Imp x3 (6.775s)
+Battle: Antlion                                                               Seed: 255   Index: 145
+Antlion's Nest                                                                Seed: 255   Index: 145
+Antlion B2F Outward Charm Room Steps                                          Seed: 255   Index: 160
+  Antlion B2F                                                                 Seed: 255   Index: 160
+    Step  20: 19 / SandWorm x1, Sandpede x1 (6.848s)
+  Antlion B2F Treasure Room                                                   Seed: 255   Index: 211
+    Extra Steps: 80
+  Antlion B2F                                                                 Seed:  16   Index:  35
+    Step  29: 20 / SandWorm x2 (6.858s)
+Antlion B1F                                                                   Seed:  16   Index:  69
+Overworld (Damcyan)                                                           Seed:  16   Index: 107
+Overworld (Kaipo)                                                             Seed:  16   Index: 107
+Kaipo Revisited                                                               Seed:  16   Index: 107
+Overworld (Kaipo)                                                             Seed:  16   Index: 107
+Overworld (Damcyan)                                                           Seed:  16   Index: 107
+Mt.Hobs-West                                                                  Seed:  16   Index: 107
+Mt.Hobs Summit                                                                Seed:  16   Index: 146
+  Step  12: 21 / GrayBomb x2, Bomb x2 (10.938s)
+Battle: MomBomb                                                               Seed:  16   Index: 161
+Mt.Hobs Summit                                                                Seed:  16   Index: 161
+Mt.Hobs-East                                                                  Seed:  16   Index: 167
+  Extra Steps: 10
+  Step  45: 22 / Spirit x2, Skelton x2 (8.237s)
+  Step  55: 23 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  16   Index: 223
+  Step  32: 24 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  40: 25 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  33   Index:  51
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  33   Index: 121
+Fabul Boat and Leviatan                                                       Seed:  33   Index: 128
+Overworld (Mysidia)                                                           Seed:  33   Index: 128
+Mysidia                                                                       Seed:  33   Index: 137
+Overworld (Mysidia)                                                           Seed:  33   Index: 137
+  Step   4: 26 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed:  33   Index: 147
+  Step  41: 27 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  73: 28 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  94: 29 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  33   Index: 241
+  Step  42: 30 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed:  50   Index:  28
+  Step  19: 31 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  50   Index:  51
+Mt.Ordeals-3rd station                                                        Seed:  50   Index:  51
+  Extra Steps: 2
+  Step   3: 32 / Ghoul x2, Soul x2 (9.197s)
+  Step   7: 33 / Zombie x2, Ghoul x2 (7.616s)
+Mt.Ordeals-7th station                                                        Seed:  50   Index:  58
+  Step   3: 34 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed:  50   Index: 100
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  50   Index: 118
+Mt.Ordeals Summit                                                             Seed:  50   Index: 118
+Paladin                                                                       Seed:  50   Index: 122
+Mt.Ordeals Summit                                                             Seed:  50   Index: 122
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  50   Index: 145
+  Step  22: 35 / Lilith x1 (8.563s)
+  Step  41: 36 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  50   Index: 187
+Mt.Ordeals                                                                    Seed:  50   Index: 217
+  Step  29: 37 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  67   Index:   5
+Take Chocobo to Mysidia                                                       Seed:  67   Index:  18
+Overworld (Mysidia)                                                           Seed:  67   Index:  18
+Town of Baron Serpent Road                                                    Seed:  67   Index:  18
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed:  67   Index:  26
+  Overworld (Baron)                                                           Seed:  67   Index:  26
+    Extra Steps: 4
+    Step   2: 38 / Eagle x3 (7.417s)
+    Step   4: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  17: 40 / FloatEye x1, Eagle x2)
+   (Step  52: 41 / Imp x3)
+   (Step 127: 42 / Imp x3)
+   (Step 152: 43 / Imp x3)
+   (Step 224: 44 / FloatEye x1, Eagle x2)
+   (Step 238: 45 / Imp x3)
+   (Step 240: 46 / Imp x3)
+
+Encounter Time:      300.834s
+Other Time:          523.837s
+Total Time:          824.672s
+
+Base Total Time:     941.137s
+Time Saved:          116.466s
+
+Optional Steps:      13
+Extra Steps:         140
+Encounters:          39
+
+Base Encounters:     48
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/222.txt
+++ b/data/routes/cw/222.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	222
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49412586
+VARS	FFFFFFFF:4 C307800:1 E000500:4 E302500:28 E302600:63 E307B00:50 E308501:2 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 222   Index:   0
+Overworld (Kaipo)                                                             Seed: 222   Index:   1
+  Step  35: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 222   Index:  37
+Overworld (Kaipo)                                                             Seed: 222   Index:  37
+Watery Pass-South B1F                                                         Seed: 222   Index:  69
+  Step   5: 2 / CaveToad x3 (6.825s)
+  Step  31: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 222   Index: 101
+Watery Pass-South B1F                                                         Seed: 222   Index: 101
+Watery Pass-South B2F                                                         Seed: 222   Index: 121
+  Step   7: 4 / Pike x3 (7.152s)
+  Step  11: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  43: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  54: 7 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed: 222   Index: 211
+Watery Pass-South B2F                                                         Seed: 222   Index: 215
+Watery Pass-South B3F                                                         Seed: 222   Index: 254
+Watery Pass-North B2F                                                         Seed: 239   Index:  32
+  Step   2: 8 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 239   Index:  53
+  Step  13: 9 / Jelly x4 (7.324s)
+  Step  45: 10 / Zombie x4 (7.148s)
+  Step  60: 11 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 239   Index: 113
+Waterfalls B1F                                                                Seed: 239   Index: 122
+Waterfalls B2F                                                                Seed: 239   Index: 123
+  Step  39: 12 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 239   Index: 168
+  Step  26: 13 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 239   Index: 205
+Waterfalls Lake                                                               Seed: 239   Index: 205
+Overworld (Kaipo)                                                             Seed: 239   Index: 206
+Overworld (Damcyan)                                                           Seed: 239   Index: 217
+Damcyan                                                                       Seed: 239   Index: 221
+  Optional Steps: 0
+  Extra Steps: 28
+Overworld (Damcyan)                                                           Seed:   0   Index:   0
+Antlion B1F                                                                   Seed:   0   Index:   0
+  Step  37: 14 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Charm Room Steps                                           Seed:   0   Index:  38
+  Antlion B2F                                                                 Seed:   0   Index:  38
+  Antlion B2F Treasure Room                                                   Seed:   0   Index:  71
+    Extra Steps: 50
+  Antlion B2F                                                                 Seed:   0   Index: 121
+    Step   9: 15 / Basilisk x1, Imp x3 (6.775s)
+    Step  23: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed:   0   Index: 173
+  Step   7: 17 / Cream x4 (7.552s)
+Battle: Antlion                                                               Seed:   0   Index: 187
+Antlion's Nest                                                                Seed:   0   Index: 187
+Antlion B2F Outward Direct                                                    Seed:   0   Index: 202
+  Antlion B2F                                                                 Seed:   0   Index: 202
+    Step  56: 18 / Basilisk x1, Imp x3 (6.783s)
+    Step  67: 19 / SandWorm x1, Sandpede x1 (6.848s)
+Antlion B1F                                                                   Seed:  17   Index:  26
+  Step   3: 20 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Step  38: 21 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  17   Index:  64
+Overworld (Kaipo)                                                             Seed:  17   Index:  64
+Kaipo Revisited                                                               Seed:  17   Index:  64
+Overworld (Kaipo)                                                             Seed:  17   Index:  64
+Overworld (Damcyan)                                                           Seed:  17   Index:  64
+Mt.Hobs-West                                                                  Seed:  17   Index:  64
+  Step  29: 22 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  17   Index: 103
+Battle: MomBomb                                                               Seed:  17   Index: 118
+Mt.Hobs Summit                                                                Seed:  17   Index: 118
+Mt.Hobs-East                                                                  Seed:  17   Index: 124
+  Step  34: 23 / Turtle x2 (7.432s)
+Overworld (Fabul)                                                             Seed:  17   Index: 170
+  Step  42: 24 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  52: 25 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  17   Index: 254
+  Optional Steps: 9
+  Extra Steps: 54
+Overworld (Fabul)                                                             Seed:  34   Index: 121
+Fabul Boat and Leviatan                                                       Seed:  34   Index: 128
+Overworld (Mysidia)                                                           Seed:  34   Index: 128
+  Extra Steps: 4
+  Step  13: 26 / Raven x1 (8.246s)
+Mysidia                                                                       Seed:  34   Index: 141
+Overworld (Mysidia)                                                           Seed:  34   Index: 141
+Overworld (Mt.Ordeals)                                                        Seed:  34   Index: 151
+  Step  37: 27 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  69: 28 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  90: 29 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  34   Index: 245
+  Step  38: 30 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed:  51   Index:  32
+  Step  22: 31 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  51   Index:  55
+Mt.Ordeals-3rd station                                                        Seed:  51   Index:  55
+  Extra Steps: 2
+  Step   3: 32 / Ghoul x2, Soul x2 (9.197s)
+  Step   6: 33 / Zombie x2, Ghoul x2 (7.616s)
+Mt.Ordeals-7th station                                                        Seed:  51   Index:  62
+  Step  27: 34 / Revenant x1, Ghoul x3 (8.914s)
+Mt.Ordeals Summit                                                             Seed:  51   Index: 104
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  51   Index: 122
+Mt.Ordeals Summit                                                             Seed:  51   Index: 122
+Paladin                                                                       Seed:  51   Index: 126
+Mt.Ordeals Summit                                                             Seed:  51   Index: 126
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  51   Index: 149
+  Step  18: 35 / Lilith x1 (8.563s)
+  Step  37: 36 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  51   Index: 191
+Mt.Ordeals                                                                    Seed:  51   Index: 221
+  Step  25: 37 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  68   Index:   9
+Take Chocobo to Mysidia                                                       Seed:  68   Index:  22
+Overworld (Mysidia)                                                           Seed:  68   Index:  22
+Town of Baron Serpent Road                                                    Seed:  68   Index:  22
+Credit Warp Fight Search                                                      Seed:  68   Index:  26
+  Overworld (Baron)                                                           Seed:  68   Index:  26
+    Extra Steps: 4
+    Step   2: 38 / Eagle x3 (7.417s)
+    Step   4: 39 / Imp x3, SwordRat x1 (7.227s)
+   (Step  17: 40 / FloatEye x1, Eagle x2)
+   (Step  93: 41 / Imp x3)
+   (Step 127: 42 / Imp x3)
+   (Step 152: 43 / Imp x3)
+   (Step 224: 44 / FloatEye x1, Eagle x2)
+   (Step 238: 45 / Imp x3)
+
+Encounter Time:      297.819s
+Other Time:          524.370s
+Total Time:          822.189s
+
+Base Total Time:     933.321s
+Time Saved:          111.132s
+
+Optional Steps:      11
+Extra Steps:         142
+Encounters:          39
+
+Base Encounters:     48
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/223.txt
+++ b/data/routes/cw/223.txt
@@ -1,0 +1,154 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	223
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	51795667
+VARS	FFFFFFFF:16 C307800:1 C307801:1 E302500:120 E302600:14 E307200:14 E307400:74 E307B00:70 E307B01:66 E307F01:2 E308501:6
+
+Overworld (Kaipo)                                                             Seed: 223   Index:   0
+Overworld (Kaipo)                                                             Seed: 223   Index:   1
+  Step  35: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 223   Index:  37
+Overworld (Kaipo)                                                             Seed: 223   Index:  37
+  Step  18: 2 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 223   Index:  69
+  Step   5: 3 / EvilShel x3, WaterBug x1 (6.866s)
+  Step  31: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 223   Index: 101
+Watery Pass-South B1F                                                         Seed: 223   Index: 101
+Watery Pass-South B2F                                                         Seed: 223   Index: 121
+  Step   7: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  11: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  43: 7 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed: 223   Index: 211
+Watery Pass-South B2F                                                         Seed: 223   Index: 215
+Watery Pass-South B3F                                                         Seed: 223   Index: 254
+Watery Pass-North B2F                                                         Seed: 240   Index:  32
+  Extra Steps: 14
+  Step   2: 8 / Zombie x4 (7.148s)
+  Step  34: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 240   Index:  67
+  Step  31: 10 / Zombie x4 (7.148s)
+  Step  46: 11 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 240   Index: 127
+Waterfalls B1F                                                                Seed: 240   Index: 136
+  Extra Steps: 74
+Waterfalls B2F                                                                Seed: 240   Index: 211
+  Step  43: 12 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed:   1   Index:   0
+  Step  37: 13 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed:   1   Index:  37
+Waterfalls Lake                                                               Seed:   1   Index:  37
+Overworld (Kaipo)                                                             Seed:   1   Index:  38
+Overworld (Damcyan)                                                           Seed:   1   Index:  49
+Damcyan                                                                       Seed:   1   Index:  53
+  Optional Steps: 0
+  Extra Steps: 120
+Overworld (Damcyan)                                                           Seed:   1   Index: 180
+Antlion B1F                                                                   Seed:   1   Index: 180
+Antlion B2F Inward Charm Room Steps                                           Seed:   1   Index: 218
+  Antlion B2F                                                                 Seed:   1   Index: 218
+  Antlion B2F Treasure Room                                                   Seed:   1   Index: 251
+    Extra Steps: 70
+  Antlion B2F                                                                 Seed:  18   Index:  65
+    Step  28: 14 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:  18   Index: 117
+Battle: Antlion                                                               Seed:  18   Index: 131
+Antlion's Nest                                                                Seed:  18   Index: 131
+Antlion B2F Outward Charm Room Steps                                          Seed:  18   Index: 146
+  Antlion B2F                                                                 Seed:  18   Index: 146
+    Step  12: 15 / Basilisk x1, Imp x3 (6.783s)
+  Antlion B2F Treasure Room                                                   Seed:  18   Index: 197
+    Extra Steps: 66
+  Antlion B2F                                                                 Seed:  35   Index:   7
+    Step  24: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  35   Index:  41
+  Step  28: 17 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  35   Index:  79
+Overworld (Kaipo)                                                             Seed:  35   Index:  79
+Kaipo Revisited                                                               Seed:  35   Index:  79
+Overworld (Kaipo)                                                             Seed:  35   Index:  79
+Overworld (Damcyan)                                                           Seed:  35   Index:  79
+Mt.Hobs-West                                                                  Seed:  35   Index:  79
+Mt.Hobs Summit                                                                Seed:  35   Index: 118
+  Step   3: 18 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:  35   Index: 133
+Mt.Hobs Summit                                                                Seed:  35   Index: 133
+  Extra Steps: 2
+  Step   8: 19 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed:  35   Index: 141
+Overworld (Fabul)                                                             Seed:  35   Index: 187
+  Step   1: 20 / SwordRat x3, Needler x3 (7.663s)
+  Step  33: 21 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  54: 22 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  52   Index:  15
+  Optional Steps: 10
+  Extra Steps: 4
+Overworld (Fabul)                                                             Seed:  52   Index:  89
+Fabul Boat and Leviatan                                                       Seed:  52   Index:  96
+Overworld (Mysidia)                                                           Seed:  52   Index:  96
+Mysidia                                                                       Seed:  52   Index: 105
+Overworld (Mysidia)                                                           Seed:  52   Index: 105
+Overworld (Mt.Ordeals)                                                        Seed:  52   Index: 115
+  Step  28: 23 / Needler x2, SwordRat x2 (8.097s)
+  Step  52: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  71: 25 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  52   Index: 209
+  Step  37: 26 / Spirit x2, Skelton x2 (8.285s)
+Mt.Ordeals-3rd station                                                        Seed:  52   Index: 252
+Recruit Tellah                                                                Seed:  69   Index:  19
+Mt.Ordeals-3rd station                                                        Seed:  69   Index:  19
+  Extra Steps: 6
+  Step   9: 27 / Ghoul x2, Soul x2 (9.197s)
+  Step  11: 28 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed:  69   Index:  30
+  Step  13: 29 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals Summit                                                             Seed:  69   Index:  72
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed:  69   Index:  89
+Mt.Ordeals Summit                                                             Seed:  69   Index:  89
+Paladin                                                                       Seed:  69   Index:  93
+Mt.Ordeals Summit                                                             Seed:  69   Index:  93
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed:  69   Index: 115
+  Step   4: 30 / Lilith x1, Red Bone x2 (8.437s)
+  Step  38: 31 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  69   Index: 157
+  Step  21: 32 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:  69   Index: 187
+  Step  44: 33 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed:  69   Index: 231
+Take Chocobo to Mysidia                                                       Seed:  69   Index: 244
+Overworld (Mysidia)                                                           Seed:  69   Index: 244
+Town of Baron Serpent Road                                                    Seed:  69   Index: 244
+Credit Warp Fight Search                                                      Seed:  69   Index: 248
+  Overworld (Baron)                                                           Seed:  69   Index: 248
+    Extra Steps: 16
+    Step   2: 34 / FloatEye x2 (7.230s)
+    Step  16: 35 / Imp x4 (7.223s)
+   (Step  40: 36 / Eagle x3)
+   (Step  84: 37 / Imp x4)
+   (Step  93: 38 / Eagle x3)
+   (Step 125: 39 / Imp x3, SwordRat x1)
+   (Step 148: 40 / FloatEye x1, Eagle x2)
+   (Step 165: 41 / Imp x3)
+
+Encounter Time:      268.452s
+Other Time:          593.389s
+Total Time:          861.842s
+
+Base Total Time:     939.868s
+Time Saved:          78.026s
+
+Optional Steps:      10
+Extra Steps:         372
+Encounters:          35
+
+Base Encounters:     48
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/224.txt
+++ b/data/routes/cw/224.txt
@@ -1,0 +1,159 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	224
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	50024331
+VARS	FFFFFFFF:30 C307800:1 C307801:1 E302500:1 E302600:22 E305400:14 E307300:1 E307400:56 E307803:2 E307B00:32 E307B01:6 E308000:4 E308500:2 E308700:1 E308702:1 E309700:18
+
+Overworld (Kaipo)                                                             Seed: 224   Index:   0
+Overworld (Kaipo)                                                             Seed: 224   Index:   1
+  Step  35: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 224   Index:  37
+Overworld (Kaipo)                                                             Seed: 224   Index:  37
+  Step  18: 2 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 224   Index:  69
+  Step  31: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 224   Index: 101
+Watery Pass-South B1F                                                         Seed: 224   Index: 101
+Watery Pass-South B2F                                                         Seed: 224   Index: 121
+  Step   7: 4 / Pike x3 (7.152s)
+  Step  11: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  43: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 224   Index: 211
+  Extra Steps: 14
+Watery Pass-South B2F                                                         Seed: 224   Index: 229
+Watery Pass-South B3F                                                         Seed: 241   Index:  12
+Watery Pass-North B2F                                                         Seed: 241   Index:  46
+  Step  11: 7 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  20: 8 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed: 241   Index:  67
+  Extra Steps: 1
+  Step  31: 9 / Jelly x4 (7.324s)
+  Step  46: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 241   Index: 128
+Waterfalls B1F                                                                Seed: 241   Index: 137
+  Extra Steps: 56
+Waterfalls B2F                                                                Seed: 241   Index: 194
+  Step  16: 11 / TinyMage x2, WaterHag x4 (8.120s)
+Waterfalls Lake                                                               Seed: 241   Index: 239
+Battle: Octomamm                                                              Seed:   2   Index:  20
+Waterfalls Lake                                                               Seed:   2   Index:  20
+Overworld (Kaipo)                                                             Seed:   2   Index:  21
+Overworld (Damcyan)                                                           Seed:   2   Index:  32
+Damcyan                                                                       Seed:   2   Index:  36
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:   2   Index:  44
+Antlion B1F                                                                   Seed:   2   Index:  44
+  Step  12: 12 / Imp x3 (6.649s)
+Antlion B2F Inward Charm Room Steps                                           Seed:   2   Index:  82
+  Antlion B2F                                                                 Seed:   2   Index:  82
+    Step   5: 13 / Turtle x2 (7.487s)
+    Step  15: 14 / Basilisk x1, Turtle x1 (7.110s)
+  Antlion B2F Treasure Room                                                   Seed:   2   Index: 115
+    Extra Steps: 32
+  Antlion B2F                                                                 Seed:   2   Index: 147
+Antlion's Nest                                                                Seed:   2   Index: 199
+Battle: Antlion                                                               Seed:   2   Index: 213
+Antlion's Nest                                                                Seed:   2   Index: 213
+Antlion B2F Outward Charm Room Steps                                          Seed:   2   Index: 228
+  Antlion B2F                                                                 Seed:   2   Index: 228
+    Step  30: 15 / Basilisk x1, Imp x3 (6.783s)
+  Antlion B2F Treasure Room                                                   Seed:  19   Index:  23
+    Extra Steps: 6
+  Antlion B2F                                                                 Seed:  19   Index:  29
+    Extra Steps: 2
+    Step  35: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  19   Index:  65
+  Step   2: 17 / Imp x3 (6.648s)
+  Step  28: 18 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  19   Index: 103
+Overworld (Kaipo)                                                             Seed:  19   Index: 103
+Kaipo Revisited                                                               Seed:  19   Index: 103
+Overworld (Kaipo)                                                             Seed:  19   Index: 103
+Overworld (Damcyan)                                                           Seed:  19   Index: 103
+Mt.Hobs-West                                                                  Seed:  19   Index: 103
+Mt.Hobs Summit                                                                Seed:  19   Index: 142
+Battle: MomBomb                                                               Seed:  19   Index: 157
+Mt.Hobs Summit                                                                Seed:  19   Index: 157
+  Step   1: 19 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed:  19   Index: 163
+  Extra Steps: 4
+Overworld (Fabul)                                                             Seed:  19   Index: 213
+  Step   9: 20 / SwordRat x3, Needler x3 (7.663s)
+  Step  11: 21 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  50: 22 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  74: 23 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed:  36   Index:  41
+  Optional Steps: 10
+  Extra Steps: 12
+Overworld (Fabul)                                                             Seed:  36   Index: 123
+Fabul Boat and Leviatan                                                       Seed:  36   Index: 130
+Overworld (Mysidia)                                                           Seed:  36   Index: 130
+Mysidia                                                                       Seed:  36   Index: 139
+Overworld (Mysidia)                                                           Seed:  36   Index: 139
+  Step   2: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Overworld (Mt.Ordeals)                                                        Seed:  36   Index: 149
+  Step  39: 25 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  71: 26 / Raven x1 (8.356s)
+  Step  92: 27 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  36   Index: 243
+  Step  28: 28 / Spirit x3, Soul x1 (8.687s)
+  Step  40: 29 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  53   Index:  30
+  Extra Steps: 2
+  Step  24: 30 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  53   Index:  55
+Mt.Ordeals-3rd station                                                        Seed:  53   Index:  55
+Mt.Ordeals-7th station                                                        Seed:  53   Index:  60
+  Step  29: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  53   Index: 102
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  53   Index: 120
+Mt.Ordeals Summit                                                             Seed:  53   Index: 120
+Paladin                                                                       Seed:  53   Index: 124
+Mt.Ordeals Summit                                                             Seed:  53   Index: 124
+  Optional Steps: 1
+  Step  19: 32 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  53   Index: 147
+  Step  20: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  39: 34 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals-3rd station                                                        Seed:  53   Index: 189
+Mt.Ordeals                                                                    Seed:  53   Index: 219
+  Step  27: 35 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  70   Index:   7
+Take Chocobo to Mysidia                                                       Seed:  70   Index:  20
+Overworld (Mysidia)                                                           Seed:  70   Index:  20
+Town of Baron Serpent Road                                                    Seed:  70   Index:  20
+  Extra Steps: 18
+Credit Warp Fight Search                                                      Seed:  70   Index:  42
+  Overworld (Baron)                                                           Seed:  70   Index:  42
+    Extra Steps: 30
+    Step   1: 36 / Eagle x3 (7.417s)
+    Step  30: 37 / Imp x4 (7.223s)
+   (Step  77: 38 / Eagle x3)
+   (Step 111: 39 / Imp x3, SwordRat x1)
+   (Step 136: 40 / FloatEye x1, Eagle x2)
+   (Step 189: 41 / Imp x3)
+   (Step 208: 42 / Imp x3)
+   (Step 222: 43 / Imp x3)
+   (Step 246: 44 / FloatEye x1, Eagle x2)
+
+Encounter Time:      286.900s
+Other Time:          545.468s
+Total Time:          832.368s
+
+Base Total Time:     958.619s
+Time Saved:          126.251s
+
+Optional Steps:      13
+Extra Steps:         177
+Encounters:          37
+
+Base Encounters:     48
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/225.txt
+++ b/data/routes/cw/225.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	225
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49347581
+VARS	FFFFFFFF:6 E000600:2 E302500:87 E302600:10 E305400:14 E307100:20 E307200:12 E307400:42 E307701:2 E308700:1 E308701:4 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed: 225   Index:   0
+Overworld (Kaipo)                                                             Seed: 225   Index:   1
+  Step   2: 1 / Sand Man x4 (7.172s)
+  Step  35: 2 / Sandpede x1, Sand Man x2 (7.026s)
+Kaipo                                                                         Seed: 225   Index:  37
+Overworld (Kaipo)                                                             Seed: 225   Index:  37
+  Step  18: 3 / Sand Man x4 (7.242s)
+Watery Pass-South B1F                                                         Seed: 225   Index:  69
+  Step  31: 4 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 225   Index: 101
+Watery Pass-South B1F                                                         Seed: 225   Index: 101
+Watery Pass-South B2F                                                         Seed: 225   Index: 121
+  Step   7: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  11: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  43: 7 / Zombie x4 (7.148s)
+Watery Pass-South B2F Save Room                                               Seed: 225   Index: 211
+  Extra Steps: 14
+Watery Pass-South B2F                                                         Seed: 225   Index: 229
+Watery Pass-South B3F                                                         Seed: 242   Index:  12
+  Extra Steps: 20
+  Step  45: 8 / Zombie x4 (7.148s)
+Watery Pass-North B2F                                                         Seed: 242   Index:  66
+  Extra Steps: 12
+  Step  32: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 242   Index:  99
+  Step  14: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 242   Index: 159
+  Step   3: 11 / Sandpede x1, Sand Man x2 (7.188s)
+Waterfalls B1F                                                                Seed: 242   Index: 168
+  Extra Steps: 42
+Waterfalls B2F                                                                Seed: 242   Index: 211
+Waterfalls Lake                                                               Seed:   3   Index:   0
+  Step  37: 12 / Jelly x4 (7.324s)
+Battle: Octomamm                                                              Seed:   3   Index:  37
+Waterfalls Lake                                                               Seed:   3   Index:  37
+Overworld (Kaipo)                                                             Seed:   3   Index:  38
+Overworld (Damcyan)                                                           Seed:   3   Index:  49
+Damcyan                                                                       Seed:   3   Index:  53
+  Optional Steps: 1
+  Extra Steps: 86
+Overworld (Damcyan)                                                           Seed:   3   Index: 147
+Antlion B1F                                                                   Seed:   3   Index: 147
+  Step  35: 13 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:   3   Index: 185
+  Antlion B2F                                                                 Seed:   3   Index: 185
+    Step  73: 14 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:  20   Index:   9
+Battle: Antlion                                                               Seed:  20   Index:  23
+Antlion's Nest                                                                Seed:  20   Index:  23
+  Step   6: 15 / Basilisk x1, Imp x3 (6.783s)
+Antlion B2F Outward Direct                                                    Seed:  20   Index:  38
+  Antlion B2F                                                                 Seed:  20   Index:  38
+    Step  29: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  55: 17 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed:  20   Index: 118
+  Extra Steps: 2
+  Step  40: 18 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  20   Index: 158
+Overworld (Kaipo)                                                             Seed:  20   Index: 158
+Kaipo Revisited                                                               Seed:  20   Index: 158
+Overworld (Kaipo)                                                             Seed:  20   Index: 158
+Overworld (Damcyan)                                                           Seed:  20   Index: 158
+Mt.Hobs-West                                                                  Seed:  20   Index: 158
+Mt.Hobs Summit                                                                Seed:  20   Index: 197
+Battle: MomBomb                                                               Seed:  20   Index: 212
+Mt.Hobs Summit                                                                Seed:  20   Index: 212
+Mt.Hobs-East                                                                  Seed:  20   Index: 218
+  Step   4: 19 / Spirit x2, Skelton x2 (8.237s)
+  Step   6: 20 / Spirit x2, Skelton x2 (8.237s)
+  Step  33: 21 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed:  37   Index:   8
+  Step  23: 22 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  61: 23 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed:  37   Index:  92
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  37   Index: 162
+Fabul Boat and Leviatan                                                       Seed:  37   Index: 169
+Overworld (Mysidia)                                                           Seed:  37   Index: 169
+Mysidia                                                                       Seed:  37   Index: 178
+Overworld (Mysidia)                                                           Seed:  37   Index: 178
+  Step  10: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Overworld (Mt.Ordeals)                                                        Seed:  37   Index: 188
+  Extra Steps: 2
+  Step  32: 25 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  53: 26 / Raven x1 (8.356s)
+  Step  83: 27 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  95: 28 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  54   Index:  28
+  Step  25: 29 / Spirit x3, Soul x1 (8.687s)
+  Step  26: 30 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed:  54   Index:  71
+  Step  18: 31 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed:  54   Index:  94
+Mt.Ordeals-3rd station                                                        Seed:  54   Index:  94
+Mt.Ordeals-7th station                                                        Seed:  54   Index:  99
+Mt.Ordeals Summit                                                             Seed:  54   Index: 141
+  Optional Steps: 1
+  Step   2: 32 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed:  54   Index: 159
+Mt.Ordeals Summit                                                             Seed:  54   Index: 159
+  Extra Steps: 4
+  Step   8: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.808s)
+Paladin                                                                       Seed:  54   Index: 167
+Mt.Ordeals Summit                                                             Seed:  54   Index: 167
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  54   Index: 190
+Mt.Ordeals-3rd station                                                        Seed:  54   Index: 232
+  Step  14: 34 / Spirit x2, Soul x2, Red Bone x2 (9.471s)
+Mt.Ordeals                                                                    Seed:  71   Index:   6
+  Step  37: 35 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  71   Index:  50
+Take Chocobo to Mysidia                                                       Seed:  71   Index:  63
+Overworld (Mysidia)                                                           Seed:  71   Index:  63
+Town of Baron Serpent Road                                                    Seed:  71   Index:  63
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed:  71   Index:  71
+  Overworld (Baron)                                                           Seed:  71   Index:  71
+    Extra Steps: 6
+    Step   1: 36 / Eagle x3 (7.417s)
+    Step   6: 37 / Imp x4 (7.223s)
+   (Step  48: 38 / Eagle x3)
+   (Step  82: 39 / Imp x3, SwordRat x1)
+   (Step 107: 40 / FloatEye x1, Eagle x2)
+   (Step 160: 41 / Imp x3)
+   (Step 193: 42 / Imp x3)
+   (Step 217: 43 / Imp x3)
+
+Encounter Time:      287.486s
+Other Time:          533.621s
+Total Time:          821.107s
+
+Base Total Time:     916.803s
+Time Saved:          95.695s
+
+Optional Steps:      13
+Extra Steps:         192
+Encounters:          37
+
+Base Encounters:     48
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/226.txt
+++ b/data/routes/cw/226.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	226
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48491176
+VARS	FFFFFFFF:6 E302500:87 E302600:10 E307200:12 E307400:76 E308000:2 E308501:2 E308700:1 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed: 226   Index:   0
+Overworld (Kaipo)                                                             Seed: 226   Index:   1
+  Step   2: 1 / Sand Man x4 (7.172s)
+Kaipo                                                                         Seed: 226   Index:  37
+Overworld (Kaipo)                                                             Seed: 226   Index:  37
+  Step  18: 2 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 226   Index:  69
+  Step  31: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 226   Index: 101
+Watery Pass-South B1F                                                         Seed: 226   Index: 101
+Watery Pass-South B2F                                                         Seed: 226   Index: 121
+  Step  11: 4 / Pike x3 (7.152s)
+  Step  43: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  71: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 226   Index: 211
+Watery Pass-South B2F                                                         Seed: 226   Index: 215
+  Step  13: 7 / Zombie x4 (7.148s)
+Watery Pass-South B3F                                                         Seed: 226   Index: 254
+Watery Pass-North B2F                                                         Seed: 243   Index:  32
+  Extra Steps: 12
+  Step  25: 8 / Zombie x4 (7.148s)
+  Step  33: 9 / Pike x2, EvilShel x2 (7.149s)
+Watery Pass-North B1F                                                         Seed: 243   Index:  65
+  Step  33: 10 / Zombie x4 (7.148s)
+  Step  48: 11 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 243   Index: 125
+Waterfalls B1F                                                                Seed: 243   Index: 134
+  Extra Steps: 76
+Waterfalls B2F                                                                Seed: 243   Index: 211
+Waterfalls Lake                                                               Seed:   4   Index:   0
+Battle: Octomamm                                                              Seed:   4   Index:  37
+Waterfalls Lake                                                               Seed:   4   Index:  37
+Overworld (Kaipo)                                                             Seed:   4   Index:  38
+Overworld (Damcyan)                                                           Seed:   4   Index:  49
+Damcyan                                                                       Seed:   4   Index:  53
+  Optional Steps: 1
+  Extra Steps: 86
+Overworld (Damcyan)                                                           Seed:   4   Index: 147
+Antlion B1F                                                                   Seed:   4   Index: 147
+  Step  35: 12 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed:   4   Index: 185
+  Antlion B2F                                                                 Seed:   4   Index: 185
+    Step  73: 13 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  21   Index:   9
+Battle: Antlion                                                               Seed:  21   Index:  23
+Antlion's Nest                                                                Seed:  21   Index:  23
+  Step   6: 14 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B2F Outward Direct                                                    Seed:  21   Index:  38
+  Antlion B2F                                                                 Seed:  21   Index:  38
+    Step  29: 15 / Basilisk x1, Imp x3 (6.783s)
+    Step  55: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  58: 17 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed:  21   Index: 118
+Overworld (Damcyan)                                                           Seed:  21   Index: 156
+Overworld (Kaipo)                                                             Seed:  21   Index: 156
+Kaipo Revisited                                                               Seed:  21   Index: 156
+Overworld (Kaipo)                                                             Seed:  21   Index: 156
+Overworld (Damcyan)                                                           Seed:  21   Index: 156
+Mt.Hobs-West                                                                  Seed:  21   Index: 156
+Mt.Hobs Summit                                                                Seed:  21   Index: 195
+Battle: MomBomb                                                               Seed:  21   Index: 210
+Mt.Hobs Summit                                                                Seed:  21   Index: 210
+Mt.Hobs-East                                                                  Seed:  21   Index: 216
+  Extra Steps: 2
+  Step   6: 18 / Gargoyle x2 (7.630s)
+  Step   8: 19 / Spirit x2, Skelton x2 (8.237s)
+  Step  35: 20 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:  38   Index:   8
+  Step  23: 21 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  65: 22 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  38   Index:  92
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  38   Index: 162
+Fabul Boat and Leviatan                                                       Seed:  38   Index: 169
+Overworld (Mysidia)                                                           Seed:  38   Index: 169
+Mysidia                                                                       Seed:  38   Index: 178
+Overworld (Mysidia)                                                           Seed:  38   Index: 178
+Overworld (Mt.Ordeals)                                                        Seed:  38   Index: 188
+  Step  32: 23 / Raven x1, Cocktric x3 (9.100s)
+  Step  53: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  83: 25 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  55   Index:  26
+  Step  27: 26 / Red Bone x1, Skelton x3 (8.067s)
+  Step  28: 27 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  55   Index:  69
+  Step  20: 28 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed:  55   Index:  92
+Mt.Ordeals-3rd station                                                        Seed:  55   Index:  92
+  Extra Steps: 2
+  Step   7: 29 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed:  55   Index:  99
+Mt.Ordeals Summit                                                             Seed:  55   Index: 141
+  Optional Steps: 1
+  Step   2: 30 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed:  55   Index: 159
+Mt.Ordeals Summit                                                             Seed:  55   Index: 159
+Paladin                                                                       Seed:  55   Index: 163
+Mt.Ordeals Summit                                                             Seed:  55   Index: 163
+  Optional Steps: 1
+  Step   4: 31 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  55   Index: 186
+Mt.Ordeals-3rd station                                                        Seed:  55   Index: 228
+  Step  18: 32 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:  72   Index:   2
+  Step  41: 33 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed:  72   Index:  46
+Take Chocobo to Mysidia                                                       Seed:  72   Index:  59
+Overworld (Mysidia)                                                           Seed:  72   Index:  59
+Town of Baron Serpent Road                                                    Seed:  72   Index:  59
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed:  72   Index:  71
+  Overworld (Baron)                                                           Seed:  72   Index:  71
+    Extra Steps: 6
+    Step   1: 34 / FloatEye x1, Eagle x2 (7.365s)
+    Step   6: 35 / Imp x4 (7.223s)
+   (Step  48: 36 / Eagle x3)
+   (Step  82: 37 / Imp x4)
+   (Step 160: 38 / Eagle x3)
+   (Step 176: 39 / Imp x3, SwordRat x1)
+   (Step 205: 40 / FloatEye x1, Eagle x2)
+   (Step 217: 41 / Imp x3)
+
+Encounter Time:      273.236s
+Other Time:          533.621s
+Total Time:          806.857s
+
+Base Total Time:     959.660s
+Time Saved:          152.803s
+
+Optional Steps:      13
+Extra Steps:         192
+Encounters:          35
+
+Base Encounters:     48
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/227.txt
+++ b/data/routes/cw/227.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	227
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49031387
+VARS	FFFFFFFF:6 C307801:1 E302500:86 E307400:88 E307B01:8 E308501:2 E308700:1 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed: 227   Index:   0
+Overworld (Kaipo)                                                             Seed: 227   Index:   1
+  Step   2: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 227   Index:  37
+Overworld (Kaipo)                                                             Seed: 227   Index:  37
+  Step  18: 2 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 227   Index:  69
+Recruit Tellah                                                                Seed: 227   Index: 101
+Watery Pass-South B1F                                                         Seed: 227   Index: 101
+Watery Pass-South B2F                                                         Seed: 227   Index: 121
+  Step  11: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  43: 4 / Pike x3 (7.152s)
+  Step  69: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  71: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 227   Index: 211
+Watery Pass-South B2F                                                         Seed: 227   Index: 215
+  Step  13: 7 / Zombie x4 (7.148s)
+Watery Pass-South B3F                                                         Seed: 227   Index: 254
+Watery Pass-North B2F                                                         Seed: 244   Index:  32
+Watery Pass-North B1F                                                         Seed: 244   Index:  53
+  Step   4: 8 / CaveToad x4 (7.163s)
+  Step  12: 9 / Jelly x4 (7.324s)
+  Step  60: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 244   Index: 113
+Waterfalls B1F                                                                Seed: 244   Index: 122
+  Extra Steps: 88
+Waterfalls B2F                                                                Seed: 244   Index: 211
+Waterfalls Lake                                                               Seed:   5   Index:   0
+Battle: Octomamm                                                              Seed:   5   Index:  37
+Waterfalls Lake                                                               Seed:   5   Index:  37
+Overworld (Kaipo)                                                             Seed:   5   Index:  38
+Overworld (Damcyan)                                                           Seed:   5   Index:  49
+Damcyan                                                                       Seed:   5   Index:  53
+  Optional Steps: 0
+  Extra Steps: 86
+Overworld (Damcyan)                                                           Seed:   5   Index: 146
+Antlion B1F                                                                   Seed:   5   Index: 146
+  Step  13: 11 / Turtle x1, Imp x2 (7.044s)
+  Step  36: 12 / Imp x3 (6.649s)
+Antlion B2F Inward Direct                                                     Seed:   5   Index: 184
+  Antlion B2F                                                                 Seed:   5   Index: 184
+    Step  74: 13 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  22   Index:   8
+Battle: Antlion                                                               Seed:  22   Index:  22
+Antlion's Nest                                                                Seed:  22   Index:  22
+Antlion B2F Outward Charm Room Steps                                          Seed:  22   Index:  37
+  Antlion B2F                                                                 Seed:  22   Index:  37
+    Step  30: 14 / Basilisk x1, Turtle x1 (7.124s)
+  Antlion B2F Treasure Room                                                   Seed:  22   Index:  88
+    Extra Steps: 8
+  Antlion B2F                                                                 Seed:  22   Index:  96
+Antlion B1F                                                                   Seed:  22   Index: 130
+Overworld (Damcyan)                                                           Seed:  22   Index: 168
+Overworld (Kaipo)                                                             Seed:  22   Index: 168
+Kaipo Revisited                                                               Seed:  22   Index: 168
+Overworld (Kaipo)                                                             Seed:  22   Index: 168
+Overworld (Damcyan)                                                           Seed:  22   Index: 168
+Mt.Hobs-West                                                                  Seed:  22   Index: 168
+  Step  38: 15 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed:  22   Index: 207
+  Step  15: 16 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed:  22   Index: 222
+Mt.Hobs Summit                                                                Seed:  22   Index: 222
+  Step   2: 17 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed:  22   Index: 228
+  Step  23: 18 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  39   Index:  18
+  Step  13: 19 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  55: 20 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  76: 21 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed:  39   Index: 102
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed:  39   Index: 162
+Fabul Boat and Leviatan                                                       Seed:  39   Index: 169
+Overworld (Mysidia)                                                           Seed:  39   Index: 169
+Mysidia                                                                       Seed:  39   Index: 178
+Overworld (Mysidia)                                                           Seed:  39   Index: 178
+Overworld (Mt.Ordeals)                                                        Seed:  39   Index: 188
+  Step  15: 22 / Raven x1 (8.356s)
+  Step  32: 23 / Raven x1, Cocktric x3 (9.100s)
+  Step  53: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  83: 25 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  56   Index:  26
+  Step  27: 26 / Red Bone x1, Skelton x3 (8.067s)
+  Step  28: 27 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  56   Index:  69
+  Step  20: 28 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed:  56   Index:  92
+Mt.Ordeals-3rd station                                                        Seed:  56   Index:  92
+  Extra Steps: 2
+  Step   7: 29 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed:  56   Index:  99
+Mt.Ordeals Summit                                                             Seed:  56   Index: 141
+  Optional Steps: 1
+  Step   2: 30 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed:  56   Index: 159
+Mt.Ordeals Summit                                                             Seed:  56   Index: 159
+Paladin                                                                       Seed:  56   Index: 163
+Mt.Ordeals Summit                                                             Seed:  56   Index: 163
+  Optional Steps: 1
+  Step   4: 31 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  56   Index: 186
+Mt.Ordeals-3rd station                                                        Seed:  56   Index: 228
+  Step  21: 32 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:  73   Index:   2
+  Step  41: 33 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed:  73   Index:  46
+Take Chocobo to Mysidia                                                       Seed:  73   Index:  59
+Overworld (Mysidia)                                                           Seed:  73   Index:  59
+Town of Baron Serpent Road                                                    Seed:  73   Index:  59
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed:  73   Index:  71
+  Overworld (Baron)                                                           Seed:  73   Index:  71
+    Extra Steps: 6
+    Step   1: 34 / FloatEye x1, Eagle x2 (7.365s)
+    Step   6: 35 / Imp x4 (7.223s)
+   (Step  48: 36 / Eagle x3)
+   (Step  56: 37 / Imp x3, SwordRat x1)
+   (Step  82: 38 / Eagle x3)
+   (Step 160: 39 / Imp x6)
+   (Step 176: 40 / FloatEye x1, Eagle x2)
+   (Step 205: 41 / Imp x3)
+   (Step 217: 42 / Imp x3)
+
+Encounter Time:      276.035s
+Other Time:          539.811s
+Total Time:          815.846s
+
+Base Total Time:     888.285s
+Time Saved:          72.439s
+
+Optional Steps:      2
+Extra Steps:         198
+Encounters:          35
+
+Base Encounters:     44
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/228.txt
+++ b/data/routes/cw/228.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	228
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48683968
+VARS	FFFFFFFF:6 C307800:1 E000600:30 E302500:12 E302600:10 E307400:72 E307B00:56 E308500:10 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 228   Index:   0
+Overworld (Kaipo)                                                             Seed: 228   Index:   1
+  Step   2: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 228   Index:  37
+Overworld (Kaipo)                                                             Seed: 228   Index:  37
+  Step  18: 2 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 228   Index:  69
+Recruit Tellah                                                                Seed: 228   Index: 101
+Watery Pass-South B1F                                                         Seed: 228   Index: 101
+Watery Pass-South B2F                                                         Seed: 228   Index: 121
+  Step  10: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  43: 4 / Pike x3 (7.152s)
+  Step  69: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  71: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 228   Index: 211
+Watery Pass-South B2F                                                         Seed: 228   Index: 215
+  Step  13: 7 / Zombie x4 (7.148s)
+Watery Pass-South B3F                                                         Seed: 228   Index: 254
+Watery Pass-North B2F                                                         Seed: 245   Index:  32
+Watery Pass-North B1F                                                         Seed: 245   Index:  53
+  Step   4: 8 / CaveToad x4 (7.163s)
+  Step  12: 9 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 245   Index: 113
+Waterfalls B1F                                                                Seed: 245   Index: 122
+  Extra Steps: 72
+Waterfalls B2F                                                                Seed: 245   Index: 195
+  Step  15: 10 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 245   Index: 240
+Battle: Octomamm                                                              Seed:   6   Index:  21
+Waterfalls Lake                                                               Seed:   6   Index:  21
+Overworld (Kaipo)                                                             Seed:   6   Index:  22
+Overworld (Damcyan)                                                           Seed:   6   Index:  33
+Damcyan                                                                       Seed:   6   Index:  37
+  Optional Steps: 0
+  Extra Steps: 12
+Overworld (Damcyan)                                                           Seed:   6   Index:  56
+Antlion B1F                                                                   Seed:   6   Index:  56
+  Step  25: 11 / Turtle x1, Imp x2 (7.044s)
+  Step  31: 12 / Imp x3 (6.649s)
+Antlion B2F Inward Charm Room Steps                                           Seed:   6   Index:  94
+  Antlion B2F                                                                 Seed:   6   Index:  94
+  Antlion B2F Treasure Room                                                   Seed:   6   Index: 127
+    Extra Steps: 56
+  Antlion B2F                                                                 Seed:   6   Index: 183
+Antlion's Nest                                                                Seed:   6   Index: 235
+Battle: Antlion                                                               Seed:   6   Index: 249
+Antlion's Nest                                                                Seed:   6   Index: 249
+  Step   9: 13 / Turtle x2 (7.464s)
+Antlion B2F Outward Direct                                                    Seed:  23   Index:   8
+  Antlion B2F                                                                 Seed:  23   Index:   8
+    Step  59: 14 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed:  23   Index:  88
+  Step   5: 15 / Imp x3, Imp Cap. x1 (6.753s)
+  Step   8: 16 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed:  23   Index: 126
+Overworld (Kaipo)                                                             Seed:  23   Index: 126
+Kaipo Revisited                                                               Seed:  23   Index: 126
+Overworld (Kaipo)                                                             Seed:  23   Index: 126
+Overworld (Damcyan)                                                           Seed:  23   Index: 126
+Mt.Hobs-West                                                                  Seed:  23   Index: 126
+Mt.Hobs Summit                                                                Seed:  23   Index: 165
+Battle: MomBomb                                                               Seed:  23   Index: 180
+Mt.Hobs Summit                                                                Seed:  23   Index: 180
+Mt.Hobs-East                                                                  Seed:  23   Index: 186
+  Step  20: 17 / Spirit x2, Skelton x2 (8.237s)
+  Step  38: 18 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed:  23   Index: 232
+  Step   7: 19 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  19: 20 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  55: 21 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed:  40   Index:  60
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  40   Index: 130
+Fabul Boat and Leviatan                                                       Seed:  40   Index: 137
+Overworld (Mysidia)                                                           Seed:  40   Index: 137
+Mysidia                                                                       Seed:  40   Index: 146
+Overworld (Mysidia)                                                           Seed:  40   Index: 146
+Overworld (Mt.Ordeals)                                                        Seed:  40   Index: 156
+  Extra Steps: 30
+  Step  47: 22 / Raven x1 (8.356s)
+  Step  64: 23 / Raven x1, Cocktric x3 (9.100s)
+  Step  85: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step 115: 25 / Imp Cap. x4, Imp x2 (8.344s)
+  Step 124: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  57   Index:  24
+  Step  29: 27 / Spirit x3, Soul x1 (8.687s)
+  Step  30: 28 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  57   Index:  67
+  Extra Steps: 10
+  Step  22: 29 / Ghoul x2, Soul x2 (9.357s)
+  Step  32: 30 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  57   Index: 100
+Mt.Ordeals-3rd station                                                        Seed:  57   Index: 100
+Mt.Ordeals-7th station                                                        Seed:  57   Index: 105
+  Step  38: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  57   Index: 147
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  57   Index: 165
+Mt.Ordeals Summit                                                             Seed:  57   Index: 165
+Paladin                                                                       Seed:  57   Index: 169
+Mt.Ordeals Summit                                                             Seed:  57   Index: 169
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  57   Index: 192
+Mt.Ordeals-3rd station                                                        Seed:  57   Index: 234
+  Step  15: 32 / Ghoul x2, Soul x2 (8.971s)
+  Step  23: 33 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed:  74   Index:   8
+Overworld (Mt.Ordeals)                                                        Seed:  74   Index:  52
+Take Chocobo to Mysidia                                                       Seed:  74   Index:  65
+Overworld (Mysidia)                                                           Seed:  74   Index:  65
+Town of Baron Serpent Road                                                    Seed:  74   Index:  65
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed:  74   Index:  71
+  Overworld (Baron)                                                           Seed:  74   Index:  71
+    Extra Steps: 6
+    Step   1: 34 / FloatEye x1, Eagle x2 (7.365s)
+    Step   6: 35 / Imp x4 (7.223s)
+   (Step  48: 36 / Eagle x3)
+   (Step  56: 37 / Imp x3, SwordRat x1)
+   (Step 160: 38 / Imp x4)
+   (Step 176: 39 / Imp x6)
+   (Step 205: 40 / FloatEye x1, Eagle x2)
+   (Step 217: 41 / Imp x3)
+
+Encounter Time:      272.917s
+Other Time:          537.149s
+Total Time:          810.065s
+
+Base Total Time:     965.337s
+Time Saved:          155.272s
+
+Optional Steps:      12
+Extra Steps:         188
+Encounters:          35
+
+Base Encounters:     48
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/229.txt
+++ b/data/routes/cw/229.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	229
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48331184
+VARS	FFFFFFFF:18 C307800:1 E302600:80 E307400:6 E307B00:8 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 229   Index:   0
+Overworld (Kaipo)                                                             Seed: 229   Index:   1
+  Step   2: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 229   Index:  37
+Overworld (Kaipo)                                                             Seed: 229   Index:  37
+  Step  18: 2 / Sandpede x1, Sand Man x2 (7.096s)
+Watery Pass-South B1F                                                         Seed: 229   Index:  69
+Recruit Tellah                                                                Seed: 229   Index: 101
+Watery Pass-South B1F                                                         Seed: 229   Index: 101
+Watery Pass-South B2F                                                         Seed: 229   Index: 121
+  Step  10: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  16: 4 / Pike x3 (7.152s)
+  Step  69: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  71: 6 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 229   Index: 211
+Watery Pass-South B2F                                                         Seed: 229   Index: 215
+  Step  13: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 229   Index: 254
+Watery Pass-North B2F                                                         Seed: 246   Index:  32
+Watery Pass-North B1F                                                         Seed: 246   Index:  53
+  Step   4: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  12: 9 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 246   Index: 113
+Waterfalls B1F                                                                Seed: 246   Index: 122
+  Extra Steps: 6
+Waterfalls B2F                                                                Seed: 246   Index: 129
+  Step  32: 10 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 246   Index: 174
+  Step   5: 11 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  20: 12 / Jelly x4 (7.324s)
+  Step  36: 13 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed: 246   Index: 211
+Waterfalls Lake                                                               Seed: 246   Index: 211
+Overworld (Kaipo)                                                             Seed: 246   Index: 212
+Overworld (Damcyan)                                                           Seed: 246   Index: 223
+Damcyan                                                                       Seed: 246   Index: 227
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 246   Index: 234
+Antlion B1F                                                                   Seed: 246   Index: 234
+Antlion B2F Inward Charm Room Steps                                           Seed:   7   Index:  16
+  Antlion B2F                                                                 Seed:   7   Index:  16
+  Antlion B2F Treasure Room                                                   Seed:   7   Index:  49
+    Extra Steps: 8
+  Antlion B2F                                                                 Seed:   7   Index:  57
+    Step  24: 14 / Basilisk x1, Turtle x1 (7.110s)
+    Step  30: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:   7   Index: 109
+Battle: Antlion                                                               Seed:   7   Index: 123
+Antlion's Nest                                                                Seed:   7   Index: 123
+Antlion B2F Outward Direct                                                    Seed:   7   Index: 138
+  Antlion B2F                                                                 Seed:   7   Index: 138
+    Step   8: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  21: 17 / Cream x4 (7.523s)
+    Step  44: 18 / Turtle x2 (7.464s)
+    Step  45: 19 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed:   7   Index: 218
+  Step   5: 20 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  24   Index:   0
+Overworld (Kaipo)                                                             Seed:  24   Index:   0
+Kaipo Revisited                                                               Seed:  24   Index:   0
+Overworld (Kaipo)                                                             Seed:  24   Index:   0
+Overworld (Damcyan)                                                           Seed:  24   Index:   0
+Mt.Hobs-West                                                                  Seed:  24   Index:   0
+Mt.Hobs Summit                                                                Seed:  24   Index:  39
+Battle: MomBomb                                                               Seed:  24   Index:  54
+Mt.Hobs Summit                                                                Seed:  24   Index:  54
+Mt.Hobs-East                                                                  Seed:  24   Index:  60
+  Step   7: 21 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  33: 22 / Spirit x2, Skelton x2 (8.237s)
+  Step  36: 23 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  24   Index: 106
+Fabul                                                                         Seed:  24   Index: 190
+  Optional Steps: 10
+  Extra Steps: 70
+Overworld (Fabul)                                                             Seed:  41   Index:  74
+Fabul Boat and Leviatan                                                       Seed:  41   Index:  81
+Overworld (Mysidia)                                                           Seed:  41   Index:  81
+Mysidia                                                                       Seed:  41   Index:  90
+Overworld (Mysidia)                                                           Seed:  41   Index:  90
+  Step   4: 24 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Overworld (Mt.Ordeals)                                                        Seed:  41   Index: 100
+  Step  21: 25 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  23: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  25: 27 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  41: 28 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  41   Index: 194
+  Step   9: 29 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  41   Index: 237
+Recruit Tellah                                                                Seed:  58   Index:   4
+Mt.Ordeals-3rd station                                                        Seed:  58   Index:   4
+Mt.Ordeals-7th station                                                        Seed:  58   Index:   9
+  Step   6: 30 / Lilith x1, Red Bone x2 (8.912s)
+  Step  15: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  58   Index:  51
+  Optional Steps: 1
+  Step   2: 32 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed:  58   Index:  69
+Mt.Ordeals Summit                                                             Seed:  58   Index:  69
+Paladin                                                                       Seed:  58   Index:  73
+Mt.Ordeals Summit                                                             Seed:  58   Index:  73
+  Optional Steps: 1
+  Step  16: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed:  58   Index:  96
+  Step   3: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  58   Index: 138
+  Step   5: 35 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed:  58   Index: 168
+Overworld (Mt.Ordeals)                                                        Seed:  58   Index: 212
+Take Chocobo to Mysidia                                                       Seed:  58   Index: 225
+Overworld (Mysidia)                                                           Seed:  58   Index: 225
+Town of Baron Serpent Road                                                    Seed:  58   Index: 225
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed:  58   Index: 231
+  Overworld (Baron)                                                           Seed:  58   Index: 231
+    Extra Steps: 18
+    Step   1: 36 / Eagle x3 (7.417s)
+    Step  18: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step  26: 38 / Imp x4)
+   (Step  73: 39 / Imp x3)
+   (Step  97: 40 / FloatEye x1, Eagle x2)
+   (Step 102: 41 / Imp x3)
+   (Step 152: 42 / Imp x3)
+   (Step 256: 43 / Imp x3)
+
+Encounter Time:      286.215s
+Other Time:          517.980s
+Total Time:          804.195s
+
+Base Total Time:     880.815s
+Time Saved:          76.620s
+
+Optional Steps:      12
+Extra Steps:         104
+Encounters:          37
+
+Base Encounters:     44
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/230.txt
+++ b/data/routes/cw/230.txt
@@ -1,0 +1,147 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	230
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48286471
+VARS	FFFFFFFF:10 E000401:1 E302500:21 E302600:10 E307400:88
+
+Overworld (Kaipo)                                                             Seed: 230   Index:   0
+Overworld (Kaipo)                                                             Seed: 230   Index:   1
+  Step   2: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 230   Index:  37
+Overworld (Kaipo)                                                             Seed: 230   Index:  37
+  Step  18: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 230   Index:  69
+Recruit Tellah                                                                Seed: 230   Index: 101
+Watery Pass-South B1F                                                         Seed: 230   Index: 101
+Watery Pass-South B2F                                                         Seed: 230   Index: 121
+  Step  10: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  16: 4 / Pike x3 (7.152s)
+  Step  42: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  69: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  71: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 230   Index: 211
+Watery Pass-South B2F                                                         Seed: 230   Index: 215
+  Step  13: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 230   Index: 254
+Watery Pass-North B2F                                                         Seed: 247   Index:  32
+Watery Pass-North B1F                                                         Seed: 247   Index:  53
+  Step   4: 9 / Jelly x4 (7.324s)
+  Step  12: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 247   Index: 113
+Waterfalls B1F                                                                Seed: 247   Index: 122
+  Extra Steps: 88
+Waterfalls B2F                                                                Seed: 247   Index: 211
+Waterfalls Lake                                                               Seed:   8   Index:   0
+Battle: Octomamm                                                              Seed:   8   Index:  37
+Waterfalls Lake                                                               Seed:   8   Index:  37
+Overworld (Kaipo)                                                             Seed:   8   Index:  38
+Overworld (Damcyan)                                                           Seed:   8   Index:  49
+Damcyan                                                                       Seed:   8   Index:  53
+  Optional Steps: 1
+  Extra Steps: 20
+Overworld (Damcyan)                                                           Seed:   8   Index:  81
+Antlion B1F                                                                   Seed:   8   Index:  81
+Antlion B2F Inward Direct                                                     Seed:   8   Index: 119
+  Antlion B2F                                                                 Seed:   8   Index: 119
+    Step  27: 11 / Turtle x2 (7.487s)
+    Step  40: 12 / Cream x4 (7.552s)
+    Step  63: 13 / Turtle x2 (7.487s)
+    Step  64: 14 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:   8   Index: 199
+Battle: Antlion                                                               Seed:   8   Index: 213
+Antlion's Nest                                                                Seed:   8   Index: 213
+  Step  10: 15 / Basilisk x1, Imp x3 (6.783s)
+Antlion B2F Outward Direct                                                    Seed:   8   Index: 228
+  Antlion B2F                                                                 Seed:   8   Index: 228
+    Step  27: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  80: 17 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  25   Index:  52
+  Step  15: 18 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  25   Index:  90
+Overworld (Kaipo)                                                             Seed:  25   Index:  90
+Kaipo Revisited                                                               Seed:  25   Index:  90
+Overworld (Kaipo)                                                             Seed:  25   Index:  90
+Overworld (Damcyan)                                                           Seed:  25   Index:  90
+Mt.Hobs-West                                                                  Seed:  25   Index:  90
+  Step   6: 19 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  25   Index: 129
+Battle: MomBomb                                                               Seed:  25   Index: 144
+Mt.Hobs Summit                                                                Seed:  25   Index: 144
+Mt.Hobs-East                                                                  Seed:  25   Index: 150
+Overworld (Fabul)                                                             Seed:  25   Index: 196
+  Step  10: 20 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  28: 21 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  43: 22 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  55: 23 / SwordRat x3, Needler x3 (7.663s)
+  Step  57: 24 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed:  42   Index:  24
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  42   Index:  94
+  Extra Steps: 1
+Fabul Boat and Leviatan                                                       Seed:  42   Index: 102
+Overworld (Mysidia)                                                           Seed:  42   Index: 102
+Mysidia                                                                       Seed:  42   Index: 111
+Overworld (Mysidia)                                                           Seed:  42   Index: 111
+Overworld (Mt.Ordeals)                                                        Seed:  42   Index: 121
+  Step   2: 25 / Imp Cap. x4, Imp x2 (8.344s)
+  Step   4: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  82: 27 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  42   Index: 215
+  Step  21: 28 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  59   Index:   2
+  Step  13: 29 / Ghoul x2, Soul x2 (9.357s)
+  Step  22: 30 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  59   Index:  25
+Mt.Ordeals-3rd station                                                        Seed:  59   Index:  25
+Mt.Ordeals-7th station                                                        Seed:  59   Index:  30
+  Step  23: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  59   Index:  72
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed:  59   Index:  89
+Mt.Ordeals Summit                                                             Seed:  59   Index:  89
+Paladin                                                                       Seed:  59   Index:  93
+Mt.Ordeals Summit                                                             Seed:  59   Index:  93
+  Optional Steps: 0
+  Step   6: 32 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  59   Index: 115
+  Step   9: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  28: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  59   Index: 157
+Mt.Ordeals                                                                    Seed:  59   Index: 187
+Overworld (Mt.Ordeals)                                                        Seed:  59   Index: 231
+  Step   1: 35 / Needler x2, SwordRat x2 (8.094s)
+Take Chocobo to Mysidia                                                       Seed:  59   Index: 244
+Overworld (Mysidia)                                                           Seed:  59   Index: 244
+Town of Baron Serpent Road                                                    Seed:  59   Index: 244
+Credit Warp Fight Search                                                      Seed:  59   Index: 248
+  Overworld (Baron)                                                           Seed:  59   Index: 248
+    Extra Steps: 10
+    Step   1: 36 / Eagle x3 (7.417s)
+    Step   9: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step  56: 38 / Imp x4)
+   (Step  80: 39 / Imp x3)
+   (Step  85: 40 / FloatEye x1, Eagle x2)
+   (Step 126: 41 / Imp x3)
+   (Step 135: 42 / Imp x3)
+   (Step 255: 43 / Imp x3)
+
+Encounter Time:      287.934s
+Other Time:          515.518s
+Total Time:          803.451s
+
+Base Total Time:     947.492s
+Time Saved:          144.040s
+
+Optional Steps:      11
+Extra Steps:         119
+Encounters:          37
+
+Base Encounters:     48
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/231.txt
+++ b/data/routes/cw/231.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	231
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48382715
+VARS	FFFFFFFF:10 C307801:1 E000201:2 E000500:4 E302600:72 E307400:6 E307B01:6 E307F01:8 E308700:1 E308702:1 E309700:14
+
+Overworld (Kaipo)                                                             Seed: 231   Index:   0
+Overworld (Kaipo)                                                             Seed: 231   Index:   1
+  Step   2: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 231   Index:  37
+Overworld (Kaipo)                                                             Seed: 231   Index:  37
+Watery Pass-South B1F                                                         Seed: 231   Index:  69
+Recruit Tellah                                                                Seed: 231   Index: 101
+Watery Pass-South B1F                                                         Seed: 231   Index: 101
+Watery Pass-South B2F                                                         Seed: 231   Index: 121
+  Step  10: 2 / Pike x2, EvilShel x2 (7.149s)
+  Step  16: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  29: 4 / Zombie x4 (7.148s)
+  Step  42: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  69: 6 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  71: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 231   Index: 211
+Watery Pass-South B2F                                                         Seed: 231   Index: 215
+Watery Pass-South B3F                                                         Seed: 231   Index: 254
+Watery Pass-North B2F                                                         Seed: 248   Index:  32
+Watery Pass-North B1F                                                         Seed: 248   Index:  53
+  Step   4: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  12: 9 / Jelly x4 (7.324s)
+Overworld (Kaipo)                                                             Seed: 248   Index: 113
+Waterfalls B1F                                                                Seed: 248   Index: 122
+  Extra Steps: 6
+Waterfalls B2F                                                                Seed: 248   Index: 129
+  Step  32: 10 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 248   Index: 174
+  Step   5: 11 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  19: 12 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 248   Index: 211
+Waterfalls Lake                                                               Seed: 248   Index: 211
+Overworld (Kaipo)                                                             Seed: 248   Index: 212
+  Extra Steps: 2
+  Step  13: 13 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed: 248   Index: 225
+Damcyan                                                                       Seed: 248   Index: 229
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed: 248   Index: 236
+Antlion B1F                                                                   Seed: 248   Index: 236
+Antlion B2F Inward Direct                                                     Seed:   9   Index:  18
+  Antlion B2F                                                                 Seed:   9   Index:  18
+    Step  17: 14 / Basilisk x1, Turtle x1 (7.110s)
+    Step  63: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:   9   Index:  98
+Battle: Antlion                                                               Seed:   9   Index: 112
+Antlion's Nest                                                                Seed:   9   Index: 112
+Antlion B2F Outward Charm Room Steps                                          Seed:   9   Index: 127
+  Antlion B2F                                                                 Seed:   9   Index: 127
+    Step  19: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  32: 17 / Basilisk x1, Imp x3 (6.783s)
+  Antlion B2F Treasure Room                                                   Seed:   9   Index: 178
+    Extra Steps: 6
+  Antlion B2F                                                                 Seed:   9   Index: 184
+Antlion B1F                                                                   Seed:   9   Index: 218
+  Step   5: 18 / Turtle x1, Imp x2 (7.009s)
+  Step  37: 19 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  26   Index:   0
+Overworld (Kaipo)                                                             Seed:  26   Index:   0
+Kaipo Revisited                                                               Seed:  26   Index:   0
+Overworld (Kaipo)                                                             Seed:  26   Index:   0
+Overworld (Damcyan)                                                           Seed:  26   Index:   0
+Mt.Hobs-West                                                                  Seed:  26   Index:   0
+Mt.Hobs Summit                                                                Seed:  26   Index:  39
+  Step  13: 20 / Gargoyle x1, Cocktric x2 (9.399s)
+Battle: MomBomb                                                               Seed:  26   Index:  54
+Mt.Hobs Summit                                                                Seed:  26   Index:  54
+  Extra Steps: 8
+  Step   6: 21 / GrayBomb x2, Bomb x2 (8.430s)
+  Step  13: 22 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed:  26   Index:  68
+  Step  28: 23 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  26   Index: 114
+Fabul                                                                         Seed:  26   Index: 198
+  Optional Steps: 10
+  Extra Steps: 62
+Overworld (Fabul)                                                             Seed:  43   Index:  74
+Fabul Boat and Leviatan                                                       Seed:  43   Index:  81
+Overworld (Mysidia)                                                           Seed:  43   Index:  81
+  Extra Steps: 4
+  Step  13: 24 / Imp Cap. x3, Needler x1 (7.821s)
+Mysidia                                                                       Seed:  43   Index:  94
+Overworld (Mysidia)                                                           Seed:  43   Index:  94
+Overworld (Mt.Ordeals)                                                        Seed:  43   Index: 104
+  Step  17: 25 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  19: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  21: 27 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  43   Index: 198
+  Step   5: 28 / Spirit x3, Soul x1 (8.687s)
+  Step  38: 29 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  43   Index: 241
+Recruit Tellah                                                                Seed:  60   Index:   8
+Mt.Ordeals-3rd station                                                        Seed:  60   Index:   8
+Mt.Ordeals-7th station                                                        Seed:  60   Index:  13
+  Step   2: 30 / Lilith x1, Red Bone x2 (8.912s)
+  Step  11: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  40: 32 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  60   Index:  55
+  Optional Steps: 1
+  Step  13: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed:  60   Index:  73
+Mt.Ordeals Summit                                                             Seed:  60   Index:  73
+Paladin                                                                       Seed:  60   Index:  77
+Mt.Ordeals Summit                                                             Seed:  60   Index:  77
+  Optional Steps: 1
+  Step  22: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed:  60   Index: 100
+  Step  24: 35 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed:  60   Index: 142
+Mt.Ordeals                                                                    Seed:  60   Index: 172
+Overworld (Mt.Ordeals)                                                        Seed:  60   Index: 216
+Take Chocobo to Mysidia                                                       Seed:  60   Index: 229
+Overworld (Mysidia)                                                           Seed:  60   Index: 229
+Town of Baron Serpent Road                                                    Seed:  60   Index: 229
+  Extra Steps: 14
+Credit Warp Fight Search                                                      Seed:  60   Index: 247
+  Overworld (Baron)                                                           Seed:  60   Index: 247
+    Extra Steps: 10
+    Step   2: 36 / Eagle x3 (7.417s)
+    Step  10: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step  57: 38 / Imp x4)
+   (Step  86: 39 / Imp x3)
+   (Step 127: 40 / FloatEye x1, Eagle x2)
+   (Step 136: 41 / Imp x3)
+   (Step 204: 42 / Imp x3)
+   (Step 256: 43 / Imp x3)
+
+Encounter Time:      287.072s
+Other Time:          517.980s
+Total Time:          805.053s
+
+Base Total Time:     925.867s
+Time Saved:          120.814s
+
+Optional Steps:      12
+Extra Steps:         112
+Encounters:          37
+
+Base Encounters:     48
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/232.txt
+++ b/data/routes/cw/232.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	232
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48359428
+VARS	FFFFFFFF:10 E000501:4 E302500:3 E302600:68 E307000:2 E307400:36 E307F01:10 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed: 232   Index:   0
+Overworld (Kaipo)                                                             Seed: 232   Index:   1
+  Step   2: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 232   Index:  37
+Overworld (Kaipo)                                                             Seed: 232   Index:  37
+Watery Pass-South B1F                                                         Seed: 232   Index:  69
+Recruit Tellah                                                                Seed: 232   Index: 101
+Watery Pass-South B1F                                                         Seed: 232   Index: 101
+Watery Pass-South B2F                                                         Seed: 232   Index: 121
+  Step  10: 2 / Pike x2, EvilShel x2 (7.149s)
+  Step  16: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  29: 4 / Zombie x4 (7.148s)
+  Step  42: 5 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  69: 6 / Pike x3 (7.152s)
+  Step  71: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 232   Index: 211
+Watery Pass-South B2F                                                         Seed: 232   Index: 215
+  Extra Steps: 2
+  Step  12: 8 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  41: 9 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed: 249   Index:   0
+Watery Pass-North B2F                                                         Seed: 249   Index:  34
+Watery Pass-North B1F                                                         Seed: 249   Index:  55
+  Step  10: 10 / Zombie x4 (7.148s)
+Overworld (Kaipo)                                                             Seed: 249   Index: 115
+Waterfalls B1F                                                                Seed: 249   Index: 124
+  Extra Steps: 36
+Waterfalls B2F                                                                Seed: 249   Index: 161
+  Step  18: 11 / Zombie x6 (7.489s)
+  Step  32: 12 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed: 249   Index: 206
+  Step  19: 13 / TinyMage x2, WaterHag x4 (8.120s)
+Battle: Octomamm                                                              Seed: 249   Index: 243
+Waterfalls Lake                                                               Seed: 249   Index: 243
+Overworld (Kaipo)                                                             Seed: 249   Index: 244
+Overworld (Damcyan)                                                           Seed: 249   Index: 255
+Damcyan                                                                       Seed:  10   Index:   3
+  Optional Steps: 1
+  Extra Steps: 2
+Overworld (Damcyan)                                                           Seed:  10   Index:  13
+Antlion B1F                                                                   Seed:  10   Index:  13
+  Step  22: 14 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Direct                                                     Seed:  10   Index:  51
+  Antlion B2F                                                                 Seed:  10   Index:  51
+    Step  30: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:  10   Index: 131
+Battle: Antlion                                                               Seed:  10   Index: 145
+Antlion's Nest                                                                Seed:  10   Index: 145
+  Step  14: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed:  10   Index: 160
+  Antlion B2F                                                                 Seed:  10   Index: 160
+    Step  22: 17 / Basilisk x1, Imp x3 (6.783s)
+    Step  23: 18 / Turtle x2 (7.464s)
+    Step  63: 19 / Cream x4 (7.523s)
+Antlion B1F                                                                   Seed:  10   Index: 240
+  Step  15: 20 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  27   Index:  22
+Overworld (Kaipo)                                                             Seed:  27   Index:  22
+Kaipo Revisited                                                               Seed:  27   Index:  22
+Overworld (Kaipo)                                                             Seed:  27   Index:  22
+Overworld (Damcyan)                                                           Seed:  27   Index:  22
+Mt.Hobs-West                                                                  Seed:  27   Index:  22
+  Step  30: 21 / Gargoyle x1, Cocktric x2 (9.399s)
+  Step  38: 22 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  27   Index:  61
+Battle: MomBomb                                                               Seed:  27   Index:  76
+Mt.Hobs Summit                                                                Seed:  27   Index:  76
+  Extra Steps: 10
+  Step  16: 23 / Spirit x3, Skelton x2, Red Bone x1 (9.099s)
+Mt.Hobs-East                                                                  Seed:  27   Index:  92
+  Step   4: 24 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed:  27   Index: 138
+  Step  68: 25 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  27   Index: 222
+  Optional Steps: 10
+  Extra Steps: 58
+Overworld (Fabul)                                                             Seed:  44   Index:  94
+Fabul Boat and Leviatan                                                       Seed:  44   Index: 101
+Overworld (Mysidia)                                                           Seed:  44   Index: 101
+Mysidia                                                                       Seed:  44   Index: 110
+Overworld (Mysidia)                                                           Seed:  44   Index: 110
+  Extra Steps: 4
+Overworld (Mt.Ordeals)                                                        Seed:  44   Index: 124
+  Step   1: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  79: 27 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  44   Index: 218
+  Step  18: 28 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  61   Index:   5
+  Step  19: 29 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed:  61   Index:  28
+Mt.Ordeals-3rd station                                                        Seed:  61   Index:  28
+Mt.Ordeals-7th station                                                        Seed:  61   Index:  33
+  Step  20: 30 / Lilith x1, Red Bone x2 (8.912s)
+  Step  35: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  61   Index:  75
+  Optional Steps: 0
+  Step   3: 32 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed:  61   Index:  92
+Mt.Ordeals Summit                                                             Seed:  61   Index:  92
+Paladin                                                                       Seed:  61   Index:  96
+Mt.Ordeals Summit                                                             Seed:  61   Index:  96
+  Optional Steps: 1
+  Step   3: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed:  61   Index: 119
+  Step   5: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  61   Index: 161
+Mt.Ordeals                                                                    Seed:  61   Index: 191
+  Step  41: 35 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  61   Index: 235
+Take Chocobo to Mysidia                                                       Seed:  61   Index: 248
+Overworld (Mysidia)                                                           Seed:  61   Index: 248
+Town of Baron Serpent Road                                                    Seed:  61   Index: 248
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed:  78   Index:   0
+  Overworld (Baron)                                                           Seed:  78   Index:   0
+    Extra Steps: 10
+    Step   1: 36 / Eagle x3 (7.417s)
+    Step  10: 37 / Imp x3, SwordRat x1 (7.227s)
+   (Step  48: 38 / Imp x4)
+   (Step 118: 39 / Imp x3)
+   (Step 127: 40 / FloatEye x1, Eagle x2)
+   (Step 195: 41 / Imp x3)
+   (Step 247: 42 / Imp x3)
+
+Encounter Time:      287.550s
+Other Time:          517.115s
+Total Time:          804.665s
+
+Base Total Time:     925.089s
+Time Saved:          120.424s
+
+Optional Steps:      12
+Extra Steps:         126
+Encounters:          37
+
+Base Encounters:     48
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/233.txt
+++ b/data/routes/cw/233.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	233
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47769533
+VARS	FFFFFFFF:18 E302500:5 E302600:36 E305400:42 E307300:6 E307400:10 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 233   Index:   0
+Overworld (Kaipo)                                                             Seed: 233   Index:   1
+Kaipo                                                                         Seed: 233   Index:  37
+Overworld (Kaipo)                                                             Seed: 233   Index:  37
+Watery Pass-South B1F                                                         Seed: 233   Index:  69
+Recruit Tellah                                                                Seed: 233   Index: 101
+Watery Pass-South B1F                                                         Seed: 233   Index: 101
+Watery Pass-South B2F                                                         Seed: 233   Index: 121
+  Step  10: 1 / Pike x3 (7.152s)
+  Step  16: 2 / Pike x2, EvilShel x2 (7.149s)
+  Step  29: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  42: 4 / Zombie x4 (7.148s)
+  Step  69: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 233   Index: 211
+  Extra Steps: 42
+Watery Pass-South B2F                                                         Seed: 250   Index:   1
+Watery Pass-South B3F                                                         Seed: 250   Index:  40
+Watery Pass-North B2F                                                         Seed: 250   Index:  74
+Watery Pass-North B1F                                                         Seed: 250   Index:  95
+  Extra Steps: 6
+  Step  31: 6 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  34: 7 / Zombie x4 (7.148s)
+  Step  66: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 250   Index: 161
+Waterfalls B1F                                                                Seed: 250   Index: 170
+  Extra Steps: 10
+Waterfalls B2F                                                                Seed: 250   Index: 181
+  Step  12: 9 / TinyMage x2, WaterHag x4 (8.120s)
+  Step  44: 10 / Jelly x4 (7.324s)
+Waterfalls Lake                                                               Seed: 250   Index: 226
+Battle: Octomamm                                                              Seed:  11   Index:   7
+Waterfalls Lake                                                               Seed:  11   Index:   7
+Overworld (Kaipo)                                                             Seed:  11   Index:   8
+  Step   5: 11 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed:  11   Index:  19
+Damcyan                                                                       Seed:  11   Index:  23
+  Optional Steps: 1
+  Extra Steps: 4
+Overworld (Damcyan)                                                           Seed:  11   Index:  35
+Antlion B1F                                                                   Seed:  11   Index:  35
+Antlion B2F Inward Direct                                                     Seed:  11   Index:  73
+  Antlion B2F                                                                 Seed:  11   Index:  73
+    Step   8: 12 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:  11   Index: 153
+  Step   6: 13 / Turtle x2 (7.487s)
+Battle: Antlion                                                               Seed:  11   Index: 167
+Antlion's Nest                                                                Seed:  11   Index: 167
+Antlion B2F Outward Direct                                                    Seed:  11   Index: 182
+  Antlion B2F                                                                 Seed:  11   Index: 182
+    Step   1: 14 / Basilisk x1, Turtle x1 (7.124s)
+    Step  30: 15 / Basilisk x1, Imp x3 (6.783s)
+    Step  41: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  73: 17 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  28   Index:   6
+Overworld (Damcyan)                                                           Seed:  28   Index:  44
+Overworld (Kaipo)                                                             Seed:  28   Index:  44
+Kaipo Revisited                                                               Seed:  28   Index:  44
+Overworld (Kaipo)                                                             Seed:  28   Index:  44
+Overworld (Damcyan)                                                           Seed:  28   Index:  44
+Mt.Hobs-West                                                                  Seed:  28   Index:  44
+  Step   8: 18 / Gargoyle x1, Cocktric x2 (9.399s)
+  Step  16: 19 / Skelton x4 (8.683s)
+  Step  25: 20 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  28   Index:  83
+  Step   9: 21 / GrayBomb x2, Bomb x2 (10.938s)
+  Step  13: 22 / Gargoyle x1, Cocktric x2 (9.399s)
+Battle: MomBomb                                                               Seed:  28   Index:  98
+Mt.Hobs Summit                                                                Seed:  28   Index:  98
+Mt.Hobs-East                                                                  Seed:  28   Index: 104
+Overworld (Fabul)                                                             Seed:  28   Index: 150
+  Step  56: 23 / SwordRat x3, Needler x3 (7.663s)
+Fabul                                                                         Seed:  28   Index: 234
+  Optional Steps: 10
+  Extra Steps: 26
+Overworld (Fabul)                                                             Seed:  45   Index:  74
+Fabul Boat and Leviatan                                                       Seed:  45   Index:  81
+Overworld (Mysidia)                                                           Seed:  45   Index:  81
+Mysidia                                                                       Seed:  45   Index:  90
+Overworld (Mysidia)                                                           Seed:  45   Index:  90
+Overworld (Mt.Ordeals)                                                        Seed:  45   Index: 100
+  Step  23: 24 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  25: 25 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  45   Index: 194
+  Step   9: 26 / Red Bone x1, Skelton x3 (8.067s)
+  Step  42: 27 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  45   Index: 237
+Recruit Tellah                                                                Seed:  62   Index:   4
+Mt.Ordeals-3rd station                                                        Seed:  62   Index:   4
+Mt.Ordeals-7th station                                                        Seed:  62   Index:   9
+  Step  15: 28 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  19: 29 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  62   Index:  51
+  Optional Steps: 1
+  Step  17: 30 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed:  62   Index:  69
+Mt.Ordeals Summit                                                             Seed:  62   Index:  69
+Paladin                                                                       Seed:  62   Index:  73
+Mt.Ordeals Summit                                                             Seed:  62   Index:  73
+  Optional Steps: 1
+  Step   5: 31 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  62   Index:  96
+  Step   3: 32 / Lilith x1, Red Bone x2 (8.437s)
+  Step  28: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  62   Index: 138
+Mt.Ordeals                                                                    Seed:  62   Index: 168
+Overworld (Mt.Ordeals)                                                        Seed:  62   Index: 212
+Take Chocobo to Mysidia                                                       Seed:  62   Index: 225
+Overworld (Mysidia)                                                           Seed:  62   Index: 225
+Town of Baron Serpent Road                                                    Seed:  62   Index: 225
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed:  62   Index: 231
+  Overworld (Baron)                                                           Seed:  62   Index: 231
+    Extra Steps: 18
+    Step   1: 34 / FloatEye x1, Eagle x2 (7.365s)
+    Step  18: 35 / Imp x4 (7.223s)
+   (Step  26: 36 / Eagle x3)
+   (Step  35: 37 / Imp x3, SwordRat x1)
+   (Step  73: 38 / Imp x4)
+   (Step 143: 39 / Imp x3)
+   (Step 152: 40 / FloatEye x1, Eagle x2)
+   (Step 220: 41 / Imp x3)
+   (Step 254: 42 / Imp x3)
+
+Encounter Time:      280.397s
+Other Time:          514.453s
+Total Time:          794.850s
+
+Base Total Time:     929.507s
+Time Saved:          134.657s
+
+Optional Steps:      13
+Extra Steps:         108
+Encounters:          35
+
+Base Encounters:     48
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/234.txt
+++ b/data/routes/cw/234.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	234
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47867763
+VARS	FFFFFFFF:10 C307801:1 E000501:8 E302500:3 E302600:28 E307000:2 E307400:36 E307B01:12 E308400:4 E308700:1 E308702:1 E309700:28
+
+Overworld (Kaipo)                                                             Seed: 234   Index:   0
+Overworld (Kaipo)                                                             Seed: 234   Index:   1
+  Step  33: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 234   Index:  37
+Overworld (Kaipo)                                                             Seed: 234   Index:  37
+Watery Pass-South B1F                                                         Seed: 234   Index:  69
+Recruit Tellah                                                                Seed: 234   Index: 101
+Watery Pass-South B1F                                                         Seed: 234   Index: 101
+Watery Pass-South B2F                                                         Seed: 234   Index: 121
+  Step  10: 2 / Pike x2, EvilShel x2 (7.149s)
+  Step  16: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  29: 4 / Zombie x4 (7.148s)
+  Step  42: 5 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 234   Index: 211
+Watery Pass-South B2F                                                         Seed: 234   Index: 215
+  Extra Steps: 2
+  Step  12: 6 / Pike x3 (7.152s)
+  Step  39: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  41: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 251   Index:   0
+Watery Pass-North B2F                                                         Seed: 251   Index:  34
+Watery Pass-North B1F                                                         Seed: 251   Index:  55
+  Step  42: 9 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 251   Index: 115
+Waterfalls B1F                                                                Seed: 251   Index: 124
+  Extra Steps: 36
+Waterfalls B2F                                                                Seed: 251   Index: 161
+  Step  19: 10 / Jelly x4 (7.324s)
+  Step  32: 11 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 251   Index: 206
+  Step  19: 12 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 251   Index: 243
+Waterfalls Lake                                                               Seed: 251   Index: 243
+Overworld (Kaipo)                                                             Seed: 251   Index: 244
+Overworld (Damcyan)                                                           Seed: 251   Index: 255
+Damcyan                                                                       Seed:  12   Index:   3
+  Optional Steps: 1
+  Extra Steps: 2
+Overworld (Damcyan)                                                           Seed:  12   Index:  13
+Antlion B1F                                                                   Seed:  12   Index:  13
+  Step  22: 13 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  12   Index:  51
+  Antlion B2F                                                                 Seed:  12   Index:  51
+    Step  13: 14 / Basilisk x1, Turtle x1 (7.110s)
+Antlion's Nest                                                                Seed:  12   Index: 131
+Battle: Antlion                                                               Seed:  12   Index: 145
+Antlion's Nest                                                                Seed:  12   Index: 145
+  Step  14: 15 / Basilisk x1, Imp x3 (6.783s)
+Antlion B2F Outward Charm Room Steps                                          Seed:  12   Index: 160
+  Antlion B2F                                                                 Seed:  12   Index: 160
+    Step  23: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Antlion B2F Treasure Room                                                   Seed:  12   Index: 211
+    Extra Steps: 12
+  Antlion B2F                                                                 Seed:  12   Index: 223
+    Step  32: 17 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  29   Index:   1
+  Step   6: 18 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  29   Index:  39
+Overworld (Kaipo)                                                             Seed:  29   Index:  39
+Kaipo Revisited                                                               Seed:  29   Index:  39
+Overworld (Kaipo)                                                             Seed:  29   Index:  39
+Overworld (Damcyan)                                                           Seed:  29   Index:  39
+Mt.Hobs-West                                                                  Seed:  29   Index:  39
+  Step  13: 19 / Skelton x4 (8.683s)
+  Step  21: 20 / Skelton x4 (8.683s)
+  Step  30: 21 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed:  29   Index:  78
+  Step  14: 22 / Gargoyle x1, Cocktric x2 (9.399s)
+Battle: MomBomb                                                               Seed:  29   Index:  93
+Mt.Hobs Summit                                                                Seed:  29   Index:  93
+Mt.Hobs-East                                                                  Seed:  29   Index:  99
+Overworld (Fabul)                                                             Seed:  29   Index: 145
+  Step  61: 23 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  29   Index: 229
+  Optional Steps: 10
+  Extra Steps: 18
+Overworld (Fabul)                                                             Seed:  46   Index:  61
+Fabul Boat and Leviatan                                                       Seed:  46   Index:  68
+Overworld (Mysidia)                                                           Seed:  46   Index:  68
+Mysidia                                                                       Seed:  46   Index:  77
+Overworld (Mysidia)                                                           Seed:  46   Index:  77
+  Extra Steps: 8
+Overworld (Mt.Ordeals)                                                        Seed:  46   Index:  95
+  Step  30: 24 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  91: 25 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  46   Index: 189
+  Extra Steps: 4
+  Step  14: 26 / Red Bone x1, Skelton x3 (8.067s)
+  Step  47: 27 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  46   Index: 236
+Recruit Tellah                                                                Seed:  63   Index:   3
+Mt.Ordeals-3rd station                                                        Seed:  63   Index:   3
+Mt.Ordeals-7th station                                                        Seed:  63   Index:   8
+  Step  16: 28 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  20: 29 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  22: 30 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed:  63   Index:  50
+  Optional Steps: 1
+  Step  18: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed:  63   Index:  68
+Mt.Ordeals Summit                                                             Seed:  63   Index:  68
+Paladin                                                                       Seed:  63   Index:  72
+Mt.Ordeals Summit                                                             Seed:  63   Index:  72
+  Optional Steps: 1
+  Step   6: 32 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed:  63   Index:  95
+  Step  29: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  63   Index: 137
+Mt.Ordeals                                                                    Seed:  63   Index: 167
+Overworld (Mt.Ordeals)                                                        Seed:  63   Index: 211
+Take Chocobo to Mysidia                                                       Seed:  63   Index: 224
+Overworld (Mysidia)                                                           Seed:  63   Index: 224
+Town of Baron Serpent Road                                                    Seed:  63   Index: 224
+  Extra Steps: 28
+Credit Warp Fight Search                                                      Seed:  80   Index:   0
+  Overworld (Baron)                                                           Seed:  80   Index:   0
+    Extra Steps: 10
+    Step   1: 34 / FloatEye x1, Eagle x2 (7.365s)
+    Step  10: 35 / Imp x4 (7.223s)
+   (Step  48: 36 / Eagle x3)
+   (Step 118: 37 / Imp x3, SwordRat x1)
+   (Step 140: 38 / Imp x4)
+   (Step 195: 39 / Imp x3)
+   (Step 229: 40 / FloatEye x1, Eagle x2)
+
+Encounter Time:      276.374s
+Other Time:          520.110s
+Total Time:          796.484s
+
+Base Total Time:     925.345s
+Time Saved:          128.861s
+
+Optional Steps:      13
+Extra Steps:         120
+Encounters:          35
+
+Base Encounters:     48
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/235.txt
+++ b/data/routes/cw/235.txt
@@ -1,0 +1,151 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	235
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47890937
+VARS	FFFFFFFF:20 E000600:6 E302500:5 E302600:23 E305400:42 E307400:16 E308400:6 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 235   Index:   0
+Overworld (Kaipo)                                                             Seed: 235   Index:   1
+  Step  33: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 235   Index:  37
+Overworld (Kaipo)                                                             Seed: 235   Index:  37
+  Step  29: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 235   Index:  69
+Recruit Tellah                                                                Seed: 235   Index: 101
+Watery Pass-South B1F                                                         Seed: 235   Index: 101
+Watery Pass-South B2F                                                         Seed: 235   Index: 121
+  Step  16: 3 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  29: 4 / Zombie x4 (7.148s)
+  Step  42: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 235   Index: 211
+  Extra Steps: 42
+Watery Pass-South B2F                                                         Seed: 252   Index:   1
+  Step  36: 6 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 252   Index:  40
+Watery Pass-North B2F                                                         Seed: 252   Index:  74
+Watery Pass-North B1F                                                         Seed: 252   Index:  95
+  Step   2: 7 / Zombie x4 (7.148s)
+  Step  34: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 252   Index: 155
+  Step   6: 9 / Imp x4 (7.049s)
+Waterfalls B1F                                                                Seed: 252   Index: 164
+  Extra Steps: 16
+Waterfalls B2F                                                                Seed: 252   Index: 181
+  Step  12: 10 / Jelly x4 (7.324s)
+  Step  44: 11 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 252   Index: 226
+Battle: Octomamm                                                              Seed:  13   Index:   7
+Waterfalls Lake                                                               Seed:  13   Index:   7
+Overworld (Kaipo)                                                             Seed:  13   Index:   8
+  Step   5: 12 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed:  13   Index:  19
+Damcyan                                                                       Seed:  13   Index:  23
+  Optional Steps: 1
+  Extra Steps: 4
+Overworld (Damcyan)                                                           Seed:  13   Index:  35
+Antlion B1F                                                                   Seed:  13   Index:  35
+  Step  29: 13 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  13   Index:  73
+  Antlion B2F                                                                 Seed:  13   Index:  73
+Antlion's Nest                                                                Seed:  13   Index: 153
+  Step   5: 14 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed:  13   Index: 167
+Antlion's Nest                                                                Seed:  13   Index: 167
+Antlion B2F Outward Direct                                                    Seed:  13   Index: 182
+  Antlion B2F                                                                 Seed:  13   Index: 182
+    Step   1: 15 / Basilisk x1, Imp x3 (6.783s)
+    Step  30: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  41: 17 / Basilisk x1, Imp x3 (6.783s)
+    Step  73: 18 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  30   Index:   6
+  Step   1: 19 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  30   Index:  44
+Overworld (Kaipo)                                                             Seed:  30   Index:  44
+Kaipo Revisited                                                               Seed:  30   Index:  44
+Overworld (Kaipo)                                                             Seed:  30   Index:  44
+Overworld (Damcyan)                                                           Seed:  30   Index:  44
+Mt.Hobs-West                                                                  Seed:  30   Index:  44
+  Step   8: 20 / Skelton x4 (8.683s)
+  Step  16: 21 / Gargoyle x1, Cocktric x2 (9.399s)
+  Step  25: 22 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  30   Index:  83
+  Step   9: 23 / Gargoyle x1, Cocktric x2 (9.399s)
+Battle: MomBomb                                                               Seed:  30   Index:  98
+Mt.Hobs Summit                                                                Seed:  30   Index:  98
+Mt.Hobs-East                                                                  Seed:  30   Index: 104
+Overworld (Fabul)                                                             Seed:  30   Index: 150
+  Step  38: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  56: 25 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  30   Index: 234
+  Optional Steps: 9
+  Extra Steps: 14
+Overworld (Fabul)                                                             Seed:  47   Index:  61
+Fabul Boat and Leviatan                                                       Seed:  47   Index:  68
+Overworld (Mysidia)                                                           Seed:  47   Index:  68
+Mysidia                                                                       Seed:  47   Index:  77
+Overworld (Mysidia)                                                           Seed:  47   Index:  77
+Overworld (Mt.Ordeals)                                                        Seed:  47   Index:  87
+  Extra Steps: 6
+  Step  38: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  99: 27 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  47   Index: 187
+  Extra Steps: 6
+  Step  49: 28 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  47   Index: 236
+Recruit Tellah                                                                Seed:  64   Index:   3
+Mt.Ordeals-3rd station                                                        Seed:  64   Index:   3
+Mt.Ordeals-7th station                                                        Seed:  64   Index:   8
+  Step  16: 29 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  20: 30 / Lilith x1, Red Bone x2 (8.912s)
+  Step  22: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  64   Index:  50
+  Optional Steps: 1
+  Step  18: 32 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed:  64   Index:  68
+Mt.Ordeals Summit                                                             Seed:  64   Index:  68
+Paladin                                                                       Seed:  64   Index:  72
+Mt.Ordeals Summit                                                             Seed:  64   Index:  72
+  Optional Steps: 1
+  Step   6: 33 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-7th station                                                        Seed:  64   Index:  95
+  Step  29: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  64   Index: 137
+Mt.Ordeals                                                                    Seed:  64   Index: 167
+Overworld (Mt.Ordeals)                                                        Seed:  64   Index: 211
+Take Chocobo to Mysidia                                                       Seed:  64   Index: 224
+Overworld (Mysidia)                                                           Seed:  64   Index: 224
+Town of Baron Serpent Road                                                    Seed:  64   Index: 224
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed:  64   Index: 230
+  Overworld (Baron)                                                           Seed:  64   Index: 230
+    Extra Steps: 20
+    Step   2: 35 / Imp x3, SwordRat x1 (7.227s)
+    Step  20: 36 / Imp x4 (7.223s)
+   (Step  36: 37 / Imp x6)
+   (Step  74: 38 / Imp x4)
+   (Step 144: 39 / Imp x3)
+   (Step 166: 40 / FloatEye x1, Eagle x2)
+   (Step 183: 41 / Imp x3)
+   (Step 221: 42 / Imp x3)
+   (Step 255: 43 / FloatEye x2)
+
+Encounter Time:      281.352s
+Other Time:          515.518s
+Total Time:          796.870s
+
+Base Total Time:     927.953s
+Time Saved:          131.083s
+
+Optional Steps:      12
+Extra Steps:         110
+Encounters:          36
+
+Base Encounters:     48
+Encounters Saved:    12
+
+Number of Variables: 54

--- a/data/routes/cw/236.txt
+++ b/data/routes/cw/236.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	236
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48480159
+VARS	FFFFFFFF:4 C307801:1 E302500:5 E302600:6 E305400:42 E307400:16 E307B01:30 E308700:1 E308702:1 E309700:28
+
+Overworld (Kaipo)                                                             Seed: 236   Index:   0
+Overworld (Kaipo)                                                             Seed: 236   Index:   1
+  Step  33: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 236   Index:  37
+Overworld (Kaipo)                                                             Seed: 236   Index:  37
+  Step  29: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 236   Index:  69
+  Step  29: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 236   Index: 101
+Watery Pass-South B1F                                                         Seed: 236   Index: 101
+Watery Pass-South B2F                                                         Seed: 236   Index: 121
+  Step  29: 4 / Zombie x4 (7.148s)
+  Step  42: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 236   Index: 211
+  Extra Steps: 42
+Watery Pass-South B2F                                                         Seed: 253   Index:   1
+  Step  36: 6 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 253   Index:  40
+Watery Pass-North B2F                                                         Seed: 253   Index:  74
+Watery Pass-North B1F                                                         Seed: 253   Index:  95
+  Step   2: 7 / Zombie x4 (7.148s)
+  Step  25: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+Overworld (Kaipo)                                                             Seed: 253   Index: 155
+  Step   6: 9 / Imp x4 (7.049s)
+Waterfalls B1F                                                                Seed: 253   Index: 164
+  Extra Steps: 16
+Waterfalls B2F                                                                Seed: 253   Index: 181
+  Step  12: 10 / Jelly x4 (7.324s)
+  Step  44: 11 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 253   Index: 226
+Battle: Octomamm                                                              Seed:  14   Index:   7
+Waterfalls Lake                                                               Seed:  14   Index:   7
+Overworld (Kaipo)                                                             Seed:  14   Index:   8
+  Step   5: 12 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed:  14   Index:  19
+Damcyan                                                                       Seed:  14   Index:  23
+  Optional Steps: 1
+  Extra Steps: 4
+Overworld (Damcyan)                                                           Seed:  14   Index:  35
+Antlion B1F                                                                   Seed:  14   Index:  35
+  Step  29: 13 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  14   Index:  73
+  Antlion B2F                                                                 Seed:  14   Index:  73
+Antlion's Nest                                                                Seed:  14   Index: 153
+  Step   5: 14 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed:  14   Index: 167
+Antlion's Nest                                                                Seed:  14   Index: 167
+Antlion B2F Outward Charm Room Steps                                          Seed:  14   Index: 182
+  Antlion B2F                                                                 Seed:  14   Index: 182
+    Step  30: 15 / Basilisk x1, Imp x3 (6.783s)
+    Step  41: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Antlion B2F Treasure Room                                                   Seed:  14   Index: 233
+    Extra Steps: 30
+  Antlion B2F                                                                 Seed:  31   Index:   7
+Antlion B1F                                                                   Seed:  31   Index:  41
+  Step  11: 17 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  19: 18 / Turtle x1, Imp x2 (7.009s)
+  Step  28: 19 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  31   Index:  79
+Overworld (Kaipo)                                                             Seed:  31   Index:  79
+Kaipo Revisited                                                               Seed:  31   Index:  79
+Overworld (Kaipo)                                                             Seed:  31   Index:  79
+Overworld (Damcyan)                                                           Seed:  31   Index:  79
+Mt.Hobs-West                                                                  Seed:  31   Index:  79
+  Step  13: 20 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  31   Index: 118
+Battle: MomBomb                                                               Seed:  31   Index: 133
+Mt.Hobs Summit                                                                Seed:  31   Index: 133
+Mt.Hobs-East                                                                  Seed:  31   Index: 139
+Overworld (Fabul)                                                             Seed:  31   Index: 185
+  Step   3: 21 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  21: 22 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  35: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  54: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  68: 25 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  48   Index:  13
+  Optional Steps: 6
+Overworld (Fabul)                                                             Seed:  48   Index:  79
+Fabul Boat and Leviatan                                                       Seed:  48   Index:  86
+Overworld (Mysidia)                                                           Seed:  48   Index:  86
+Mysidia                                                                       Seed:  48   Index:  95
+Overworld (Mysidia)                                                           Seed:  48   Index:  95
+Overworld (Mt.Ordeals)                                                        Seed:  48   Index: 105
+  Step  20: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  81: 27 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  48   Index: 199
+  Step  37: 28 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  48   Index: 242
+  Step   4: 29 / Ghoul x2, Soul x2 (9.357s)
+Recruit Tellah                                                                Seed:  65   Index:   9
+Mt.Ordeals-3rd station                                                        Seed:  65   Index:   9
+Mt.Ordeals-7th station                                                        Seed:  65   Index:  14
+  Step  14: 30 / Lilith x1, Red Bone x2 (8.912s)
+  Step  16: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  65   Index:  56
+  Optional Steps: 1
+  Step  12: 32 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed:  65   Index:  74
+Mt.Ordeals Summit                                                             Seed:  65   Index:  74
+  Step   4: 33 / Soul x2, Ghoul x2, Revenant x2 (10.046s)
+Paladin                                                                       Seed:  65   Index:  78
+Mt.Ordeals Summit                                                             Seed:  65   Index:  78
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  65   Index: 101
+  Step  23: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  65   Index: 143
+Mt.Ordeals                                                                    Seed:  65   Index: 173
+  Step   5: 35 / Lilith x1, Red Bone x2 (8.437s)
+Overworld (Mt.Ordeals)                                                        Seed:  65   Index: 217
+Take Chocobo to Mysidia                                                       Seed:  65   Index: 230
+Overworld (Mysidia)                                                           Seed:  65   Index: 230
+Town of Baron Serpent Road                                                    Seed:  65   Index: 230
+  Extra Steps: 28
+Credit Warp Fight Search                                                      Seed:  82   Index:   6
+  Overworld (Baron)                                                           Seed:  82   Index:   6
+    Extra Steps: 4
+    Step   2: 36 / Imp x4 (7.223s)
+    Step   4: 37 / Imp x6 (7.090s)
+   (Step 112: 38 / Imp x4)
+   (Step 134: 39 / Imp x3)
+   (Step 151: 40 / FloatEye x1, Eagle x2)
+   (Step 189: 41 / Imp x3)
+   (Step 223: 42 / Imp x3)
+
+Encounter Time:      287.096s
+Other Time:          519.578s
+Total Time:          806.674s
+
+Base Total Time:     893.606s
+Time Saved:          86.932s
+
+Optional Steps:      9
+Extra Steps:         124
+Encounters:          37
+
+Base Encounters:     44
+Encounters Saved:    7
+
+Number of Variables: 54

--- a/data/routes/cw/237.txt
+++ b/data/routes/cw/237.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	237
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48819395
+VARS	FFFFFFFF:4 C307801:1 E000501:14 E302500:5 E302600:10 E305400:42 E307400:16 E307B01:30 E307F01:2 E309700:10
+
+Overworld (Kaipo)                                                             Seed: 237   Index:   0
+Overworld (Kaipo)                                                             Seed: 237   Index:   1
+  Step  33: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 237   Index:  37
+Overworld (Kaipo)                                                             Seed: 237   Index:  37
+  Step  29: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 237   Index:  69
+  Step  29: 3 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 237   Index: 101
+Watery Pass-South B1F                                                         Seed: 237   Index: 101
+  Step  12: 4 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 237   Index: 121
+  Step  29: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 237   Index: 211
+  Extra Steps: 42
+Watery Pass-South B2F                                                         Seed: 254   Index:   1
+  Step  36: 6 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 254   Index:  40
+Watery Pass-North B2F                                                         Seed: 254   Index:  74
+Watery Pass-North B1F                                                         Seed: 254   Index:  95
+  Step   2: 7 / Zombie x4 (7.148s)
+  Step  25: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  49: 9 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed: 254   Index: 155
+Waterfalls B1F                                                                Seed: 254   Index: 164
+  Extra Steps: 16
+Waterfalls B2F                                                                Seed: 254   Index: 181
+  Step  12: 10 / Jelly x4 (7.324s)
+  Step  44: 11 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 254   Index: 226
+Battle: Octomamm                                                              Seed:  15   Index:   7
+Waterfalls Lake                                                               Seed:  15   Index:   7
+Overworld (Kaipo)                                                             Seed:  15   Index:   8
+  Step   5: 12 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed:  15   Index:  19
+Damcyan                                                                       Seed:  15   Index:  23
+  Optional Steps: 1
+  Extra Steps: 4
+Overworld (Damcyan)                                                           Seed:  15   Index:  35
+Antlion B1F                                                                   Seed:  15   Index:  35
+  Step  29: 13 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  15   Index:  73
+  Antlion B2F                                                                 Seed:  15   Index:  73
+Antlion's Nest                                                                Seed:  15   Index: 153
+  Step   5: 14 / Weeper x2 (7.114s)
+Battle: Antlion                                                               Seed:  15   Index: 167
+Antlion's Nest                                                                Seed:  15   Index: 167
+Antlion B2F Outward Charm Room Steps                                          Seed:  15   Index: 182
+  Antlion B2F                                                                 Seed:  15   Index: 182
+    Step  30: 15 / Basilisk x1, Imp x3 (6.783s)
+    Step  40: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+  Antlion B2F Treasure Room                                                   Seed:  15   Index: 233
+    Extra Steps: 30
+  Antlion B2F                                                                 Seed:  32   Index:   7
+Antlion B1F                                                                   Seed:  32   Index:  41
+  Step  11: 17 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  19: 18 / Turtle x1, Imp x2 (7.009s)
+  Step  28: 19 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  32   Index:  79
+Overworld (Kaipo)                                                             Seed:  32   Index:  79
+Kaipo Revisited                                                               Seed:  32   Index:  79
+Overworld (Kaipo)                                                             Seed:  32   Index:  79
+Overworld (Damcyan)                                                           Seed:  32   Index:  79
+Mt.Hobs-West                                                                  Seed:  32   Index:  79
+  Step  13: 20 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  32   Index: 118
+Battle: MomBomb                                                               Seed:  32   Index: 133
+Mt.Hobs Summit                                                                Seed:  32   Index: 133
+  Extra Steps: 2
+  Step   8: 21 / Skelton x4 (7.819s)
+Mt.Hobs-East                                                                  Seed:  32   Index: 141
+Overworld (Fabul)                                                             Seed:  32   Index: 187
+  Step   1: 22 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  33: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  52: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  66: 25 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  49   Index:  15
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  49   Index:  85
+Fabul Boat and Leviatan                                                       Seed:  49   Index:  92
+Overworld (Mysidia)                                                           Seed:  49   Index:  92
+Mysidia                                                                       Seed:  49   Index: 101
+Overworld (Mysidia)                                                           Seed:  49   Index: 101
+  Extra Steps: 14
+Overworld (Mt.Ordeals)                                                        Seed:  49   Index: 125
+  Step  42: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  61: 27 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  49   Index: 219
+  Step  17: 28 / Spirit x3, Soul x1 (8.687s)
+  Step  27: 29 / Spirit x3, Soul x1 (8.687s)
+Mt.Ordeals-3rd station                                                        Seed:  66   Index:   6
+  Step  22: 30 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed:  66   Index:  29
+Mt.Ordeals-3rd station                                                        Seed:  66   Index:  29
+  Step   1: 31 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed:  66   Index:  34
+  Step   9: 32 / Lilith x1, Red Bone x2 (8.912s)
+  Step  34: 33 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  66   Index:  76
+  Optional Steps: 0
+  Step   2: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed:  66   Index:  93
+Mt.Ordeals Summit                                                             Seed:  66   Index:  93
+Paladin                                                                       Seed:  66   Index:  97
+Mt.Ordeals Summit                                                             Seed:  66   Index:  97
+  Optional Steps: 0
+Mt.Ordeals-7th station                                                        Seed:  66   Index: 119
+  Step   5: 35 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-3rd station                                                        Seed:  66   Index: 161
+  Step  17: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed:  66   Index: 191
+Overworld (Mt.Ordeals)                                                        Seed:  66   Index: 235
+Take Chocobo to Mysidia                                                       Seed:  66   Index: 248
+Overworld (Mysidia)                                                           Seed:  66   Index: 248
+Town of Baron Serpent Road                                                    Seed:  66   Index: 248
+  Extra Steps: 10
+Credit Warp Fight Search                                                      Seed:  83   Index:   6
+  Overworld (Baron)                                                           Seed:  83   Index:   6
+    Extra Steps: 4
+    Step   2: 37 / Imp x3 (7.174s)
+    Step   4: 38 / Imp x4 (7.223s)
+   (Step  79: 39 / Imp x3)
+   (Step 134: 40 / FloatEye x1, Eagle x2)
+   (Step 151: 41 / Imp x3)
+   (Step 189: 42 / Imp x3)
+   (Step 223: 43 / FloatEye x2)
+
+Encounter Time:      293.274s
+Other Time:          519.045s
+Total Time:          812.319s
+
+Base Total Time:     1001.440s
+Time Saved:          189.121s
+
+Optional Steps:      11
+Extra Steps:         122
+Encounters:          38
+
+Base Encounters:     49
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/238.txt
+++ b/data/routes/cw/238.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	238
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47894279
+VARS	FFFFFFFF:4 E000600:6 E302500:21 E302600:23 E305400:42 E308401:10 E308502:18 E308700:1 E308702:1 E309700:12
+
+Overworld (Kaipo)                                                             Seed: 238   Index:   0
+Overworld (Kaipo)                                                             Seed: 238   Index:   1
+  Step  33: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 238   Index:  37
+Overworld (Kaipo)                                                             Seed: 238   Index:  37
+  Step  29: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 238   Index:  69
+  Step  29: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 238   Index: 101
+Watery Pass-South B1F                                                         Seed: 238   Index: 101
+  Step  12: 4 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 238   Index: 121
+  Step  41: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 238   Index: 211
+  Extra Steps: 42
+Watery Pass-South B2F                                                         Seed: 255   Index:   1
+  Step  36: 6 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 255   Index:  40
+Watery Pass-North B2F                                                         Seed: 255   Index:  74
+Watery Pass-North B1F                                                         Seed: 255   Index:  95
+  Step   2: 7 / Zombie x4 (7.148s)
+  Step  25: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  35: 9 / CaveToad x4 (7.163s)
+  Step  49: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed: 255   Index: 155
+Waterfalls B1F                                                                Seed: 255   Index: 164
+Waterfalls B2F                                                                Seed: 255   Index: 165
+  Step  15: 11 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed: 255   Index: 210
+  Step  15: 12 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed: 255   Index: 247
+Waterfalls Lake                                                               Seed: 255   Index: 247
+Overworld (Kaipo)                                                             Seed: 255   Index: 248
+  Step  10: 13 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed:  16   Index:   3
+Damcyan                                                                       Seed:  16   Index:   7
+  Optional Steps: 1
+  Extra Steps: 20
+Overworld (Damcyan)                                                           Seed:  16   Index:  35
+Antlion B1F                                                                   Seed:  16   Index:  35
+  Step  29: 14 / Turtle x2 (7.487s)
+Antlion B2F Inward Direct                                                     Seed:  16   Index:  73
+  Antlion B2F                                                                 Seed:  16   Index:  73
+Antlion's Nest                                                                Seed:  16   Index: 153
+  Step   5: 15 / Basilisk x1, Imp x3 (6.775s)
+Battle: Antlion                                                               Seed:  16   Index: 167
+Antlion's Nest                                                                Seed:  16   Index: 167
+Antlion B2F Outward Direct                                                    Seed:  16   Index: 182
+  Antlion B2F                                                                 Seed:  16   Index: 182
+    Step  30: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  40: 17 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  33   Index:   6
+  Step   1: 18 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  33   Index:  44
+Overworld (Kaipo)                                                             Seed:  33   Index:  44
+Kaipo Revisited                                                               Seed:  33   Index:  44
+Overworld (Kaipo)                                                             Seed:  33   Index:  44
+Overworld (Damcyan)                                                           Seed:  33   Index:  44
+Mt.Hobs-West                                                                  Seed:  33   Index:  44
+  Step  16: 19 / Skelton x4 (8.683s)
+  Step  25: 20 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  33   Index:  83
+  Step   9: 21 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed:  33   Index:  98
+Mt.Hobs Summit                                                                Seed:  33   Index:  98
+Mt.Hobs-East                                                                  Seed:  33   Index: 104
+  Step  37: 22 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:  33   Index: 150
+  Step  38: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  70: 24 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed:  33   Index: 234
+  Optional Steps: 9
+  Extra Steps: 14
+Overworld (Fabul)                                                             Seed:  50   Index:  61
+Fabul Boat and Leviatan                                                       Seed:  50   Index:  68
+Overworld (Mysidia)                                                           Seed:  50   Index:  68
+Mysidia                                                                       Seed:  50   Index:  77
+Overworld (Mysidia)                                                           Seed:  50   Index:  77
+Overworld (Mt.Ordeals)                                                        Seed:  50   Index:  87
+  Extra Steps: 6
+  Step  80: 25 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  99: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  50   Index: 187
+Mt.Ordeals-3rd station                                                        Seed:  50   Index: 230
+  Step  16: 27 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  50   Index: 253
+Mt.Ordeals-3rd station                                                        Seed:  50   Index: 253
+Mt.Ordeals-7th station                                                        Seed:  67   Index:   2
+  Step  26: 28 / Lilith x1, Red Bone x2 (8.912s)
+  Step  28: 29 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  41: 30 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed:  67   Index:  44
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  67   Index:  62
+Mt.Ordeals Summit                                                             Seed:  67   Index:  62
+Paladin                                                                       Seed:  67   Index:  66
+Mt.Ordeals Summit                                                             Seed:  67   Index:  66
+  Optional Steps: 1
+  Step   2: 31 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  12: 32 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed:  67   Index:  89
+Mt.Ordeals-3rd station                                                        Seed:  67   Index: 131
+  Extra Steps: 18
+  Step  22: 33 / Ghoul x2, Soul x2 (8.971s)
+  Step  47: 34 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed:  67   Index: 179
+  Extra Steps: 10
+Overworld (Mt.Ordeals)                                                        Seed:  67   Index: 233
+Take Chocobo to Mysidia                                                       Seed:  67   Index: 246
+Overworld (Mysidia)                                                           Seed:  67   Index: 246
+Town of Baron Serpent Road                                                    Seed:  67   Index: 246
+  Extra Steps: 12
+Credit Warp Fight Search                                                      Seed:  84   Index:   6
+  Overworld (Baron)                                                           Seed:  84   Index:   6
+    Extra Steps: 4
+    Step   2: 35 / Imp x3, SwordRat x1 (7.227s)
+    Step   4: 36 / Imp x4 (7.223s)
+   (Step  79: 37 / Imp x3)
+   (Step 111: 38 / Imp x4)
+   (Step 134: 39 / Imp x3)
+   (Step 151: 40 / FloatEye x1, Eagle x2)
+   (Step 223: 41 / Imp x3)
+
+Encounter Time:      281.408s
+Other Time:          515.518s
+Total Time:          796.926s
+
+Base Total Time:     972.898s
+Time Saved:          175.973s
+
+Optional Steps:      12
+Extra Steps:         126
+Encounters:          36
+
+Base Encounters:     49
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/239.txt
+++ b/data/routes/cw/239.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	239
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47694021
+VARS	FFFFFFFF:16 C307801:1 E302500:19 E302600:66 E307400:22 E307B01:2 E308700:1 E308702:1 E309700:4
+
+Overworld (Kaipo)                                                             Seed: 239   Index:   0
+Overworld (Kaipo)                                                             Seed: 239   Index:   1
+  Step  33: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 239   Index:  37
+Overworld (Kaipo)                                                             Seed: 239   Index:  37
+  Step  29: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 239   Index:  69
+  Step  29: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 239   Index: 101
+Watery Pass-South B1F                                                         Seed: 239   Index: 101
+  Step  12: 4 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 239   Index: 121
+  Step  41: 5 / Pike x3 (7.152s)
+  Step  73: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 239   Index: 211
+Watery Pass-South B2F                                                         Seed: 239   Index: 215
+  Step  39: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B3F                                                         Seed: 239   Index: 254
+Watery Pass-North B2F                                                         Seed:   0   Index:  32
+  Step   5: 8 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Watery Pass-North B1F                                                         Seed:   0   Index:  53
+  Step  34: 9 / CaveToad x4 (7.163s)
+  Step  44: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:   0   Index: 113
+  Step   7: 11 / Imp x4 (7.049s)
+Waterfalls B1F                                                                Seed:   0   Index: 122
+  Extra Steps: 22
+Waterfalls B2F                                                                Seed:   0   Index: 145
+  Step  35: 12 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:   0   Index: 190
+Battle: Octomamm                                                              Seed:   0   Index: 227
+Waterfalls Lake                                                               Seed:   0   Index: 227
+Overworld (Kaipo)                                                             Seed:   0   Index: 228
+Overworld (Damcyan)                                                           Seed:   0   Index: 239
+Damcyan                                                                       Seed:   0   Index: 243
+  Optional Steps: 1
+  Extra Steps: 18
+Overworld (Damcyan)                                                           Seed:  17   Index:  13
+Antlion B1F                                                                   Seed:  17   Index:  13
+  Step  16: 13 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  17   Index:  51
+  Antlion B2F                                                                 Seed:  17   Index:  51
+    Step  13: 14 / Weeper x2 (7.114s)
+    Step  42: 15 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:  17   Index: 131
+Battle: Antlion                                                               Seed:  17   Index: 145
+Antlion's Nest                                                                Seed:  17   Index: 145
+  Step  13: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Charm Room Steps                                          Seed:  17   Index: 160
+  Antlion B2F                                                                 Seed:  17   Index: 160
+  Antlion B2F Treasure Room                                                   Seed:  17   Index: 211
+    Extra Steps: 2
+  Antlion B2F                                                                 Seed:  17   Index: 213
+    Step   9: 17 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  17   Index: 247
+  Step  16: 18 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  34   Index:  29
+Overworld (Kaipo)                                                             Seed:  34   Index:  29
+Kaipo Revisited                                                               Seed:  34   Index:  29
+Overworld (Kaipo)                                                             Seed:  34   Index:  29
+Overworld (Damcyan)                                                           Seed:  34   Index:  29
+Mt.Hobs-West                                                                  Seed:  34   Index:  29
+Mt.Hobs Summit                                                                Seed:  34   Index:  68
+  Step   1: 19 / Gargoyle x1, Cocktric x2 (9.399s)
+Battle: MomBomb                                                               Seed:  34   Index:  83
+Mt.Hobs Summit                                                                Seed:  34   Index:  83
+Mt.Hobs-East                                                                  Seed:  34   Index:  89
+  Step   3: 20 / Spirit x2, Skelton x2 (8.237s)
+  Step  32: 21 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed:  34   Index: 135
+  Step   6: 22 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  53: 23 / Imp Cap. x3, Needler x1 (8.023s)
+Fabul                                                                         Seed:  34   Index: 219
+  Optional Steps: 10
+  Extra Steps: 56
+Overworld (Fabul)                                                             Seed:  51   Index:  89
+Fabul Boat and Leviatan                                                       Seed:  51   Index:  96
+Overworld (Mysidia)                                                           Seed:  51   Index:  96
+Mysidia                                                                       Seed:  51   Index: 105
+Overworld (Mysidia)                                                           Seed:  51   Index: 105
+Overworld (Mt.Ordeals)                                                        Seed:  51   Index: 115
+  Step  52: 24 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  71: 25 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  51   Index: 209
+  Step  37: 26 / Red Bone x1, Skelton x3 (8.067s)
+Mt.Ordeals-3rd station                                                        Seed:  51   Index: 252
+Recruit Tellah                                                                Seed:  68   Index:  19
+Mt.Ordeals-3rd station                                                        Seed:  68   Index:  19
+Mt.Ordeals-7th station                                                        Seed:  68   Index:  24
+  Step   4: 27 / Lilith x1, Red Bone x2 (8.912s)
+  Step   6: 28 / Lilith x1, Red Bone x2 (8.912s)
+  Step  19: 29 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  68   Index:  66
+  Optional Steps: 1
+  Step  12: 30 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed:  68   Index:  84
+Mt.Ordeals Summit                                                             Seed:  68   Index:  84
+Paladin                                                                       Seed:  68   Index:  88
+Mt.Ordeals Summit                                                             Seed:  68   Index:  88
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  68   Index: 111
+  Step   8: 31 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  42: 32 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  68   Index: 153
+  Step  25: 33 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:  68   Index: 183
+Overworld (Mt.Ordeals)                                                        Seed:  68   Index: 227
+Take Chocobo to Mysidia                                                       Seed:  68   Index: 240
+Overworld (Mysidia)                                                           Seed:  68   Index: 240
+Town of Baron Serpent Road                                                    Seed:  68   Index: 240
+  Extra Steps: 4
+Credit Warp Fight Search                                                      Seed:  68   Index: 248
+  Overworld (Baron)                                                           Seed:  68   Index: 248
+    Extra Steps: 16
+    Step   2: 34 / FloatEye x1, Eagle x2 (7.365s)
+    Step  16: 35 / Imp x3, SwordRat x1 (7.227s)
+   (Step  84: 36 / Imp x4)
+   (Step  93: 37 / Imp x3)
+   (Step 125: 38 / Imp x4)
+   (Step 148: 39 / Imp x3)
+   (Step 165: 40 / FloatEye x1, Eagle x2)
+   (Step 237: 41 / Imp x3)
+
+Encounter Time:      272.418s
+Other Time:          521.175s
+Total Time:          793.593s
+
+Base Total Time:     972.674s
+Time Saved:          179.081s
+
+Optional Steps:      13
+Extra Steps:         118
+Encounters:          35
+
+Base Encounters:     49
+Encounters Saved:    14
+
+Number of Variables: 54

--- a/data/routes/cw/240.txt
+++ b/data/routes/cw/240.txt
@@ -1,0 +1,156 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	240
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48725510
+VARS	FFFFFFFF:20 C307801:1 E000600:6 E302500:9 E302600:26 E307200:4 E307300:4 E307400:14 E307B01:24 E308700:1 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed: 240   Index:   0
+Overworld (Kaipo)                                                             Seed: 240   Index:   1
+  Step  33: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 240   Index:  37
+Overworld (Kaipo)                                                             Seed: 240   Index:  37
+  Step  29: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 240   Index:  69
+  Step  29: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 240   Index: 101
+Watery Pass-South B1F                                                         Seed: 240   Index: 101
+  Step  12: 4 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 240   Index: 121
+  Step  41: 5 / Pike x3 (7.152s)
+  Step  73: 6 / Pike x3 (7.152s)
+  Step  89: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 240   Index: 211
+Watery Pass-South B2F                                                         Seed: 240   Index: 215
+Watery Pass-South B3F                                                         Seed: 240   Index: 254
+Watery Pass-North B2F                                                         Seed:   1   Index:  32
+  Extra Steps: 4
+  Step   5: 8 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  24: 9 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:   1   Index:  57
+  Extra Steps: 4
+  Step  30: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+  Step  40: 11 / CaveToad x4 (7.163s)
+  Step  63: 12 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:   1   Index: 121
+  Step   9: 13 / Sandpede x1, Sand Man x2 (7.188s)
+Waterfalls B1F                                                                Seed:   1   Index: 130
+  Extra Steps: 14
+Waterfalls B2F                                                                Seed:   1   Index: 145
+  Step  35: 14 / Aligator x1, WaterBug x2 (7.292s)
+Waterfalls Lake                                                               Seed:   1   Index: 190
+Battle: Octomamm                                                              Seed:   1   Index: 227
+Waterfalls Lake                                                               Seed:   1   Index: 227
+Overworld (Kaipo)                                                             Seed:   1   Index: 228
+Overworld (Damcyan)                                                           Seed:   1   Index: 239
+Damcyan                                                                       Seed:   1   Index: 243
+  Optional Steps: 1
+  Extra Steps: 8
+Overworld (Damcyan)                                                           Seed:  18   Index:   3
+Antlion B1F                                                                   Seed:  18   Index:   3
+  Step  26: 15 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  18   Index:  41
+  Antlion B2F                                                                 Seed:  18   Index:  41
+    Step  23: 16 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  52: 17 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:  18   Index: 121
+Battle: Antlion                                                               Seed:  18   Index: 135
+Antlion's Nest                                                                Seed:  18   Index: 135
+Antlion B2F Outward Charm Room Steps                                          Seed:  18   Index: 150
+  Antlion B2F                                                                 Seed:  18   Index: 150
+    Step   8: 18 / Turtle x2 (7.464s)
+  Antlion B2F Treasure Room                                                   Seed:  18   Index: 201
+    Extra Steps: 24
+  Antlion B2F                                                                 Seed:  18   Index: 225
+Antlion B1F                                                                   Seed:  35   Index:   3
+  Step   4: 19 / Imp x3 (6.648s)
+  Step  28: 20 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  35   Index:  41
+Overworld (Kaipo)                                                             Seed:  35   Index:  41
+Kaipo Revisited                                                               Seed:  35   Index:  41
+Overworld (Kaipo)                                                             Seed:  35   Index:  41
+Overworld (Damcyan)                                                           Seed:  35   Index:  41
+Mt.Hobs-West                                                                  Seed:  35   Index:  41
+  Step  28: 21 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed:  35   Index:  80
+Battle: MomBomb                                                               Seed:  35   Index:  95
+Mt.Hobs Summit                                                                Seed:  35   Index:  95
+Mt.Hobs-East                                                                  Seed:  35   Index: 101
+  Step  20: 22 / Gargoyle x2 (7.630s)
+  Step  40: 23 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:  35   Index: 147
+  Step  41: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  73: 25 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  35   Index: 231
+  Optional Steps: 10
+  Extra Steps: 16
+Overworld (Fabul)                                                             Seed:  52   Index:  61
+Fabul Boat and Leviatan                                                       Seed:  52   Index:  68
+Overworld (Mysidia)                                                           Seed:  52   Index:  68
+Mysidia                                                                       Seed:  52   Index:  77
+Overworld (Mysidia)                                                           Seed:  52   Index:  77
+Overworld (Mt.Ordeals)                                                        Seed:  52   Index:  87
+  Extra Steps: 6
+  Step   2: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  56: 27 / Raven x1 (8.356s)
+  Step  80: 28 / Raven x1 (8.356s)
+  Step  99: 29 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  52   Index: 187
+Mt.Ordeals-3rd station                                                        Seed:  52   Index: 230
+  Step  16: 30 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed:  52   Index: 253
+Mt.Ordeals-3rd station                                                        Seed:  52   Index: 253
+Mt.Ordeals-7th station                                                        Seed:  69   Index:   2
+  Step  26: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  28: 32 / Lilith x1, Red Bone x2 (8.912s)
+  Step  41: 33 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Mt.Ordeals Summit                                                             Seed:  69   Index:  44
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  69   Index:  62
+Mt.Ordeals Summit                                                             Seed:  69   Index:  62
+Paladin                                                                       Seed:  69   Index:  66
+Mt.Ordeals Summit                                                             Seed:  69   Index:  66
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  69   Index:  89
+  Step  30: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  69   Index: 131
+  Step  22: 35 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals                                                                    Seed:  69   Index: 161
+  Step  17: 36 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  69   Index: 205
+Take Chocobo to Mysidia                                                       Seed:  69   Index: 218
+Overworld (Mysidia)                                                           Seed:  69   Index: 218
+Town of Baron Serpent Road                                                    Seed:  69   Index: 218
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed:  69   Index: 230
+  Overworld (Baron)                                                           Seed:  69   Index: 230
+    Extra Steps: 20
+    Step   1: 37 / Imp x3 (7.174s)
+    Step  20: 38 / Imp x4 (7.223s)
+   (Step  34: 39 / Imp x3)
+   (Step  58: 40 / Imp x3, SwordRat x1)
+   (Step 102: 41 / Imp x3)
+   (Step 111: 42 / FloatEye x2)
+   (Step 143: 43 / FloatEye x2)
+   (Step 166: 44 / Imp x3, SwordRat x1)
+   (Step 183: 45 / FloatEye x2)
+
+Encounter Time:      292.244s
+Other Time:          518.513s
+Total Time:          810.757s
+
+Base Total Time:     937.705s
+Time Saved:          126.948s
+
+Optional Steps:      13
+Extra Steps:         104
+Encounters:          38
+
+Base Encounters:     49
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/241.txt
+++ b/data/routes/cw/241.txt
@@ -1,0 +1,155 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	241
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48630387
+VARS	FFFFFFFF:20 C307801:1 E000600:6 E302500:7 E302600:26 E307200:4 E307400:20 E307B01:24 E308700:1 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed: 241   Index:   0
+Overworld (Kaipo)                                                             Seed: 241   Index:   1
+  Step  33: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 241   Index:  37
+Overworld (Kaipo)                                                             Seed: 241   Index:  37
+  Step  20: 2 / Imp x4 (6.944s)
+  Step  29: 3 / SandMoth x2, Larva x2 (7.049s)
+Watery Pass-South B1F                                                         Seed: 241   Index:  69
+  Step  29: 4 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 241   Index: 101
+Watery Pass-South B1F                                                         Seed: 241   Index: 101
+  Step  12: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 241   Index: 121
+  Step  41: 6 / Pike x3 (7.152s)
+  Step  73: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  89: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 241   Index: 211
+Watery Pass-South B2F                                                         Seed: 241   Index: 215
+Watery Pass-South B3F                                                         Seed: 241   Index: 254
+Watery Pass-North B2F                                                         Seed:   2   Index:  32
+  Extra Steps: 4
+  Step   5: 9 / Zombie x4 (7.148s)
+  Step  24: 10 / CaveToad x3 (7.014s)
+Watery Pass-North B1F                                                         Seed:   2   Index:  57
+  Step  30: 11 / CaveToad x4 (7.163s)
+  Step  40: 12 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:   2   Index: 117
+  Step   3: 13 / Sandpede x1, Sand Man x2 (7.188s)
+Waterfalls B1F                                                                Seed:   2   Index: 126
+  Extra Steps: 20
+Waterfalls B2F                                                                Seed:   2   Index: 147
+Waterfalls Lake                                                               Seed:   2   Index: 192
+Battle: Octomamm                                                              Seed:   2   Index: 229
+Waterfalls Lake                                                               Seed:   2   Index: 229
+Overworld (Kaipo)                                                             Seed:   2   Index: 230
+Overworld (Damcyan)                                                           Seed:   2   Index: 241
+Damcyan                                                                       Seed:   2   Index: 245
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed:  19   Index:   3
+Antlion B1F                                                                   Seed:  19   Index:   3
+  Step  26: 14 / Turtle x2 (7.487s)
+Antlion B2F Inward Direct                                                     Seed:  19   Index:  41
+  Antlion B2F                                                                 Seed:  19   Index:  41
+    Step  23: 15 / Turtle x2 (7.487s)
+    Step  26: 16 / Basilisk x1, Turtle x1 (7.110s)
+    Step  52: 17 / Basilisk x1, Imp x3 (6.775s)
+Antlion's Nest                                                                Seed:  19   Index: 121
+Battle: Antlion                                                               Seed:  19   Index: 135
+Antlion's Nest                                                                Seed:  19   Index: 135
+Antlion B2F Outward Charm Room Steps                                          Seed:  19   Index: 150
+  Antlion B2F                                                                 Seed:  19   Index: 150
+    Step   8: 18 / Turtle x2 (7.464s)
+  Antlion B2F Treasure Room                                                   Seed:  19   Index: 201
+    Extra Steps: 24
+  Antlion B2F                                                                 Seed:  19   Index: 225
+Antlion B1F                                                                   Seed:  36   Index:   3
+  Step   4: 19 / Imp x3 (6.648s)
+  Step  28: 20 / Imp x3 (6.648s)
+Overworld (Damcyan)                                                           Seed:  36   Index:  41
+Overworld (Kaipo)                                                             Seed:  36   Index:  41
+Kaipo Revisited                                                               Seed:  36   Index:  41
+Overworld (Kaipo)                                                             Seed:  36   Index:  41
+Overworld (Damcyan)                                                           Seed:  36   Index:  41
+Mt.Hobs-West                                                                  Seed:  36   Index:  41
+Mt.Hobs Summit                                                                Seed:  36   Index:  80
+Battle: MomBomb                                                               Seed:  36   Index:  95
+Mt.Hobs Summit                                                                Seed:  36   Index:  95
+Mt.Hobs-East                                                                  Seed:  36   Index: 101
+  Step  20: 21 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  22: 22 / Gargoyle x2 (7.630s)
+  Step  40: 23 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:  36   Index: 147
+  Step  41: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  73: 25 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  36   Index: 231
+  Optional Steps: 10
+  Extra Steps: 16
+Overworld (Fabul)                                                             Seed:  53   Index:  61
+Fabul Boat and Leviatan                                                       Seed:  53   Index:  68
+Overworld (Mysidia)                                                           Seed:  53   Index:  68
+Mysidia                                                                       Seed:  53   Index:  77
+Overworld (Mysidia)                                                           Seed:  53   Index:  77
+Overworld (Mt.Ordeals)                                                        Seed:  53   Index:  87
+  Extra Steps: 6
+  Step   2: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  56: 27 / Raven x1 (8.356s)
+  Step  80: 28 / Raven x1 (8.356s)
+  Step  99: 29 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  53   Index: 187
+Mt.Ordeals-3rd station                                                        Seed:  53   Index: 230
+  Step  16: 30 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed:  53   Index: 253
+Mt.Ordeals-3rd station                                                        Seed:  53   Index: 253
+Mt.Ordeals-7th station                                                        Seed:  70   Index:   2
+  Step  28: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+  Step  41: 32 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed:  70   Index:  44
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  70   Index:  62
+Mt.Ordeals Summit                                                             Seed:  70   Index:  62
+Paladin                                                                       Seed:  70   Index:  66
+Mt.Ordeals Summit                                                             Seed:  70   Index:  66
+  Optional Steps: 1
+  Step   6: 33 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  70   Index:  89
+  Step  30: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  70   Index: 131
+  Step  22: 35 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals                                                                    Seed:  70   Index: 161
+  Step  17: 36 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  70   Index: 205
+Take Chocobo to Mysidia                                                       Seed:  70   Index: 218
+Overworld (Mysidia)                                                           Seed:  70   Index: 218
+Town of Baron Serpent Road                                                    Seed:  70   Index: 218
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed:  70   Index: 230
+  Overworld (Baron)                                                           Seed:  70   Index: 230
+    Extra Steps: 20
+    Step   1: 37 / Imp x3 (7.174s)
+    Step  20: 38 / Imp x4 (7.223s)
+   (Step  34: 39 / Imp x3)
+   (Step  58: 40 / Imp x3, SwordRat x1)
+   (Step 102: 41 / Imp x3)
+   (Step 111: 42 / FloatEye x2)
+   (Step 143: 43 / FloatEye x2)
+   (Step 183: 44 / Imp x3, SwordRat x1)
+   (Step 239: 45 / FloatEye x2)
+
+Encounter Time:      290.661s
+Other Time:          518.513s
+Total Time:          809.174s
+
+Base Total Time:     926.876s
+Time Saved:          117.702s
+
+Optional Steps:      13
+Extra Steps:         104
+Encounters:          38
+
+Base Encounters:     49
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/242.txt
+++ b/data/routes/cw/242.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	242
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48440040
+VARS	FFFFFFFF:34 C307801:1 E302500:7 E302600:26 E307100:6 E307400:18 E307B01:24 E308700:1 E308702:1 E309700:14
+
+Overworld (Kaipo)                                                             Seed: 242   Index:   0
+Overworld (Kaipo)                                                             Seed: 242   Index:   1
+Kaipo                                                                         Seed: 242   Index:  37
+Overworld (Kaipo)                                                             Seed: 242   Index:  37
+  Step  20: 1 / SandMoth x2, Larva x2 (7.049s)
+  Step  29: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 242   Index:  69
+  Step  29: 3 / Pike x3 (6.935s)
+Recruit Tellah                                                                Seed: 242   Index: 101
+Watery Pass-South B1F                                                         Seed: 242   Index: 101
+  Step  12: 4 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F                                                         Seed: 242   Index: 121
+  Step  41: 5 / Pike x3 (7.152s)
+  Step  58: 6 / Pike x3 (7.152s)
+  Step  73: 7 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  89: 8 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 242   Index: 211
+Watery Pass-South B2F                                                         Seed: 242   Index: 215
+Watery Pass-South B3F                                                         Seed: 242   Index: 254
+  Extra Steps: 6
+Watery Pass-North B2F                                                         Seed:   3   Index:  38
+  Step  18: 9 / Zombie x4 (7.148s)
+Watery Pass-North B1F                                                         Seed:   3   Index:  59
+  Step  28: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:   3   Index: 119
+  Step   1: 11 / Imp x4 (7.049s)
+Waterfalls B1F                                                                Seed:   3   Index: 128
+  Extra Steps: 18
+Waterfalls B2F                                                                Seed:   3   Index: 147
+  Step  35: 12 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:   3   Index: 192
+Battle: Octomamm                                                              Seed:   3   Index: 229
+Waterfalls Lake                                                               Seed:   3   Index: 229
+Overworld (Kaipo)                                                             Seed:   3   Index: 230
+Overworld (Damcyan)                                                           Seed:   3   Index: 241
+Damcyan                                                                       Seed:   3   Index: 245
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed:  20   Index:   3
+Antlion B1F                                                                   Seed:  20   Index:   3
+  Step  26: 13 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  20   Index:  41
+  Antlion B2F                                                                 Seed:  20   Index:  41
+    Step  26: 14 / Weeper x2 (7.114s)
+    Step  52: 15 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  20   Index: 121
+Battle: Antlion                                                               Seed:  20   Index: 135
+Antlion's Nest                                                                Seed:  20   Index: 135
+Antlion B2F Outward Charm Room Steps                                          Seed:  20   Index: 150
+  Antlion B2F                                                                 Seed:  20   Index: 150
+    Step   8: 16 / Basilisk x1, Turtle x1 (7.124s)
+  Antlion B2F Treasure Room                                                   Seed:  20   Index: 201
+    Extra Steps: 24
+  Antlion B2F                                                                 Seed:  20   Index: 225
+    Step  26: 17 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  37   Index:   3
+  Step  28: 18 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  37   Index:  41
+Overworld (Kaipo)                                                             Seed:  37   Index:  41
+Kaipo Revisited                                                               Seed:  37   Index:  41
+Overworld (Kaipo)                                                             Seed:  37   Index:  41
+Overworld (Damcyan)                                                           Seed:  37   Index:  41
+Mt.Hobs-West                                                                  Seed:  37   Index:  41
+Mt.Hobs Summit                                                                Seed:  37   Index:  80
+  Step  14: 19 / Gargoyle x1, Cocktric x2 (9.399s)
+Battle: MomBomb                                                               Seed:  37   Index:  95
+Mt.Hobs Summit                                                                Seed:  37   Index:  95
+Mt.Hobs-East                                                                  Seed:  37   Index: 101
+  Step  20: 20 / Spirit x2, Skelton x2 (8.237s)
+  Step  22: 21 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  40: 22 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  37   Index: 147
+  Step  41: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  73: 24 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed:  37   Index: 231
+  Optional Steps: 10
+  Extra Steps: 16
+Overworld (Fabul)                                                             Seed:  54   Index:  61
+Fabul Boat and Leviatan                                                       Seed:  54   Index:  68
+Overworld (Mysidia)                                                           Seed:  54   Index:  68
+Mysidia                                                                       Seed:  54   Index:  77
+Overworld (Mysidia)                                                           Seed:  54   Index:  77
+Overworld (Mt.Ordeals)                                                        Seed:  54   Index:  87
+  Step   2: 25 / Imp Cap. x4, Imp x2 (8.344s)
+  Step  56: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  80: 27 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  54   Index: 181
+Mt.Ordeals-3rd station                                                        Seed:  54   Index: 224
+  Step  22: 28 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  54   Index: 247
+Mt.Ordeals-3rd station                                                        Seed:  54   Index: 247
+Mt.Ordeals-7th station                                                        Seed:  54   Index: 252
+Mt.Ordeals Summit                                                             Seed:  71   Index:  38
+  Optional Steps: 1
+  Step   5: 29 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed:  71   Index:  56
+Mt.Ordeals Summit                                                             Seed:  71   Index:  56
+Paladin                                                                       Seed:  71   Index:  60
+Mt.Ordeals Summit                                                             Seed:  71   Index:  60
+  Optional Steps: 1
+  Step  12: 30 / Lilith x1 (8.563s)
+  Step  17: 31 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  71   Index:  83
+  Step  36: 32 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  71   Index: 125
+  Step  28: 33 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:  71   Index: 155
+  Step  23: 34 / Spirit x3, Skelton x2, Red Bone x1 (8.758s)
+Overworld (Mt.Ordeals)                                                        Seed:  71   Index: 199
+Take Chocobo to Mysidia                                                       Seed:  71   Index: 212
+Overworld (Mysidia)                                                           Seed:  71   Index: 212
+Town of Baron Serpent Road                                                    Seed:  71   Index: 212
+  Extra Steps: 14
+Credit Warp Fight Search                                                      Seed:  71   Index: 230
+  Overworld (Baron)                                                           Seed:  71   Index: 230
+    Extra Steps: 34
+    Step   1: 35 / Imp x3, SwordRat x1 (7.227s)
+    Step  34: 36 / Imp x4 (7.223s)
+   (Step  58: 37 / Imp x3)
+   (Step 102: 38 / Imp x4)
+   (Step 111: 39 / Imp x3)
+   (Step 143: 40 / Imp x3, SwordRat x1)
+   (Step 239: 41 / Imp x3)
+
+Encounter Time:      280.039s
+Other Time:          525.967s
+Total Time:          806.007s
+
+Base Total Time:     968.438s
+Time Saved:          162.432s
+
+Optional Steps:      13
+Extra Steps:         118
+Encounters:          36
+
+Base Encounters:     49
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/243.txt
+++ b/data/routes/cw/243.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	243
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48689944
+VARS	FFFFFFFF:18 C307800:1 E302500:7 E302600:22 E307400:24 E307B00:22 E308702:1 E309700:20
+
+Overworld (Kaipo)                                                             Seed: 243   Index:   0
+Overworld (Kaipo)                                                             Seed: 243   Index:   1
+Kaipo                                                                         Seed: 243   Index:  37
+Overworld (Kaipo)                                                             Seed: 243   Index:  37
+  Step  20: 1 / SandWorm x1 (7.100s)
+  Step  28: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 243   Index:  69
+Recruit Tellah                                                                Seed: 243   Index: 101
+Watery Pass-South B1F                                                         Seed: 243   Index: 101
+  Step  12: 3 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 243   Index: 121
+  Step  41: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  58: 5 / Pike x3 (7.152s)
+  Step  73: 6 / Pike x3 (7.152s)
+  Step  89: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 243   Index: 211
+Watery Pass-South B2F                                                         Seed: 243   Index: 215
+Watery Pass-South B3F                                                         Seed: 243   Index: 254
+Watery Pass-North B2F                                                         Seed:   4   Index:  32
+Watery Pass-North B1F                                                         Seed:   4   Index:  53
+  Step   3: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  28: 9 / CaveToad x4 (7.163s)
+  Step  34: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:   4   Index: 113
+  Step   7: 11 / Imp x4 (7.049s)
+Waterfalls B1F                                                                Seed:   4   Index: 122
+  Extra Steps: 24
+Waterfalls B2F                                                                Seed:   4   Index: 147
+  Step  35: 12 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:   4   Index: 192
+Battle: Octomamm                                                              Seed:   4   Index: 229
+Waterfalls Lake                                                               Seed:   4   Index: 229
+Overworld (Kaipo)                                                             Seed:   4   Index: 230
+Overworld (Damcyan)                                                           Seed:   4   Index: 241
+Damcyan                                                                       Seed:   4   Index: 245
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed:  21   Index:   3
+Antlion B1F                                                                   Seed:  21   Index:   3
+  Step  26: 13 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Charm Room Steps                                           Seed:  21   Index:  41
+  Antlion B2F                                                                 Seed:  21   Index:  41
+    Step  26: 14 / Weeper x2 (7.114s)
+  Antlion B2F Treasure Room                                                   Seed:  21   Index:  74
+    Extra Steps: 22
+  Antlion B2F                                                                 Seed:  21   Index:  96
+Antlion's Nest                                                                Seed:  21   Index: 148
+Battle: Antlion                                                               Seed:  21   Index: 162
+Antlion's Nest                                                                Seed:  21   Index: 162
+Antlion B2F Outward Direct                                                    Seed:  21   Index: 177
+  Antlion B2F                                                                 Seed:  21   Index: 177
+    Step  45: 15 / Turtle x2 (7.464s)
+    Step  47: 16 / Basilisk x1, Turtle x1 (7.124s)
+    Step  74: 17 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  38   Index:   1
+  Step  30: 18 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  38   Index:  39
+Overworld (Kaipo)                                                             Seed:  38   Index:  39
+Kaipo Revisited                                                               Seed:  38   Index:  39
+Overworld (Kaipo)                                                             Seed:  38   Index:  39
+Overworld (Damcyan)                                                           Seed:  38   Index:  39
+Mt.Hobs-West                                                                  Seed:  38   Index:  39
+  Step  34: 19 / Skelton x4 (8.683s)
+Mt.Hobs Summit                                                                Seed:  38   Index:  78
+Battle: MomBomb                                                               Seed:  38   Index:  93
+Mt.Hobs Summit                                                                Seed:  38   Index:  93
+  Step   1: 20 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed:  38   Index:  99
+  Step  22: 21 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  24: 22 / Gargoyle x2 (7.630s)
+  Step  42: 23 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:  38   Index: 145
+  Step  43: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  75: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed:  38   Index: 229
+  Optional Steps: 10
+  Extra Steps: 12
+Overworld (Fabul)                                                             Seed:  55   Index:  55
+Fabul Boat and Leviatan                                                       Seed:  55   Index:  62
+Overworld (Mysidia)                                                           Seed:  55   Index:  62
+Mysidia                                                                       Seed:  55   Index:  71
+Overworld (Mysidia)                                                           Seed:  55   Index:  71
+Overworld (Mt.Ordeals)                                                        Seed:  55   Index:  81
+  Step   8: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  18: 27 / Raven x1 (8.356s)
+  Step  62: 28 / Raven x1 (8.356s)
+  Step  86: 29 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  55   Index: 175
+Mt.Ordeals-3rd station                                                        Seed:  55   Index: 218
+Recruit Tellah                                                                Seed:  55   Index: 241
+Mt.Ordeals-3rd station                                                        Seed:  55   Index: 241
+  Step   5: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed:  55   Index: 246
+Mt.Ordeals Summit                                                             Seed:  72   Index:  32
+  Optional Steps: 0
+  Step  11: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed:  72   Index:  49
+Mt.Ordeals Summit                                                             Seed:  72   Index:  49
+Paladin                                                                       Seed:  72   Index:  53
+Mt.Ordeals Summit                                                             Seed:  72   Index:  53
+  Optional Steps: 1
+  Step  19: 32 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed:  72   Index:  76
+  Step   1: 33 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-3rd station                                                        Seed:  72   Index: 118
+  Step   1: 34 / Zombie x2, Ghoul x2 (7.552s)
+Mt.Ordeals                                                                    Seed:  72   Index: 148
+  Step   5: 35 / Lilith x1, Red Bone x2 (8.437s)
+  Step  30: 36 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  72   Index: 192
+Take Chocobo to Mysidia                                                       Seed:  72   Index: 205
+Overworld (Mysidia)                                                           Seed:  72   Index: 205
+Town of Baron Serpent Road                                                    Seed:  72   Index: 205
+  Extra Steps: 20
+Credit Warp Fight Search                                                      Seed:  72   Index: 229
+  Overworld (Baron)                                                           Seed:  72   Index: 229
+    Extra Steps: 18
+    Step   2: 37 / Imp x3 (7.174s)
+    Step  18: 38 / Imp x4 (7.223s)
+   (Step  47: 39 / Imp x3)
+   (Step  59: 40 / Imp x3, SwordRat x1)
+   (Step 103: 41 / FloatEye x2)
+   (Step 112: 42 / FloatEye x2)
+   (Step 144: 43 / FloatEye x2)
+   (Step 240: 44 / Imp x3, SwordRat x1)
+
+Encounter Time:      292.717s
+Other Time:          517.448s
+Total Time:          810.165s
+
+Base Total Time:     971.006s
+Time Saved:          160.841s
+
+Optional Steps:      12
+Extra Steps:         102
+Encounters:          38
+
+Base Encounters:     49
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/244.txt
+++ b/data/routes/cw/244.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	244
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48806899
+VARS	FFFFFFFF:18 C307800:1 E302500:1 E302600:21 E307400:36 E307B00:16 E308501:4 E308502:2 E308700:1 E308702:1 E309700:14
+
+Overworld (Kaipo)                                                             Seed: 244   Index:   0
+Overworld (Kaipo)                                                             Seed: 244   Index:   1
+Kaipo                                                                         Seed: 244   Index:  37
+Overworld (Kaipo)                                                             Seed: 244   Index:  37
+  Step  20: 1 / SandWorm x1 (7.100s)
+  Step  28: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 244   Index:  69
+Recruit Tellah                                                                Seed: 244   Index: 101
+Watery Pass-South B1F                                                         Seed: 244   Index: 101
+Watery Pass-South B2F                                                         Seed: 244   Index: 121
+  Step   5: 3 / Pike x3 (7.152s)
+  Step  41: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  58: 5 / Pike x3 (7.152s)
+  Step  73: 6 / Pike x3 (7.152s)
+  Step  89: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 244   Index: 211
+Watery Pass-South B2F                                                         Seed: 244   Index: 215
+Watery Pass-South B3F                                                         Seed: 244   Index: 254
+Watery Pass-North B2F                                                         Seed:   5   Index:  32
+Watery Pass-North B1F                                                         Seed:   5   Index:  53
+  Step   3: 8 / CaveToad x2, Mad Toad x2 (7.163s)
+  Step  28: 9 / CaveToad x4 (7.163s)
+  Step  34: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:   5   Index: 113
+Waterfalls B1F                                                                Seed:   5   Index: 122
+  Extra Steps: 36
+Waterfalls B2F                                                                Seed:   5   Index: 159
+  Step  23: 11 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed:   5   Index: 204
+Battle: Octomamm                                                              Seed:   5   Index: 241
+Waterfalls Lake                                                               Seed:   5   Index: 241
+Overworld (Kaipo)                                                             Seed:   5   Index: 242
+Overworld (Damcyan)                                                           Seed:   5   Index: 253
+Damcyan                                                                       Seed:  22   Index:   1
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  22   Index:   9
+Antlion B1F                                                                   Seed:  22   Index:   9
+Antlion B2F Inward Charm Room Steps                                           Seed:  22   Index:  47
+  Antlion B2F                                                                 Seed:  22   Index:  47
+    Step  20: 12 / Basilisk x1, Imp x3 (6.775s)
+  Antlion B2F Treasure Room                                                   Seed:  22   Index:  80
+    Extra Steps: 16
+  Antlion B2F                                                                 Seed:  22   Index:  96
+Antlion's Nest                                                                Seed:  22   Index: 148
+Battle: Antlion                                                               Seed:  22   Index: 162
+Antlion's Nest                                                                Seed:  22   Index: 162
+Antlion B2F Outward Direct                                                    Seed:  22   Index: 177
+  Antlion B2F                                                                 Seed:  22   Index: 177
+    Step  29: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+    Step  45: 14 / Weeper x2 (7.132s)
+    Step  47: 15 / Turtle x2 (7.464s)
+    Step  74: 16 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed:  39   Index:   1
+  Step  30: 17 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  39   Index:  39
+Overworld (Kaipo)                                                             Seed:  39   Index:  39
+Kaipo Revisited                                                               Seed:  39   Index:  39
+Overworld (Kaipo)                                                             Seed:  39   Index:  39
+Overworld (Damcyan)                                                           Seed:  39   Index:  39
+Mt.Hobs-West                                                                  Seed:  39   Index:  39
+  Step  34: 18 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed:  39   Index:  78
+Battle: MomBomb                                                               Seed:  39   Index:  93
+Mt.Hobs Summit                                                                Seed:  39   Index:  93
+  Step   1: 19 / Spirit x2 (7.652s)
+Mt.Hobs-East                                                                  Seed:  39   Index:  99
+  Step  22: 20 / Spirit x2, Skelton x2 (8.237s)
+  Step  24: 21 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  42: 22 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  39   Index: 145
+  Step  43: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  58: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  75: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed:  39   Index: 229
+  Optional Steps: 9
+  Extra Steps: 12
+Overworld (Fabul)                                                             Seed:  56   Index:  54
+Fabul Boat and Leviatan                                                       Seed:  56   Index:  61
+Overworld (Mysidia)                                                           Seed:  56   Index:  61
+Mysidia                                                                       Seed:  56   Index:  70
+Overworld (Mysidia)                                                           Seed:  56   Index:  70
+Overworld (Mt.Ordeals)                                                        Seed:  56   Index:  80
+  Step   9: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  19: 27 / Raven x1 (8.356s)
+  Step  63: 28 / Raven x1 (8.356s)
+  Step  87: 29 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  56   Index: 174
+Mt.Ordeals-3rd station                                                        Seed:  56   Index: 217
+Recruit Tellah                                                                Seed:  56   Index: 240
+Mt.Ordeals-3rd station                                                        Seed:  56   Index: 240
+  Extra Steps: 4
+  Step   9: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed:  56   Index: 249
+Mt.Ordeals Summit                                                             Seed:  73   Index:  35
+  Optional Steps: 1
+  Step   8: 31 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed:  73   Index:  53
+Mt.Ordeals Summit                                                             Seed:  73   Index:  53
+Paladin                                                                       Seed:  73   Index:  57
+Mt.Ordeals Summit                                                             Seed:  73   Index:  57
+  Optional Steps: 1
+  Step  15: 32 / Lilith x1, Red Bone x2 (8.437s)
+  Step  20: 33 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  73   Index:  80
+  Step  39: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals-3rd station                                                        Seed:  73   Index: 122
+  Extra Steps: 2
+  Step   5: 35 / Lilith x1, Red Bone x2 (8.437s)
+  Step  31: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed:  73   Index: 154
+Overworld (Mt.Ordeals)                                                        Seed:  73   Index: 198
+Take Chocobo to Mysidia                                                       Seed:  73   Index: 211
+Overworld (Mysidia)                                                           Seed:  73   Index: 211
+Town of Baron Serpent Road                                                    Seed:  73   Index: 211
+  Extra Steps: 14
+Credit Warp Fight Search                                                      Seed:  73   Index: 229
+  Overworld (Baron)                                                           Seed:  73   Index: 229
+    Extra Steps: 18
+    Step   2: 37 / Imp x3 (7.174s)
+    Step  18: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  47: 39 / Imp x3)
+   (Step  59: 40 / Imp x3, SwordRat x1)
+   (Step 103: 41 / FloatEye x2)
+   (Step 144: 42 / FloatEye x2)
+   (Step 232: 43 / FloatEye x2)
+   (Step 240: 44 / Imp x3, SwordRat x1)
+
+Encounter Time:      294.663s
+Other Time:          517.448s
+Total Time:          812.111s
+
+Base Total Time:     970.457s
+Time Saved:          158.346s
+
+Optional Steps:      12
+Extra Steps:         102
+Encounters:          38
+
+Base Encounters:     49
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/245.txt
+++ b/data/routes/cw/245.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	245
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48688846
+VARS	FFFFFFFF:18 C307800:1 E302500:1 E302600:21 E307200:4 E307400:32 E307B00:16 E308501:12 E308700:1 E308702:1 E309700:8
+
+Overworld (Kaipo)                                                             Seed: 245   Index:   0
+Overworld (Kaipo)                                                             Seed: 245   Index:   1
+Kaipo                                                                         Seed: 245   Index:  37
+Overworld (Kaipo)                                                             Seed: 245   Index:  37
+  Step  20: 1 / SandWorm x1 (7.100s)
+  Step  28: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 245   Index:  69
+Recruit Tellah                                                                Seed: 245   Index: 101
+Watery Pass-South B1F                                                         Seed: 245   Index: 101
+Watery Pass-South B2F                                                         Seed: 245   Index: 121
+  Step   5: 3 / Pike x3 (7.152s)
+  Step   8: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  58: 5 / Pike x3 (7.152s)
+  Step  73: 6 / Pike x3 (7.152s)
+  Step  89: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 245   Index: 211
+Watery Pass-South B2F                                                         Seed: 245   Index: 215
+Watery Pass-South B3F                                                         Seed: 245   Index: 254
+Watery Pass-North B2F                                                         Seed:   6   Index:  32
+  Extra Steps: 4
+  Step  24: 8 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed:   6   Index:  57
+  Step  24: 9 / CaveToad x4 (7.163s)
+  Step  30: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:   6   Index: 117
+Waterfalls B1F                                                                Seed:   6   Index: 126
+  Extra Steps: 32
+Waterfalls B2F                                                                Seed:   6   Index: 159
+  Step  23: 11 / Zombie x6 (7.489s)
+  Step  24: 12 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:   6   Index: 204
+Battle: Octomamm                                                              Seed:   6   Index: 241
+Waterfalls Lake                                                               Seed:   6   Index: 241
+Overworld (Kaipo)                                                             Seed:   6   Index: 242
+Overworld (Damcyan)                                                           Seed:   6   Index: 253
+Damcyan                                                                       Seed:  23   Index:   1
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  23   Index:   9
+Antlion B1F                                                                   Seed:  23   Index:   9
+Antlion B2F Inward Charm Room Steps                                           Seed:  23   Index:  47
+  Antlion B2F                                                                 Seed:  23   Index:  47
+    Step  20: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+  Antlion B2F Treasure Room                                                   Seed:  23   Index:  80
+    Extra Steps: 16
+  Antlion B2F                                                                 Seed:  23   Index:  96
+Antlion's Nest                                                                Seed:  23   Index: 148
+Battle: Antlion                                                               Seed:  23   Index: 162
+Antlion's Nest                                                                Seed:  23   Index: 162
+Antlion B2F Outward Direct                                                    Seed:  23   Index: 177
+  Antlion B2F                                                                 Seed:  23   Index: 177
+    Step  29: 14 / Weeper x2 (7.132s)
+    Step  47: 15 / Turtle x2 (7.464s)
+    Step  62: 16 / Basilisk x1, Turtle x1 (7.124s)
+    Step  74: 17 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  40   Index:   1
+  Step  30: 18 / Turtle x1, Imp x2 (7.009s)
+Overworld (Damcyan)                                                           Seed:  40   Index:  39
+Overworld (Kaipo)                                                             Seed:  40   Index:  39
+Kaipo Revisited                                                               Seed:  40   Index:  39
+Overworld (Kaipo)                                                             Seed:  40   Index:  39
+Overworld (Damcyan)                                                           Seed:  40   Index:  39
+Mt.Hobs-West                                                                  Seed:  40   Index:  39
+  Step  34: 19 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed:  40   Index:  78
+Battle: MomBomb                                                               Seed:  40   Index:  93
+Mt.Hobs Summit                                                                Seed:  40   Index:  93
+  Step   1: 20 / Gargoyle x1, Cocktric x2 (7.868s)
+Mt.Hobs-East                                                                  Seed:  40   Index:  99
+  Step  22: 21 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step  24: 22 / Gargoyle x2 (7.630s)
+  Step  26: 23 / Spirit x2, Skelton x2 (8.237s)
+Overworld (Fabul)                                                             Seed:  40   Index: 145
+  Step  58: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  75: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed:  40   Index: 229
+  Optional Steps: 9
+  Extra Steps: 12
+Overworld (Fabul)                                                             Seed:  57   Index:  54
+Fabul Boat and Leviatan                                                       Seed:  57   Index:  61
+Overworld (Mysidia)                                                           Seed:  57   Index:  61
+Mysidia                                                                       Seed:  57   Index:  70
+Overworld (Mysidia)                                                           Seed:  57   Index:  70
+Overworld (Mt.Ordeals)                                                        Seed:  57   Index:  80
+  Step   9: 26 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  19: 27 / Raven x1 (8.356s)
+  Step  63: 28 / Raven x1 (8.356s)
+  Step  87: 29 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  57   Index: 174
+Mt.Ordeals-3rd station                                                        Seed:  57   Index: 217
+Recruit Tellah                                                                Seed:  57   Index: 240
+Mt.Ordeals-3rd station                                                        Seed:  57   Index: 240
+  Extra Steps: 12
+  Step   9: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+  Step  17: 31 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed:  74   Index:   1
+Mt.Ordeals Summit                                                             Seed:  74   Index:  43
+  Optional Steps: 1
+Battle: Milon and Milon Z                                                     Seed:  74   Index:  61
+Mt.Ordeals Summit                                                             Seed:  74   Index:  61
+Paladin                                                                       Seed:  74   Index:  65
+Mt.Ordeals Summit                                                             Seed:  74   Index:  65
+  Optional Steps: 1
+  Step   7: 32 / Lilith x1, Red Bone x2 (8.437s)
+  Step  12: 33 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  74   Index:  88
+  Step  31: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  39: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed:  74   Index: 130
+  Step  23: 36 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed:  74   Index: 160
+Overworld (Mt.Ordeals)                                                        Seed:  74   Index: 204
+Take Chocobo to Mysidia                                                       Seed:  74   Index: 217
+Overworld (Mysidia)                                                           Seed:  74   Index: 217
+Town of Baron Serpent Road                                                    Seed:  74   Index: 217
+  Extra Steps: 8
+Credit Warp Fight Search                                                      Seed:  74   Index: 229
+  Overworld (Baron)                                                           Seed:  74   Index: 229
+    Extra Steps: 18
+    Step   2: 37 / Imp x3 (7.174s)
+    Step  18: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  47: 39 / Imp x3)
+   (Step  59: 40 / Imp x3, SwordRat x1)
+   (Step 103: 41 / FloatEye x2)
+   (Step 232: 42 / FloatEye x2)
+   (Step 240: 43 / FloatEye x2)
+
+Encounter Time:      292.699s
+Other Time:          517.448s
+Total Time:          810.147s
+
+Base Total Time:     1040.719s
+Time Saved:          230.573s
+
+Optional Steps:      12
+Extra Steps:         102
+Encounters:          38
+
+Base Encounters:     49
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/246.txt
+++ b/data/routes/cw/246.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	246
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49937539
+VARS	FFFFFFFF:18 C307801:1 E302500:1 E302600:7 E307200:4 E307400:56 E307B01:20 E308700:1 E308701:6 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 246   Index:   0
+Overworld (Kaipo)                                                             Seed: 246   Index:   1
+Kaipo                                                                         Seed: 246   Index:  37
+Overworld (Kaipo)                                                             Seed: 246   Index:  37
+  Step  20: 1 / SandWorm x1 (7.100s)
+  Step  28: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 246   Index:  69
+Recruit Tellah                                                                Seed: 246   Index: 101
+Watery Pass-South B1F                                                         Seed: 246   Index: 101
+Watery Pass-South B2F                                                         Seed: 246   Index: 121
+  Step   5: 3 / Pike x3 (7.152s)
+  Step   8: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  40: 5 / Pike x3 (7.152s)
+  Step  58: 6 / Pike x3 (7.152s)
+  Step  89: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 246   Index: 211
+Watery Pass-South B2F                                                         Seed: 246   Index: 215
+Watery Pass-South B3F                                                         Seed: 246   Index: 254
+Watery Pass-North B2F                                                         Seed:   7   Index:  32
+  Extra Steps: 4
+  Step  24: 8 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed:   7   Index:  57
+  Step  24: 9 / CaveToad x4 (7.163s)
+  Step  30: 10 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:   7   Index: 117
+Waterfalls B1F                                                                Seed:   7   Index: 126
+  Extra Steps: 56
+Waterfalls B2F                                                                Seed:   7   Index: 183
+  Step  40: 11 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed:   7   Index: 228
+Battle: Octomamm                                                              Seed:  24   Index:   9
+Waterfalls Lake                                                               Seed:  24   Index:   9
+Overworld (Kaipo)                                                             Seed:  24   Index:  10
+Overworld (Damcyan)                                                           Seed:  24   Index:  21
+Damcyan                                                                       Seed:  24   Index:  25
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  24   Index:  33
+Antlion B1F                                                                   Seed:  24   Index:  33
+  Step  34: 12 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Direct                                                     Seed:  24   Index:  71
+  Antlion B2F                                                                 Seed:  24   Index:  71
+    Step  22: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+    Step  25: 14 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed:  24   Index: 151
+Battle: Antlion                                                               Seed:  24   Index: 165
+Antlion's Nest                                                                Seed:  24   Index: 165
+Antlion B2F Outward Charm Room Steps                                          Seed:  24   Index: 180
+  Antlion B2F                                                                 Seed:  24   Index: 180
+    Step  26: 15 / Turtle x2 (7.464s)
+    Step  44: 16 / Basilisk x1, Turtle x1 (7.124s)
+  Antlion B2F Treasure Room                                                   Seed:  24   Index: 231
+    Extra Steps: 20
+  Antlion B2F                                                                 Seed:  24   Index: 251
+    Step   2: 17 / Basilisk x1, Imp x3 (6.783s)
+    Step  31: 18 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  41   Index:  29
+  Step   2: 19 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  41   Index:  67
+Overworld (Kaipo)                                                             Seed:  41   Index:  67
+Kaipo Revisited                                                               Seed:  41   Index:  67
+Overworld (Kaipo)                                                             Seed:  41   Index:  67
+Overworld (Damcyan)                                                           Seed:  41   Index:  67
+Mt.Hobs-West                                                                  Seed:  41   Index:  67
+  Step   6: 20 / Skelton x4 (8.683s)
+  Step  27: 21 / Bomb x3 (8.832s)
+Mt.Hobs Summit                                                                Seed:  41   Index: 106
+  Step  15: 22 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:  41   Index: 121
+Mt.Hobs Summit                                                                Seed:  41   Index: 121
+  Step   2: 23 / Gargoyle x1, Cocktric x2 (7.868s)
+  Step   4: 24 / GrayBomb x2, Bomb x2 (8.430s)
+Mt.Hobs-East                                                                  Seed:  41   Index: 127
+Overworld (Fabul)                                                             Seed:  41   Index: 173
+  Step  30: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+  Step  68: 26 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed:  58   Index:   1
+  Optional Steps: 7
+Overworld (Fabul)                                                             Seed:  58   Index:  68
+Fabul Boat and Leviatan                                                       Seed:  58   Index:  75
+Overworld (Mysidia)                                                           Seed:  58   Index:  75
+Mysidia                                                                       Seed:  58   Index:  84
+Overworld (Mysidia)                                                           Seed:  58   Index:  84
+  Step   5: 27 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed:  58   Index:  94
+  Step   5: 28 / Raven x1 (8.356s)
+  Step  49: 29 / Raven x1 (8.356s)
+  Step  73: 30 / Needler x2, SwordRat x2 (8.097s)
+Mt.Ordeals                                                                    Seed:  58   Index: 188
+Mt.Ordeals-3rd station                                                        Seed:  58   Index: 231
+  Step   1: 31 / Revenant x1, Ghoul x3 (8.911s)
+  Step  18: 32 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  58   Index: 254
+Mt.Ordeals-3rd station                                                        Seed:  58   Index: 254
+  Step   3: 33 / Ghoul x2, Soul x2 (9.197s)
+Mt.Ordeals-7th station                                                        Seed:  75   Index:   3
+Mt.Ordeals Summit                                                             Seed:  75   Index:  45
+  Optional Steps: 1
+  Step   3: 34 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Battle: Milon and Milon Z                                                     Seed:  75   Index:  63
+Mt.Ordeals Summit                                                             Seed:  75   Index:  63
+  Extra Steps: 6
+  Step   9: 35 / Ghoul x2, Soul x2 (8.941s)
+Paladin                                                                       Seed:  75   Index:  73
+Mt.Ordeals Summit                                                             Seed:  75   Index:  73
+  Optional Steps: 1
+  Step   4: 36 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed:  75   Index:  96
+  Step  23: 37 / Ghoul x2, Soul x2 (8.971s)
+  Step  31: 38 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-3rd station                                                        Seed:  75   Index: 138
+Mt.Ordeals                                                                    Seed:  75   Index: 168
+Overworld (Mt.Ordeals)                                                        Seed:  75   Index: 212
+Take Chocobo to Mysidia                                                       Seed:  75   Index: 225
+Overworld (Mysidia)                                                           Seed:  75   Index: 225
+Town of Baron Serpent Road                                                    Seed:  75   Index: 225
+Credit Warp Fight Search                                                      Seed:  75   Index: 229
+  Overworld (Baron)                                                           Seed:  75   Index: 229
+    Extra Steps: 18
+    Step   2: 39 / Imp x3 (7.174s)
+    Step  18: 40 / Imp x3, SwordRat x1 (7.227s)
+   (Step  47: 41 / FloatEye x2)
+   (Step  59: 42 / FloatEye x2)
+   (Step  77: 43 / FloatEye x2)
+   (Step 232: 44 / Imp x3, SwordRat x1)
+   (Step 240: 45 / FloatEye x1, Eagle x2)
+
+Encounter Time:      312.944s
+Other Time:          517.980s
+Total Time:          830.924s
+
+Base Total Time:     965.466s
+Time Saved:          134.542s
+
+Optional Steps:      10
+Extra Steps:         104
+Encounters:          40
+
+Base Encounters:     49
+Encounters Saved:    9
+
+Number of Variables: 54

--- a/data/routes/cw/247.txt
+++ b/data/routes/cw/247.txt
@@ -1,0 +1,153 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	247
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49631212
+VARS	FFFFFFFF:30 C307801:1 E302500:1 E302600:10 E307100:24 E307200:4 E307400:32 E307701:4 E307B01:22 E308700:1 E308702:1 E309700:14
+
+Overworld (Kaipo)                                                             Seed: 247   Index:   0
+Overworld (Kaipo)                                                             Seed: 247   Index:   1
+Kaipo                                                                         Seed: 247   Index:  37
+Overworld (Kaipo)                                                             Seed: 247   Index:  37
+  Step  20: 1 / SandWorm x1 (7.100s)
+  Step  28: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 247   Index:  69
+Recruit Tellah                                                                Seed: 247   Index: 101
+Watery Pass-South B1F                                                         Seed: 247   Index: 101
+Watery Pass-South B2F                                                         Seed: 247   Index: 121
+  Step   5: 3 / Pike x3 (7.152s)
+  Step   8: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  40: 5 / Pike x3 (7.152s)
+  Step  58: 6 / Pike x3 (7.152s)
+  Step  72: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 247   Index: 211
+Watery Pass-South B2F                                                         Seed: 247   Index: 215
+Watery Pass-South B3F                                                         Seed: 247   Index: 254
+  Extra Steps: 24
+Watery Pass-North B2F                                                         Seed:   8   Index:  56
+  Extra Steps: 4
+  Step  25: 8 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed:   8   Index:  81
+Overworld (Kaipo)                                                             Seed:   8   Index: 141
+  Step   5: 9 / Imp x4 (7.049s)
+Waterfalls B1F                                                                Seed:   8   Index: 150
+  Extra Steps: 32
+Waterfalls B2F                                                                Seed:   8   Index: 183
+  Step  40: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:   8   Index: 228
+  Step  27: 11 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed:  25   Index:   9
+Waterfalls Lake                                                               Seed:  25   Index:   9
+Overworld (Kaipo)                                                             Seed:  25   Index:  10
+Overworld (Damcyan)                                                           Seed:  25   Index:  21
+Damcyan                                                                       Seed:  25   Index:  25
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  25   Index:  33
+Antlion B1F                                                                   Seed:  25   Index:  33
+  Step  19: 12 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  34: 13 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed:  25   Index:  71
+  Antlion B2F                                                                 Seed:  25   Index:  71
+    Step  25: 14 / Weeper x2 (7.114s)
+Antlion's Nest                                                                Seed:  25   Index: 151
+Battle: Antlion                                                               Seed:  25   Index: 165
+Antlion's Nest                                                                Seed:  25   Index: 165
+Antlion B2F Outward Charm Room Steps                                          Seed:  25   Index: 180
+  Antlion B2F                                                                 Seed:  25   Index: 180
+    Step  26: 15 / Turtle x2 (7.464s)
+    Step  44: 16 / Basilisk x1, Turtle x1 (7.124s)
+  Antlion B2F Treasure Room                                                   Seed:  25   Index: 231
+    Extra Steps: 22
+  Antlion B2F                                                                 Seed:  25   Index: 253
+    Step  29: 17 / Basilisk x1, Imp x3 (6.783s)
+    Step  34: 18 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  42   Index:  31
+  Extra Steps: 4
+  Step  42: 19 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  42   Index:  73
+Overworld (Kaipo)                                                             Seed:  42   Index:  73
+Kaipo Revisited                                                               Seed:  42   Index:  73
+Overworld (Kaipo)                                                             Seed:  42   Index:  73
+Overworld (Damcyan)                                                           Seed:  42   Index:  73
+Mt.Hobs-West                                                                  Seed:  42   Index:  73
+  Step  21: 20 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed:  42   Index: 112
+  Step  11: 21 / Skelton x4 (8.683s)
+  Step  13: 22 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:  42   Index: 127
+Mt.Hobs Summit                                                                Seed:  42   Index: 127
+Mt.Hobs-East                                                                  Seed:  42   Index: 133
+Overworld (Fabul)                                                             Seed:  42   Index: 179
+  Step  24: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  57: 24 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  62: 25 / Gargoyle x1, Cocktric x2 (8.254s)
+Fabul                                                                         Seed:  59   Index:   7
+  Optional Steps: 10
+Overworld (Fabul)                                                             Seed:  59   Index:  77
+Fabul Boat and Leviatan                                                       Seed:  59   Index:  84
+Overworld (Mysidia)                                                           Seed:  59   Index:  84
+Mysidia                                                                       Seed:  59   Index:  93
+Overworld (Mysidia)                                                           Seed:  59   Index:  93
+  Step   6: 26 / Imp Cap. x3, Needler x1 (7.932s)
+Overworld (Mt.Ordeals)                                                        Seed:  59   Index: 103
+  Step  21: 27 / Raven x1 (8.356s)
+  Step  40: 28 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  59   Index: 197
+  Step  35: 29 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed:  59   Index: 240
+  Step   9: 30 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+  Step  17: 31 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  76   Index:   7
+Mt.Ordeals-3rd station                                                        Seed:  76   Index:   7
+Mt.Ordeals-7th station                                                        Seed:  76   Index:  12
+  Step  36: 32 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed:  76   Index:  54
+  Optional Steps: 1
+  Step  18: 33 / Soul x2, Ghoul x2, Revenant x2 (10.367s)
+Battle: Milon and Milon Z                                                     Seed:  76   Index:  72
+Mt.Ordeals Summit                                                             Seed:  76   Index:  72
+Paladin                                                                       Seed:  76   Index:  76
+Mt.Ordeals Summit                                                             Seed:  76   Index:  76
+  Optional Steps: 1
+  Step   1: 34 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+Mt.Ordeals-7th station                                                        Seed:  76   Index:  99
+  Step  19: 35 / Ghoul x2, Soul x2 (8.971s)
+  Step  28: 36 / Lilith x1 (8.563s)
+Mt.Ordeals-3rd station                                                        Seed:  76   Index: 141
+Mt.Ordeals                                                                    Seed:  76   Index: 171
+Overworld (Mt.Ordeals)                                                        Seed:  76   Index: 215
+Take Chocobo to Mysidia                                                       Seed:  76   Index: 228
+Overworld (Mysidia)                                                           Seed:  76   Index: 228
+Town of Baron Serpent Road                                                    Seed:  76   Index: 228
+  Extra Steps: 14
+Credit Warp Fight Search                                                      Seed:  76   Index: 246
+  Overworld (Baron)                                                           Seed:  76   Index: 246
+    Extra Steps: 30
+    Step   1: 37 / Imp x3 (7.174s)
+    Step  30: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  60: 39 / Imp x3)
+   (Step 158: 40 / Imp x3, SwordRat x1)
+   (Step 215: 41 / FloatEye x2)
+   (Step 223: 42 / FloatEye x2)
+   (Step 240: 43 / FloatEye x2)
+   (Step 255: 44 / Eagle x3)
+
+Encounter Time:      297.730s
+Other Time:          528.097s
+Total Time:          825.827s
+
+Base Total Time:     966.425s
+Time Saved:          140.598s
+
+Optional Steps:      13
+Extra Steps:         130
+Encounters:          38
+
+Base Encounters:     49
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/248.txt
+++ b/data/routes/cw/248.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	248
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	49395124
+VARS	FFFFFFFF:30 E302500:35 E302600:9 E305400:10 E307400:50 E308700:1 E308702:1 E309700:12
+
+Overworld (Kaipo)                                                             Seed: 248   Index:   0
+Overworld (Kaipo)                                                             Seed: 248   Index:   1
+Kaipo                                                                         Seed: 248   Index:  37
+Overworld (Kaipo)                                                             Seed: 248   Index:  37
+  Step  20: 1 / SandWorm x1 (7.100s)
+  Step  28: 2 / Imp x4 (6.944s)
+Watery Pass-South B1F                                                         Seed: 248   Index:  69
+Recruit Tellah                                                                Seed: 248   Index: 101
+Watery Pass-South B1F                                                         Seed: 248   Index: 101
+Watery Pass-South B2F                                                         Seed: 248   Index: 121
+  Step   5: 3 / Pike x3 (7.152s)
+  Step   8: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  40: 5 / Pike x3 (7.152s)
+  Step  58: 6 / Pike x3 (7.152s)
+  Step  72: 7 / EvilShel x3, WaterBug x1 (7.081s)
+Watery Pass-South B2F Save Room                                               Seed: 248   Index: 211
+  Extra Steps: 10
+Watery Pass-South B2F                                                         Seed: 248   Index: 225
+Watery Pass-South B3F                                                         Seed:   9   Index:   8
+  Step  27: 8 / Jelly x4 (7.324s)
+Watery Pass-North B2F                                                         Seed:   9   Index:  42
+Watery Pass-North B1F                                                         Seed:   9   Index:  63
+  Step  18: 9 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed:   9   Index: 123
+Waterfalls B1F                                                                Seed:   9   Index: 132
+  Extra Steps: 50
+Waterfalls B2F                                                                Seed:   9   Index: 183
+  Step  40: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:   9   Index: 228
+  Step  27: 11 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed:  26   Index:   9
+Waterfalls Lake                                                               Seed:  26   Index:   9
+Overworld (Kaipo)                                                             Seed:  26   Index:  10
+Overworld (Damcyan)                                                           Seed:  26   Index:  21
+Damcyan                                                                       Seed:  26   Index:  25
+  Optional Steps: 1
+  Extra Steps: 34
+Overworld (Damcyan)                                                           Seed:  26   Index:  67
+Antlion B1F                                                                   Seed:  26   Index:  67
+  Step  29: 12 / Imp x3, Imp Cap. x1 (6.755s)
+Antlion B2F Inward Direct                                                     Seed:  26   Index: 105
+  Antlion B2F                                                                 Seed:  26   Index: 105
+Antlion's Nest                                                                Seed:  26   Index: 185
+Battle: Antlion                                                               Seed:  26   Index: 199
+Antlion's Nest                                                                Seed:  26   Index: 199
+  Step   7: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Direct                                                    Seed:  26   Index: 214
+  Antlion B2F                                                                 Seed:  26   Index: 214
+    Step  25: 14 / Weeper x2 (7.132s)
+    Step  37: 15 / Turtle x2 (7.464s)
+    Step  39: 16 / Basilisk x1, Turtle x1 (7.124s)
+    Step  68: 17 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  43   Index:  38
+  Step   9: 18 / Turtle x1, Imp x2 (7.009s)
+  Step  35: 19 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  43   Index:  76
+Overworld (Kaipo)                                                             Seed:  43   Index:  76
+Kaipo Revisited                                                               Seed:  43   Index:  76
+Overworld (Kaipo)                                                             Seed:  43   Index:  76
+Overworld (Damcyan)                                                           Seed:  43   Index:  76
+Mt.Hobs-West                                                                  Seed:  43   Index:  76
+  Step  18: 20 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed:  43   Index: 115
+  Step   8: 21 / Skelton x4 (8.683s)
+  Step  10: 22 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:  43   Index: 130
+Mt.Hobs Summit                                                                Seed:  43   Index: 130
+Mt.Hobs-East                                                                  Seed:  43   Index: 136
+Overworld (Fabul)                                                             Seed:  43   Index: 182
+  Step  21: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  54: 24 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed:  60   Index:  10
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed:  60   Index:  79
+Fabul Boat and Leviatan                                                       Seed:  60   Index:  86
+Overworld (Mysidia)                                                           Seed:  60   Index:  86
+Mysidia                                                                       Seed:  60   Index:  95
+Overworld (Mysidia)                                                           Seed:  60   Index:  95
+  Step   4: 25 / Raven x1 (8.356s)
+Overworld (Mt.Ordeals)                                                        Seed:  60   Index: 105
+  Step  19: 26 / Imp Cap. x3, Needler x1 (7.932s)
+  Step  38: 27 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  60   Index: 199
+  Step  33: 28 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed:  60   Index: 242
+  Step   7: 29 / Revenant x1, Ghoul x3 (8.911s)
+  Step  15: 30 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed:  77   Index:   9
+Mt.Ordeals-3rd station                                                        Seed:  77   Index:   9
+Mt.Ordeals-7th station                                                        Seed:  77   Index:  14
+  Step  34: 31 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed:  77   Index:  56
+  Optional Steps: 1
+  Step  16: 32 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed:  77   Index:  74
+Mt.Ordeals Summit                                                             Seed:  77   Index:  74
+  Step   3: 33 / Soul x2, Ghoul x2, Revenant x2 (10.046s)
+Paladin                                                                       Seed:  77   Index:  78
+Mt.Ordeals Summit                                                             Seed:  77   Index:  78
+  Optional Steps: 1
+Mt.Ordeals-7th station                                                        Seed:  77   Index: 101
+  Step  17: 34 / Soul x2, Ghoul x2, Revenant x2 (9.991s)
+  Step  26: 35 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals-3rd station                                                        Seed:  77   Index: 143
+Mt.Ordeals                                                                    Seed:  77   Index: 173
+  Step  22: 36 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  77   Index: 217
+Take Chocobo to Mysidia                                                       Seed:  77   Index: 230
+Overworld (Mysidia)                                                           Seed:  77   Index: 230
+Town of Baron Serpent Road                                                    Seed:  77   Index: 230
+  Extra Steps: 12
+Credit Warp Fight Search                                                      Seed:  77   Index: 246
+  Overworld (Baron)                                                           Seed:  77   Index: 246
+    Extra Steps: 30
+    Step   1: 37 / Imp x3 (7.174s)
+    Step  30: 38 / Imp x3, SwordRat x1 (7.227s)
+   (Step  60: 39 / Imp x3)
+   (Step 158: 40 / Imp x3, SwordRat x1)
+   (Step 191: 41 / FloatEye x2)
+   (Step 215: 42 / FloatEye x2)
+   (Step 240: 43 / FloatEye x2)
+   (Step 255: 44 / Eagle x3)
+
+Encounter Time:      296.797s
+Other Time:          525.102s
+Total Time:          821.898s
+
+Base Total Time:     947.477s
+Time Saved:          125.579s
+
+Optional Steps:      12
+Extra Steps:         136
+Encounters:          38
+
+Base Encounters:     49
+Encounters Saved:    11
+
+Number of Variables: 54

--- a/data/routes/cw/249.txt
+++ b/data/routes/cw/249.txt
@@ -1,0 +1,149 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	249
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48046945
+VARS	FFFFFFFF:12 C307800:1 C307801:1 E000202:4 E302500:1 E302600:56 E307B00:52 E307B01:26 E308702:1 E309700:16
+
+Overworld (Kaipo)                                                             Seed: 249   Index:   0
+Overworld (Kaipo)                                                             Seed: 249   Index:   1
+Kaipo                                                                         Seed: 249   Index:  37
+Overworld (Kaipo)                                                             Seed: 249   Index:  37
+  Step  28: 1 / SandWorm x1 (7.100s)
+Watery Pass-South B1F                                                         Seed: 249   Index:  69
+Recruit Tellah                                                                Seed: 249   Index: 101
+Watery Pass-South B1F                                                         Seed: 249   Index: 101
+Watery Pass-South B2F                                                         Seed: 249   Index: 121
+  Step   5: 2 / Pike x2, EvilShel x2 (7.149s)
+  Step   8: 3 / Pike x3 (7.152s)
+  Step  40: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  72: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 249   Index: 211
+Watery Pass-South B2F                                                         Seed: 249   Index: 215
+  Step  10: 6 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 249   Index: 254
+  Step  15: 7 / Pike x3 (7.152s)
+Watery Pass-North B2F                                                         Seed:  10   Index:  32
+  Step   3: 8 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed:  10   Index:  53
+  Step  28: 9 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed:  10   Index: 113
+Waterfalls B1F                                                                Seed:  10   Index: 122
+Waterfalls B2F                                                                Seed:  10   Index: 123
+  Step  36: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:  10   Index: 168
+  Step  14: 11 / Zombie x6 (7.489s)
+  Step  15: 12 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed:  10   Index: 205
+Waterfalls Lake                                                               Seed:  10   Index: 205
+Overworld (Kaipo)                                                             Seed:  10   Index: 206
+Overworld (Damcyan)                                                           Seed:  10   Index: 217
+Damcyan                                                                       Seed:  10   Index: 221
+  Optional Steps: 1
+Overworld (Damcyan)                                                           Seed:  10   Index: 229
+Antlion B1F                                                                   Seed:  10   Index: 229
+  Step  26: 13 / Cream x4 (7.552s)
+Antlion B2F Inward Charm Room Steps                                           Seed:  27   Index:  11
+  Antlion B2F                                                                 Seed:  27   Index:  11
+  Antlion B2F Treasure Room                                                   Seed:  27   Index:  44
+    Extra Steps: 52
+  Antlion B2F                                                                 Seed:  27   Index:  96
+Antlion's Nest                                                                Seed:  27   Index: 148
+Battle: Antlion                                                               Seed:  27   Index: 162
+Antlion's Nest                                                                Seed:  27   Index: 162
+Antlion B2F Outward Charm Room Steps                                          Seed:  27   Index: 177
+  Antlion B2F                                                                 Seed:  27   Index: 177
+    Step  29: 14 / Weeper x2 (7.132s)
+  Antlion B2F Treasure Room                                                   Seed:  27   Index: 228
+    Extra Steps: 26
+  Antlion B2F                                                                 Seed:  27   Index: 254
+    Step  28: 15 / Turtle x2 (7.464s)
+Antlion B1F                                                                   Seed:  44   Index:  32
+  Step  15: 16 / Basilisk x1, Imp x3 (6.783s)
+  Step  26: 17 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  44   Index:  70
+Overworld (Kaipo)                                                             Seed:  44   Index:  70
+  Extra Steps: 4
+  Step   3: 18 / Imp x4 (7.024s)
+Kaipo Revisited                                                               Seed:  44   Index:  74
+Overworld (Kaipo)                                                             Seed:  44   Index:  74
+Overworld (Damcyan)                                                           Seed:  44   Index:  74
+Mt.Hobs-West                                                                  Seed:  44   Index:  74
+  Step  20: 19 / Spirit x2 (8.028s)
+Mt.Hobs Summit                                                                Seed:  44   Index: 113
+  Step  12: 20 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:  44   Index: 128
+Mt.Hobs Summit                                                                Seed:  44   Index: 128
+Mt.Hobs-East                                                                  Seed:  44   Index: 134
+Overworld (Fabul)                                                             Seed:  44   Index: 180
+  Step  23: 21 / Cocktric x3 (8.241s)
+  Step  56: 22 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed:  61   Index:   8
+  Optional Steps: 10
+  Extra Steps: 46
+Overworld (Fabul)                                                             Seed:  61   Index: 124
+Fabul Boat and Leviatan                                                       Seed:  61   Index: 131
+Overworld (Mysidia)                                                           Seed:  61   Index: 131
+Mysidia                                                                       Seed:  61   Index: 140
+Overworld (Mysidia)                                                           Seed:  61   Index: 140
+Overworld (Mt.Ordeals)                                                        Seed:  61   Index: 150
+  Step  82: 23 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  61   Index: 244
+  Step   5: 24 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  13: 25 / Soul x2, Red Bone x2 (9.583s)
+  Step  22: 26 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:  78   Index:  31
+  Step  17: 27 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  78   Index:  54
+Mt.Ordeals-3rd station                                                        Seed:  78   Index:  54
+Mt.Ordeals-7th station                                                        Seed:  78   Index:  59
+  Step  18: 28 / Lilith x1, Red Bone x2 (8.912s)
+Mt.Ordeals Summit                                                             Seed:  78   Index: 101
+  Optional Steps: 0
+  Step  17: 29 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed:  78   Index: 118
+Mt.Ordeals Summit                                                             Seed:  78   Index: 118
+Paladin                                                                       Seed:  78   Index: 122
+Mt.Ordeals Summit                                                             Seed:  78   Index: 122
+  Optional Steps: 1
+  Step   5: 30 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed:  78   Index: 145
+Mt.Ordeals-3rd station                                                        Seed:  78   Index: 187
+  Step   8: 31 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed:  78   Index: 217
+  Step  30: 32 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  95   Index:   5
+Take Chocobo to Mysidia                                                       Seed:  95   Index:  18
+Overworld (Mysidia)                                                           Seed:  95   Index:  18
+Town of Baron Serpent Road                                                    Seed:  95   Index:  18
+  Extra Steps: 16
+Credit Warp Fight Search                                                      Seed:  95   Index:  38
+  Overworld (Baron)                                                           Seed:  95   Index:  38
+    Extra Steps: 12
+    Step   1: 33 / Imp x3, SwordRat x1 (7.227s)
+    Step  12: 34 / Imp x3, SwordRat x1 (7.227s)
+   (Step 110: 35 / Imp x3)
+   (Step 143: 36 / Imp x4)
+   (Step 167: 37 / Imp x3)
+   (Step 192: 38 / Imp x3, SwordRat x1)
+   (Step 251: 39 / Imp x3)
+
+Encounter Time:      264.647s
+Other Time:          534.819s
+Total Time:          799.466s
+
+Base Total Time:     1013.121s
+Time Saved:          213.655s
+
+Optional Steps:      12
+Extra Steps:         156
+Encounters:          34
+
+Base Encounters:     49
+Encounters Saved:    15
+
+Number of Variables: 54

--- a/data/routes/cw/250.txt
+++ b/data/routes/cw/250.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	250
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48400925
+VARS	FFFFFFFF:12 E000201:2 E302500:5 E302600:52 E305400:54 E307400:36 E308702:1 E309700:16
+
+Overworld (Kaipo)                                                             Seed: 250   Index:   0
+Overworld (Kaipo)                                                             Seed: 250   Index:   1
+Kaipo                                                                         Seed: 250   Index:  37
+Overworld (Kaipo)                                                             Seed: 250   Index:  37
+  Step  28: 1 / SandWorm x1 (7.100s)
+Watery Pass-South B1F                                                         Seed: 250   Index:  69
+Recruit Tellah                                                                Seed: 250   Index: 101
+Watery Pass-South B1F                                                         Seed: 250   Index: 101
+Watery Pass-South B2F                                                         Seed: 250   Index: 121
+  Step   5: 2 / Pike x2, EvilShel x2 (7.149s)
+  Step   8: 3 / Pike x3 (7.152s)
+  Step  40: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  59: 5 / Pike x3 (7.152s)
+  Step  72: 6 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 250   Index: 211
+  Extra Steps: 54
+Watery Pass-South B2F                                                         Seed:  11   Index:  13
+  Step  22: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  11   Index:  52
+Watery Pass-North B2F                                                         Seed:  11   Index:  86
+Watery Pass-North B1F                                                         Seed:  11   Index: 107
+  Step  52: 8 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  11   Index: 167
+Waterfalls B1F                                                                Seed:  11   Index: 176
+  Extra Steps: 36
+Waterfalls B2F                                                                Seed:  11   Index: 213
+  Step  10: 9 / Zombie x6 (7.489s)
+  Step  42: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:  28   Index:   2
+Battle: Octomamm                                                              Seed:  28   Index:  39
+Waterfalls Lake                                                               Seed:  28   Index:  39
+Overworld (Kaipo)                                                             Seed:  28   Index:  40
+  Extra Steps: 2
+  Step  12: 11 / Imp x4 (7.092s)
+Overworld (Damcyan)                                                           Seed:  28   Index:  53
+Damcyan                                                                       Seed:  28   Index:  57
+  Optional Steps: 1
+  Extra Steps: 4
+Overworld (Damcyan)                                                           Seed:  28   Index:  69
+Antlion B1F                                                                   Seed:  28   Index:  69
+  Step  23: 12 / Imp x3, Imp Cap. x1 (6.755s)
+  Step  27: 13 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed:  28   Index: 107
+  Antlion B2F                                                                 Seed:  28   Index: 107
+Antlion's Nest                                                                Seed:  28   Index: 187
+Battle: Antlion                                                               Seed:  28   Index: 201
+Antlion's Nest                                                                Seed:  28   Index: 201
+  Step   5: 14 / Weeper x2 (7.132s)
+Antlion B2F Outward Direct                                                    Seed:  28   Index: 216
+  Antlion B2F                                                                 Seed:  28   Index: 216
+    Step  23: 15 / Turtle x2 (7.464s)
+    Step  37: 16 / Basilisk x1, Turtle x1 (7.124s)
+    Step  66: 17 / Basilisk x1, Imp x3 (6.783s)
+Antlion B1F                                                                   Seed:  45   Index:  40
+  Step   7: 18 / Cream x4 (7.523s)
+  Step  18: 19 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  21: 20 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  33: 21 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed:  45   Index:  78
+Overworld (Kaipo)                                                             Seed:  45   Index:  78
+Kaipo Revisited                                                               Seed:  45   Index:  78
+Overworld (Kaipo)                                                             Seed:  45   Index:  78
+Overworld (Damcyan)                                                           Seed:  45   Index:  78
+Mt.Hobs-West                                                                  Seed:  45   Index:  78
+Mt.Hobs Summit                                                                Seed:  45   Index: 117
+  Step   8: 22 / Spirit x2 (8.028s)
+Battle: MomBomb                                                               Seed:  45   Index: 132
+Mt.Hobs Summit                                                                Seed:  45   Index: 132
+Mt.Hobs-East                                                                  Seed:  45   Index: 138
+Overworld (Fabul)                                                             Seed:  45   Index: 184
+  Step  19: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  52: 24 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed:  62   Index:  12
+  Optional Steps: 10
+  Extra Steps: 42
+Overworld (Fabul)                                                             Seed:  62   Index: 124
+Fabul Boat and Leviatan                                                       Seed:  62   Index: 131
+Overworld (Mysidia)                                                           Seed:  62   Index: 131
+Mysidia                                                                       Seed:  62   Index: 140
+Overworld (Mysidia)                                                           Seed:  62   Index: 140
+Overworld (Mt.Ordeals)                                                        Seed:  62   Index: 150
+  Step  82: 25 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  62   Index: 244
+  Step   5: 26 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  13: 27 / Soul x2, Red Bone x2 (9.583s)
+  Step  22: 28 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed:  79   Index:  31
+  Step  17: 29 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  79   Index:  54
+Mt.Ordeals-3rd station                                                        Seed:  79   Index:  54
+Mt.Ordeals-7th station                                                        Seed:  79   Index:  59
+Mt.Ordeals Summit                                                             Seed:  79   Index: 101
+  Optional Steps: 0
+  Step  17: 30 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed:  79   Index: 118
+Mt.Ordeals Summit                                                             Seed:  79   Index: 118
+Paladin                                                                       Seed:  79   Index: 122
+Mt.Ordeals Summit                                                             Seed:  79   Index: 122
+  Optional Steps: 1
+  Step   5: 31 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed:  79   Index: 145
+Mt.Ordeals-3rd station                                                        Seed:  79   Index: 187
+  Step   8: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed:  79   Index: 217
+  Step  12: 33 / Spirit x3, Soul x1 (8.429s)
+  Step  30: 34 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  96   Index:   5
+Take Chocobo to Mysidia                                                       Seed:  96   Index:  18
+Overworld (Mysidia)                                                           Seed:  96   Index:  18
+Town of Baron Serpent Road                                                    Seed:  96   Index:  18
+  Extra Steps: 16
+Credit Warp Fight Search                                                      Seed:  96   Index:  38
+  Overworld (Baron)                                                           Seed:  96   Index:  38
+    Extra Steps: 12
+    Step   1: 35 / Imp x3 (7.174s)
+    Step  12: 36 / Imp x4 (7.223s)
+   (Step  64: 37 / Imp x3)
+   (Step 110: 38 / Imp x3, SwordRat x1)
+   (Step 143: 39 / Imp x3)
+   (Step 167: 40 / Imp x3, SwordRat x1)
+   (Step 192: 41 / FloatEye x2)
+   (Step 235: 42 / FloatEye x2)
+   (Step 251: 43 / FloatEye x2)
+
+Encounter Time:      277.059s
+Other Time:          528.297s
+Total Time:          805.356s
+
+Base Total Time:     960.123s
+Time Saved:          154.767s
+
+Optional Steps:      12
+Extra Steps:         166
+Encounters:          36
+
+Base Encounters:     49
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/251.txt
+++ b/data/routes/cw/251.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	251
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48400587
+VARS	FFFFFFFF:12 E000600:4 E302600:46 E305400:10 E307200:2 E307400:88 E307802:2 E307900:2 E308401:10 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 251   Index:   0
+Overworld (Kaipo)                                                             Seed: 251   Index:   1
+Kaipo                                                                         Seed: 251   Index:  37
+Overworld (Kaipo)                                                             Seed: 251   Index:  37
+Watery Pass-South B1F                                                         Seed: 251   Index:  69
+  Step  28: 1 / Zombie x4 (6.967s)
+Recruit Tellah                                                                Seed: 251   Index: 101
+Watery Pass-South B1F                                                         Seed: 251   Index: 101
+Watery Pass-South B2F                                                         Seed: 251   Index: 121
+  Step   8: 2 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  40: 3 / Pike x3 (7.152s)
+  Step  59: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  72: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 251   Index: 211
+  Extra Steps: 10
+Watery Pass-South B2F                                                         Seed: 251   Index: 225
+Watery Pass-South B3F                                                         Seed:  12   Index:   8
+  Step   5: 6 / CaveToad x3 (7.014s)
+  Step  27: 7 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  12   Index:  42
+  Extra Steps: 2
+  Step  22: 8 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed:  12   Index:  65
+Overworld (Kaipo)                                                             Seed:  12   Index: 125
+Waterfalls B1F                                                                Seed:  12   Index: 134
+  Extra Steps: 88
+Waterfalls B2F                                                                Seed:  12   Index: 223
+  Step  32: 9 / Zombie x6 (7.489s)
+  Step  40: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:  29   Index:  12
+Battle: Octomamm                                                              Seed:  29   Index:  49
+Waterfalls Lake                                                               Seed:  29   Index:  49
+Overworld (Kaipo)                                                             Seed:  29   Index:  50
+  Step   2: 11 / Imp x4 (7.092s)
+  Step  10: 12 / Sand Man x4 (7.347s)
+Overworld (Damcyan)                                                           Seed:  29   Index:  61
+Damcyan                                                                       Seed:  29   Index:  65
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  29   Index:  72
+Antlion B1F                                                                   Seed:  29   Index:  72
+  Step  20: 13 / Cream x4 (7.552s)
+Antlion B2F Inward Direct                                                     Seed:  29   Index: 110
+  Antlion B2F                                                                 Seed:  29   Index: 110
+Antlion's Nest                                                                Seed:  29   Index: 190
+  Extra Steps: 2
+  Step  16: 14 / SandWorm x2 (6.841s)
+Battle: Antlion                                                               Seed:  29   Index: 206
+Antlion's Nest                                                                Seed:  29   Index: 206
+Antlion B2F Outward Direct                                                    Seed:  29   Index: 221
+  Antlion B2F                                                                 Seed:  29   Index: 221
+    Extra Steps: 2
+    Step  18: 15 / Turtle x2 (7.464s)
+    Step  32: 16 / Basilisk x1, Turtle x1 (7.124s)
+    Step  61: 17 / Turtle x2 (7.464s)
+    Step  82: 18 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B1F                                                                   Seed:  46   Index:  47
+  Step  11: 19 / Imp x3, Imp Cap. x1 (6.753s)
+  Step  14: 20 / Imp x3, Imp Cap. x1 (6.753s)
+Overworld (Damcyan)                                                           Seed:  46   Index:  85
+Overworld (Kaipo)                                                             Seed:  46   Index:  85
+Kaipo Revisited                                                               Seed:  46   Index:  85
+Overworld (Kaipo)                                                             Seed:  46   Index:  85
+Overworld (Damcyan)                                                           Seed:  46   Index:  85
+Mt.Hobs-West                                                                  Seed:  46   Index:  85
+Mt.Hobs Summit                                                                Seed:  46   Index: 124
+  Step   1: 21 / Skelton x4 (8.683s)
+Battle: MomBomb                                                               Seed:  46   Index: 139
+Mt.Hobs Summit                                                                Seed:  46   Index: 139
+Mt.Hobs-East                                                                  Seed:  46   Index: 145
+  Step  41: 22 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  46   Index: 191
+  Step  12: 23 / Imp Cap. x3, Needler x1 (8.023s)
+  Step  45: 24 / Imp Cap. x4, Imp x2 (8.467s)
+Fabul                                                                         Seed:  63   Index:  19
+  Optional Steps: 10
+  Extra Steps: 36
+Overworld (Fabul)                                                             Seed:  63   Index: 125
+Fabul Boat and Leviatan                                                       Seed:  63   Index: 132
+Overworld (Mysidia)                                                           Seed:  63   Index: 132
+Mysidia                                                                       Seed:  63   Index: 141
+Overworld (Mysidia)                                                           Seed:  63   Index: 141
+Overworld (Mt.Ordeals)                                                        Seed:  63   Index: 151
+  Extra Steps: 4
+  Step  81: 25 / Raven x1 (8.356s)
+  Step  98: 26 / Imp Cap. x3, Needler x1 (7.932s)
+Mt.Ordeals                                                                    Seed:  63   Index: 249
+  Step   8: 27 / Skelton x3, Red Bone x2 (8.244s)
+  Step  17: 28 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed:  80   Index:  36
+  Step  12: 29 / Revenant x1, Ghoul x3 (8.911s)
+Recruit Tellah                                                                Seed:  80   Index:  59
+Mt.Ordeals-3rd station                                                        Seed:  80   Index:  59
+Mt.Ordeals-7th station                                                        Seed:  80   Index:  64
+Mt.Ordeals Summit                                                             Seed:  80   Index: 106
+  Optional Steps: 1
+  Step  12: 30 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed:  80   Index: 124
+Mt.Ordeals Summit                                                             Seed:  80   Index: 124
+  Step   3: 31 / Lilith x1, Red Bone x2 (8.744s)
+Paladin                                                                       Seed:  80   Index: 128
+Mt.Ordeals Summit                                                             Seed:  80   Index: 128
+  Optional Steps: 1
+  Step  12: 32 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed:  80   Index: 151
+Mt.Ordeals-3rd station                                                        Seed:  80   Index: 193
+  Step   2: 33 / Ghoul x2, Soul x2 (8.971s)
+Mt.Ordeals                                                                    Seed:  80   Index: 223
+  Extra Steps: 10
+  Step   6: 34 / Spirit x3, Soul x1 (8.429s)
+Overworld (Mt.Ordeals)                                                        Seed:  97   Index:  21
+Take Chocobo to Mysidia                                                       Seed:  97   Index:  34
+Overworld (Mysidia)                                                           Seed:  97   Index:  34
+Town of Baron Serpent Road                                                    Seed:  97   Index:  34
+Credit Warp Fight Search                                                      Seed:  97   Index:  38
+  Overworld (Baron)                                                           Seed:  97   Index:  38
+    Extra Steps: 12
+    Step   1: 35 / Imp x3 (7.174s)
+    Step  12: 36 / Imp x3, SwordRat x1 (7.227s)
+   (Step  53: 37 / Imp x3)
+   (Step  64: 38 / Imp x3, SwordRat x1)
+   (Step 110: 39 / FloatEye x2)
+   (Step 143: 40 / Imp x3, SwordRat x1)
+   (Step 192: 41 / FloatEye x2)
+   (Step 235: 42 / FloatEye x2)
+   (Step 251: 43 / FloatEye x2)
+
+Encounter Time:      277.054s
+Other Time:          528.297s
+Total Time:          805.350s
+
+Base Total Time:     1010.006s
+Time Saved:          204.656s
+
+Optional Steps:      12
+Extra Steps:         166
+Encounters:          36
+
+Base Encounters:     49
+Encounters Saved:    13
+
+Number of Variables: 54

--- a/data/routes/cw/252.txt
+++ b/data/routes/cw/252.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	252
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47637678
+VARS	FFFFFFFF:2 C307800:1 C307801:1 E302600:1 E307B00:50 E307B01:92 E308401:2 E308502:8 E308700:1 E308702:1 E309700:12
+
+Overworld (Kaipo)                                                             Seed: 252   Index:   0
+Overworld (Kaipo)                                                             Seed: 252   Index:   1
+  Step  36: 1 / SandWorm x1 (6.973s)
+Kaipo                                                                         Seed: 252   Index:  37
+Overworld (Kaipo)                                                             Seed: 252   Index:  37
+Watery Pass-South B1F                                                         Seed: 252   Index:  69
+  Step  28: 2 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 252   Index: 101
+Watery Pass-South B1F                                                         Seed: 252   Index: 101
+Watery Pass-South B2F                                                         Seed: 252   Index: 121
+  Step  40: 3 / Pike x3 (7.152s)
+  Step  59: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  72: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 252   Index: 211
+Watery Pass-South B2F                                                         Seed: 252   Index: 215
+  Step  10: 6 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed: 252   Index: 254
+  Step  15: 7 / CaveToad x3 (7.014s)
+Watery Pass-North B2F                                                         Seed:  13   Index:  32
+  Step   3: 8 / Jelly x4 (7.324s)
+Watery Pass-North B1F                                                         Seed:  13   Index:  53
+  Step  11: 9 / CaveToad x4 (7.163s)
+Overworld (Kaipo)                                                             Seed:  13   Index: 113
+Waterfalls B1F                                                                Seed:  13   Index: 122
+Waterfalls B2F                                                                Seed:  13   Index: 123
+  Step  35: 10 / Aligator x1, Pike x2 (7.368s)
+Waterfalls Lake                                                               Seed:  13   Index: 168
+  Step  15: 11 / Zombie x6 (7.489s)
+Battle: Octomamm                                                              Seed:  13   Index: 205
+Waterfalls Lake                                                               Seed:  13   Index: 205
+Overworld (Kaipo)                                                             Seed:  13   Index: 206
+  Step   6: 12 / Sandpede x1, Sand Man x2 (7.221s)
+Overworld (Damcyan)                                                           Seed:  13   Index: 217
+Damcyan                                                                       Seed:  13   Index: 221
+  Optional Steps: 0
+Overworld (Damcyan)                                                           Seed:  13   Index: 228
+Antlion B1F                                                                   Seed:  13   Index: 228
+  Step  27: 13 / Cream x4 (7.552s)
+  Step  35: 14 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion B2F Inward Charm Room Steps                                           Seed:  30   Index:  10
+  Antlion B2F                                                                 Seed:  30   Index:  10
+  Antlion B2F Treasure Room                                                   Seed:  30   Index:  43
+    Extra Steps: 50
+  Antlion B2F                                                                 Seed:  30   Index:  93
+Antlion's Nest                                                                Seed:  30   Index: 145
+Battle: Antlion                                                               Seed:  30   Index: 159
+Antlion's Nest                                                                Seed:  30   Index: 159
+Antlion B2F Outward Charm Room Steps                                          Seed:  30   Index: 174
+  Antlion B2F                                                                 Seed:  30   Index: 174
+    Step  14: 15 / Turtle x2 (7.464s)
+  Antlion B2F Treasure Room                                                   Seed:  30   Index: 225
+    Extra Steps: 92
+  Antlion B2F                                                                 Seed:  47   Index:  61
+Antlion B1F                                                                   Seed:  47   Index:  95
+  Step  30: 16 / Basilisk x1, Imp x3 (6.783s)
+Overworld (Damcyan)                                                           Seed:  47   Index: 133
+Overworld (Kaipo)                                                             Seed:  47   Index: 133
+Kaipo Revisited                                                               Seed:  47   Index: 133
+Overworld (Kaipo)                                                             Seed:  47   Index: 133
+Overworld (Damcyan)                                                           Seed:  47   Index: 133
+Mt.Hobs-West                                                                  Seed:  47   Index: 133
+Mt.Hobs Summit                                                                Seed:  47   Index: 172
+  Step  14: 17 / GrayBomb x2, Bomb x2 (10.938s)
+Battle: MomBomb                                                               Seed:  47   Index: 187
+Mt.Hobs Summit                                                                Seed:  47   Index: 187
+Mt.Hobs-East                                                                  Seed:  47   Index: 193
+  Step  43: 18 / Gargoyle x1, Cocktric x2 (7.868s)
+Overworld (Fabul)                                                             Seed:  47   Index: 239
+  Step  41: 19 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  45: 20 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  47: 21 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  64   Index:  67
+  Optional Steps: 1
+Overworld (Fabul)                                                             Seed:  64   Index: 128
+Fabul Boat and Leviatan                                                       Seed:  64   Index: 135
+Overworld (Mysidia)                                                           Seed:  64   Index: 135
+Mysidia                                                                       Seed:  64   Index: 144
+Overworld (Mysidia)                                                           Seed:  64   Index: 144
+Overworld (Mt.Ordeals)                                                        Seed:  64   Index: 154
+  Step  78: 22 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+Mt.Ordeals                                                                    Seed:  64   Index: 248
+  Step   2: 23 / Spirit x2, Skelton x2 (8.285s)
+  Step   9: 24 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+  Step  18: 25 / Soul x2, Red Bone x2 (9.583s)
+Mt.Ordeals-3rd station                                                        Seed:  81   Index:  35
+  Step  13: 26 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  81   Index:  58
+Mt.Ordeals-3rd station                                                        Seed:  81   Index:  58
+Mt.Ordeals-7th station                                                        Seed:  81   Index:  63
+Mt.Ordeals Summit                                                             Seed:  81   Index: 105
+  Optional Steps: 1
+  Step  13: 27 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed:  81   Index: 123
+Mt.Ordeals Summit                                                             Seed:  81   Index: 123
+Paladin                                                                       Seed:  81   Index: 127
+Mt.Ordeals Summit                                                             Seed:  81   Index: 127
+  Optional Steps: 1
+  Step  13: 28 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed:  81   Index: 150
+  Step   7: 29 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  81   Index: 192
+  Extra Steps: 8
+  Step   3: 30 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+  Step  37: 31 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed:  81   Index: 230
+  Extra Steps: 2
+Overworld (Mt.Ordeals)                                                        Seed:  98   Index:  20
+Take Chocobo to Mysidia                                                       Seed:  98   Index:  33
+Overworld (Mysidia)                                                           Seed:  98   Index:  33
+Town of Baron Serpent Road                                                    Seed:  98   Index:  33
+  Extra Steps: 12
+Credit Warp Fight Search                                                      Seed:  98   Index:  49
+  Overworld (Baron)                                                           Seed:  98   Index:  49
+    Extra Steps: 2
+    Step   1: 32 / Imp x4 (7.223s)
+    Step   2: 33 / Imp x3, SwordRat x1 (7.227s)
+   (Step  42: 34 / Imp x3, SwordRat x1)
+   (Step  53: 35 / Imp x3)
+   (Step  99: 36 / Imp x3, SwordRat x1)
+   (Step 132: 37 / Imp x3)
+   (Step 224: 38 / Imp x6)
+   (Step 240: 39 / FloatEye x2)
+   (Step 256: 40 / Imp x3, SwordRat x1)
+
+Encounter Time:      257.837s
+Other Time:          534.819s
+Total Time:          792.656s
+
+Base Total Time:     974.352s
+Time Saved:          181.696s
+
+Optional Steps:      3
+Extra Steps:         166
+Encounters:          33
+
+Base Encounters:     48
+Encounters Saved:    15
+
+Number of Variables: 54

--- a/data/routes/cw/253.txt
+++ b/data/routes/cw/253.txt
@@ -1,0 +1,150 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	253
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48220423
+VARS	FFFFFFFF:14 C307801:1 E302500:7 E302600:1 E305400:76 E307400:14 E307B01:50 E308502:4 E308601:4 E308700:1 E308702:1 E309700:2
+
+Overworld (Kaipo)                                                             Seed: 253   Index:   0
+Overworld (Kaipo)                                                             Seed: 253   Index:   1
+  Step  36: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 253   Index:  37
+Overworld (Kaipo)                                                             Seed: 253   Index:  37
+Watery Pass-South B1F                                                         Seed: 253   Index:  69
+  Step  28: 2 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 253   Index: 101
+Watery Pass-South B1F                                                         Seed: 253   Index: 101
+  Step  19: 3 / Pike x3 (7.152s)
+Watery Pass-South B2F                                                         Seed: 253   Index: 121
+  Step  59: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  72: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 253   Index: 211
+  Extra Steps: 76
+Watery Pass-South B2F                                                         Seed:  14   Index:  35
+  Step  29: 6 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  14   Index:  74
+Watery Pass-North B2F                                                         Seed:  14   Index: 108
+Watery Pass-North B1F                                                         Seed:  14   Index: 129
+  Step  29: 7 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:  14   Index: 189
+Waterfalls B1F                                                                Seed:  14   Index: 198
+  Extra Steps: 14
+Waterfalls B2F                                                                Seed:  14   Index: 213
+  Step  10: 8 / Aligator x1, WaterBug x2 (7.292s)
+  Step  42: 9 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed:  31   Index:   2
+  Step   5: 10 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed:  31   Index:  39
+Waterfalls Lake                                                               Seed:  31   Index:  39
+Overworld (Kaipo)                                                             Seed:  31   Index:  40
+Overworld (Damcyan)                                                           Seed:  31   Index:  51
+  Step   1: 11 / SandWorm x1 (7.264s)
+Damcyan                                                                       Seed:  31   Index:  55
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed:  31   Index:  69
+Antlion B1F                                                                   Seed:  31   Index:  69
+  Step  23: 12 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Direct                                                     Seed:  31   Index: 107
+  Antlion B2F                                                                 Seed:  31   Index: 107
+Antlion's Nest                                                                Seed:  31   Index: 187
+  Step   1: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Battle: Antlion                                                               Seed:  31   Index: 201
+Antlion's Nest                                                                Seed:  31   Index: 201
+Antlion B2F Outward Charm Room Steps                                          Seed:  31   Index: 216
+  Antlion B2F                                                                 Seed:  31   Index: 216
+    Step   4: 14 / SandWorm x2 (6.858s)
+    Step  37: 15 / Turtle x2 (7.464s)
+  Antlion B2F Treasure Room                                                   Seed:  48   Index:  11
+    Extra Steps: 50
+  Antlion B2F                                                                 Seed:  48   Index:  61
+Antlion B1F                                                                   Seed:  48   Index:  95
+Overworld (Damcyan)                                                           Seed:  48   Index: 133
+Overworld (Kaipo)                                                             Seed:  48   Index: 133
+Kaipo Revisited                                                               Seed:  48   Index: 133
+Overworld (Kaipo)                                                             Seed:  48   Index: 133
+Overworld (Damcyan)                                                           Seed:  48   Index: 133
+Mt.Hobs-West                                                                  Seed:  48   Index: 133
+Mt.Hobs Summit                                                                Seed:  48   Index: 172
+  Step  14: 16 / Cocktric x3 (9.055s)
+Battle: MomBomb                                                               Seed:  48   Index: 187
+Mt.Hobs Summit                                                                Seed:  48   Index: 187
+Mt.Hobs-East                                                                  Seed:  48   Index: 193
+  Step  43: 17 / GrayBomb x2, Bomb x2 (8.430s)
+Overworld (Fabul)                                                             Seed:  48   Index: 239
+  Step   7: 18 / Cocktric x3 (8.241s)
+  Step  41: 19 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  45: 20 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  47: 21 / Cocktric x3 (8.241s)
+Fabul                                                                         Seed:  65   Index:  67
+  Optional Steps: 1
+Overworld (Fabul)                                                             Seed:  65   Index: 128
+Fabul Boat and Leviatan                                                       Seed:  65   Index: 135
+Overworld (Mysidia)                                                           Seed:  65   Index: 135
+Mysidia                                                                       Seed:  65   Index: 144
+Overworld (Mysidia)                                                           Seed:  65   Index: 144
+Overworld (Mt.Ordeals)                                                        Seed:  65   Index: 154
+  Step  24: 22 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  78: 23 / Raven x1 (8.356s)
+Mt.Ordeals                                                                    Seed:  65   Index: 248
+  Step   2: 24 / Spirit x3, Soul x1 (8.687s)
+  Step  16: 25 / Soul x2, Red Bone x2 (9.583s)
+  Step  18: 26 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:  82   Index:  35
+  Step  13: 27 / Zombie x3, Ghoul x2, Revenant x2 (8.005s)
+Recruit Tellah                                                                Seed:  82   Index:  58
+Mt.Ordeals-3rd station                                                        Seed:  82   Index:  58
+Mt.Ordeals-7th station                                                        Seed:  82   Index:  63
+Mt.Ordeals Summit                                                             Seed:  82   Index: 105
+  Optional Steps: 1
+  Step  13: 28 / Lilith x1, Red Bone x2 (8.912s)
+Battle: Milon and Milon Z                                                     Seed:  82   Index: 123
+Mt.Ordeals Summit                                                             Seed:  82   Index: 123
+Paladin                                                                       Seed:  82   Index: 127
+Mt.Ordeals Summit                                                             Seed:  82   Index: 127
+  Optional Steps: 1
+  Step  13: 29 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-7th station                                                        Seed:  82   Index: 150
+  Extra Steps: 4
+  Step   7: 30 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+  Step  45: 31 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  82   Index: 196
+  Extra Steps: 4
+  Step  33: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed:  82   Index: 230
+Overworld (Mt.Ordeals)                                                        Seed:  99   Index:  18
+Take Chocobo to Mysidia                                                       Seed:  99   Index:  31
+Overworld (Mysidia)                                                           Seed:  99   Index:  31
+Town of Baron Serpent Road                                                    Seed:  99   Index:  31
+  Extra Steps: 2
+Credit Warp Fight Search                                                      Seed:  99   Index:  37
+  Overworld (Baron)                                                           Seed:  99   Index:  37
+    Extra Steps: 14
+    Step   2: 33 / Imp x3, SwordRat x1 (7.227s)
+    Step  14: 34 / Imp x3, SwordRat x1 (7.227s)
+   (Step  54: 35 / Imp x3)
+   (Step  65: 36 / Imp x3, SwordRat x1)
+   (Step 111: 37 / Imp x3)
+   (Step 144: 38 / Imp x6)
+   (Step 180: 39 / FloatEye x2)
+   (Step 236: 40 / Imp x3, SwordRat x1)
+
+Encounter Time:      267.866s
+Other Time:          534.486s
+Total Time:          802.352s
+
+Base Total Time:     954.441s
+Time Saved:          152.089s
+
+Optional Steps:      4
+Extra Steps:         170
+Encounters:          34
+
+Base Encounters:     48
+Encounters Saved:    14
+
+Number of Variables: 54

--- a/data/routes/cw/254.txt
+++ b/data/routes/cw/254.txt
@@ -1,0 +1,148 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	254
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	47818577
+VARS	FFFFFFFF:14 C307800:1 E302500:7 E305400:76 E307400:14 E307B00:2 E309700:61
+
+Overworld (Kaipo)                                                             Seed: 254   Index:   0
+Overworld (Kaipo)                                                             Seed: 254   Index:   1
+  Step  36: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 254   Index:  37
+Overworld (Kaipo)                                                             Seed: 254   Index:  37
+Watery Pass-South B1F                                                         Seed: 254   Index:  69
+  Step  28: 2 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 254   Index: 101
+Watery Pass-South B1F                                                         Seed: 254   Index: 101
+  Step  19: 3 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 254   Index: 121
+  Step  23: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  59: 5 / Pike x3 (7.152s)
+Watery Pass-South B2F Save Room                                               Seed: 254   Index: 211
+  Extra Steps: 76
+Watery Pass-South B2F                                                         Seed:  15   Index:  35
+  Step  29: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B3F                                                         Seed:  15   Index:  74
+Watery Pass-North B2F                                                         Seed:  15   Index: 108
+Watery Pass-North B1F                                                         Seed:  15   Index: 129
+  Step  29: 7 / Pike x2, EvilShel x2, WaterBug x2 (7.266s)
+Overworld (Kaipo)                                                             Seed:  15   Index: 189
+Waterfalls B1F                                                                Seed:  15   Index: 198
+  Extra Steps: 14
+Waterfalls B2F                                                                Seed:  15   Index: 213
+  Step   9: 8 / Aligator x1, WaterBug x2 (7.292s)
+  Step  42: 9 / Zombie x6 (7.489s)
+Waterfalls Lake                                                               Seed:  32   Index:   2
+  Step   5: 10 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed:  32   Index:  39
+Waterfalls Lake                                                               Seed:  32   Index:  39
+Overworld (Kaipo)                                                             Seed:  32   Index:  40
+Overworld (Damcyan)                                                           Seed:  32   Index:  51
+  Step   1: 11 / SandWorm x1 (7.264s)
+Damcyan                                                                       Seed:  32   Index:  55
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed:  32   Index:  69
+Antlion B1F                                                                   Seed:  32   Index:  69
+  Step  23: 12 / Turtle x1, Imp x2 (7.044s)
+Antlion B2F Inward Charm Room Steps                                           Seed:  32   Index: 107
+  Antlion B2F                                                                 Seed:  32   Index: 107
+  Antlion B2F Treasure Room                                                   Seed:  32   Index: 140
+    Extra Steps: 2
+  Antlion B2F                                                                 Seed:  32   Index: 142
+    Step  46: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.385s)
+Antlion's Nest                                                                Seed:  32   Index: 194
+Battle: Antlion                                                               Seed:  32   Index: 208
+Antlion's Nest                                                                Seed:  32   Index: 208
+  Step  12: 14 / SandWorm x2 (6.858s)
+Antlion B2F Outward Direct                                                    Seed:  32   Index: 223
+  Antlion B2F                                                                 Seed:  32   Index: 223
+    Step  60: 15 / Turtle x2 (7.464s)
+    Step  80: 16 / Basilisk x1, Turtle x1 (7.124s)
+Antlion B1F                                                                   Seed:  49   Index:  47
+  Step  11: 17 / Turtle x1, Imp x2 (7.009s)
+  Step  14: 18 / Cream x4 (7.523s)
+Overworld (Damcyan)                                                           Seed:  49   Index:  85
+Overworld (Kaipo)                                                             Seed:  49   Index:  85
+Kaipo Revisited                                                               Seed:  49   Index:  85
+Overworld (Kaipo)                                                             Seed:  49   Index:  85
+Overworld (Damcyan)                                                           Seed:  49   Index:  85
+Mt.Hobs-West                                                                  Seed:  49   Index:  85
+Mt.Hobs Summit                                                                Seed:  49   Index: 124
+Battle: MomBomb                                                               Seed:  49   Index: 139
+Mt.Hobs Summit                                                                Seed:  49   Index: 139
+Mt.Hobs-East                                                                  Seed:  49   Index: 145
+  Step  22: 19 / Gargoyle x2 (7.630s)
+  Step  41: 20 / Gargoyle x2 (7.630s)
+Overworld (Fabul)                                                             Seed:  49   Index: 191
+  Step  45: 21 / Cocktric x3 (8.241s)
+  Step  55: 22 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed:  66   Index:  19
+  Optional Steps: 0
+Overworld (Fabul)                                                             Seed:  66   Index:  79
+Fabul Boat and Leviatan                                                       Seed:  66   Index:  86
+Overworld (Mysidia)                                                           Seed:  66   Index:  86
+Mysidia                                                                       Seed:  66   Index:  95
+Overworld (Mysidia)                                                           Seed:  66   Index:  95
+Overworld (Mt.Ordeals)                                                        Seed:  66   Index: 105
+  Step  19: 23 / Raven x1 (8.356s)
+  Step  73: 24 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  66   Index: 199
+Mt.Ordeals-3rd station                                                        Seed:  66   Index: 242
+  Step   8: 25 / Revenant x1, Ghoul x3 (8.911s)
+  Step  22: 26 / Zombie x2, Ghoul x2 (7.661s)
+Recruit Tellah                                                                Seed:  83   Index:   9
+Mt.Ordeals-3rd station                                                        Seed:  83   Index:   9
+  Step   1: 27 / Zombie x3, Ghoul x2, Revenant x2 (7.869s)
+Mt.Ordeals-7th station                                                        Seed:  83   Index:  14
+Mt.Ordeals Summit                                                             Seed:  83   Index:  56
+  Optional Steps: 0
+Battle: Milon and Milon Z                                                     Seed:  83   Index:  73
+Mt.Ordeals Summit                                                             Seed:  83   Index:  73
+Paladin                                                                       Seed:  83   Index:  77
+Mt.Ordeals Summit                                                             Seed:  83   Index:  77
+  Optional Steps: 0
+  Step   8: 28 / Lilith x1 (8.563s)
+Mt.Ordeals-7th station                                                        Seed:  83   Index:  99
+  Step  19: 29 / Lilith x1, Red Bone x2 (8.437s)
+  Step  41: 30 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-3rd station                                                        Seed:  83   Index: 141
+  Step  16: 31 / Revenant x1, Ghoul x3 (8.489s)
+Mt.Ordeals                                                                    Seed:  83   Index: 171
+  Step  24: 32 / Skelton x3, Red Bone x2 (7.997s)
+Overworld (Mt.Ordeals)                                                        Seed:  83   Index: 215
+Take Chocobo to Mysidia                                                       Seed:  83   Index: 228
+Overworld (Mysidia)                                                           Seed:  83   Index: 228
+Town of Baron Serpent Road                                                    Seed:  83   Index: 228
+  Extra Steps: 61
+Credit Warp Fight Search                                                      Seed: 100   Index:  37
+  Overworld (Baron)                                                           Seed: 100   Index:  37
+    Extra Steps: 14
+    Step   2: 33 / Imp x3, SwordRat x1 (7.227s)
+    Step  14: 34 / Imp x3, SwordRat x1 (7.227s)
+   (Step  54: 35 / Imp x3)
+   (Step  65: 36 / Imp x3, SwordRat x1)
+   (Step  78: 37 / Imp x3)
+   (Step 144: 38 / Imp x3)
+   (Step 180: 39 / FloatEye x2)
+   (Step 236: 40 / Imp x3, SwordRat x1)
+
+Encounter Time:      260.115s
+Other Time:          535.551s
+Total Time:          795.666s
+
+Base Total Time:     950.218s
+Time Saved:          154.552s
+
+Optional Steps:      1
+Extra Steps:         173
+Encounters:          34
+
+Base Encounters:     48
+Encounters Saved:    14
+
+Number of Variables: 54

--- a/data/routes/cw/255.txt
+++ b/data/routes/cw/255.txt
@@ -1,0 +1,152 @@
+ROUTE	Final Fantasy IV Any% (Credits Warp)
+VERSION	1
+ROSA	f2aeb34+
+SEED	255
+MAXSTEP	150
+MAXSEG	-1
+TASMODE	0
+MINIMUM	0
+FRAMES	48369483
+VARS	FFFFFFFF:14 C307800:1 C307801:1 E000500:2 E302500:7 E302600:9 E305400:70 E307400:20 E307802:1 E307B00:2 E307B01:42 E308700:1 E308702:1
+
+Overworld (Kaipo)                                                             Seed: 255   Index:   0
+Overworld (Kaipo)                                                             Seed: 255   Index:   1
+  Step  36: 1 / SandMoth x2, Larva x2 (7.009s)
+Kaipo                                                                         Seed: 255   Index:  37
+Overworld (Kaipo)                                                             Seed: 255   Index:  37
+Watery Pass-South B1F                                                         Seed: 255   Index:  69
+  Step  28: 2 / EvilShel x3, WaterBug x1 (6.866s)
+Recruit Tellah                                                                Seed: 255   Index: 101
+Watery Pass-South B1F                                                         Seed: 255   Index: 101
+  Step  19: 3 / Zombie x4 (7.148s)
+Watery Pass-South B2F                                                         Seed: 255   Index: 121
+  Step   9: 4 / EvilShel x3, WaterBug x1 (7.081s)
+  Step  23: 5 / Pike x3 (7.152s)
+  Step  59: 6 / CaveToad x3 (7.014s)
+Watery Pass-South B2F Save Room                                               Seed: 255   Index: 211
+  Extra Steps: 70
+Watery Pass-South B2F                                                         Seed:  16   Index:  29
+  Step  35: 7 / Pike x3 (7.152s)
+Watery Pass-South B3F                                                         Seed:  16   Index:  68
+Watery Pass-North B2F                                                         Seed:  16   Index: 102
+Watery Pass-North B1F                                                         Seed:  16   Index: 123
+  Step  35: 8 / Aligator x1, Pike x2 (7.368s)
+Overworld (Kaipo)                                                             Seed:  16   Index: 183
+Waterfalls B1F                                                                Seed:  16   Index: 192
+  Extra Steps: 20
+Waterfalls B2F                                                                Seed:  16   Index: 213
+  Step   9: 9 / Aligator x2 (7.544s)
+Waterfalls Lake                                                               Seed:  33   Index:   2
+  Step   5: 10 / Aligator x1, Pike x2 (7.368s)
+Battle: Octomamm                                                              Seed:  33   Index:  39
+Waterfalls Lake                                                               Seed:  33   Index:  39
+Overworld (Kaipo)                                                             Seed:  33   Index:  40
+Overworld (Damcyan)                                                           Seed:  33   Index:  51
+Damcyan                                                                       Seed:  33   Index:  55
+  Optional Steps: 1
+  Extra Steps: 6
+Overworld (Damcyan)                                                           Seed:  33   Index:  69
+Antlion B1F                                                                   Seed:  33   Index:  69
+  Step  23: 11 / Basilisk x1, Imp x3 (6.775s)
+Antlion B2F Inward Charm Room Steps                                           Seed:  33   Index: 107
+  Antlion B2F                                                                 Seed:  33   Index: 107
+  Antlion B2F Treasure Room                                                   Seed:  33   Index: 140
+    Extra Steps: 2
+  Antlion B2F                                                                 Seed:  33   Index: 142
+    Step  46: 12 / Turtle x2 (7.487s)
+Antlion's Nest                                                                Seed:  33   Index: 194
+Battle: Antlion                                                               Seed:  33   Index: 208
+Antlion's Nest                                                                Seed:  33   Index: 208
+  Step  12: 13 / Weeper x1, Turtle x1, Basilisk x1 (7.339s)
+Antlion B2F Outward Charm Room Steps                                          Seed:  33   Index: 223
+  Antlion B2F                                                                 Seed:  33   Index: 223
+    Extra Steps: 1
+    Step  18: 14 / SandWorm x2 (6.858s)
+  Antlion B2F Treasure Room                                                   Seed:  50   Index:  19
+    Extra Steps: 42
+  Antlion B2F                                                                 Seed:  50   Index:  61
+Antlion B1F                                                                   Seed:  50   Index:  95
+Overworld (Damcyan)                                                           Seed:  50   Index: 133
+Overworld (Kaipo)                                                             Seed:  50   Index: 133
+Kaipo Revisited                                                               Seed:  50   Index: 133
+Overworld (Kaipo)                                                             Seed:  50   Index: 133
+Overworld (Damcyan)                                                           Seed:  50   Index: 133
+Mt.Hobs-West                                                                  Seed:  50   Index: 133
+  Step  34: 15 / Gargoyle x1, Cocktric x2 (9.399s)
+Mt.Hobs Summit                                                                Seed:  50   Index: 172
+  Step  14: 16 / Cocktric x3 (9.055s)
+Battle: MomBomb                                                               Seed:  50   Index: 187
+Mt.Hobs Summit                                                                Seed:  50   Index: 187
+Mt.Hobs-East                                                                  Seed:  50   Index: 193
+Overworld (Fabul)                                                             Seed:  50   Index: 239
+  Step   7: 17 / Imp Cap. x4, Imp x2 (8.467s)
+  Step  45: 18 / Cocktric x3 (8.241s)
+  Step  47: 19 / Imp Cap. x3, Needler x3 (8.555s)
+  Step  60: 20 / Imp Cap. x3, Needler x3 (8.555s)
+Fabul                                                                         Seed:  67   Index:  67
+  Optional Steps: 9
+Overworld (Fabul)                                                             Seed:  67   Index: 136
+Fabul Boat and Leviatan                                                       Seed:  67   Index: 143
+Overworld (Mysidia)                                                           Seed:  67   Index: 143
+  Extra Steps: 2
+  Step  10: 21 / Imp Cap. x4, Imp x2 (8.293s)
+Mysidia                                                                       Seed:  67   Index: 154
+Overworld (Mysidia)                                                           Seed:  67   Index: 154
+Overworld (Mt.Ordeals)                                                        Seed:  67   Index: 164
+  Step  14: 22 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  68: 23 / SwordRat x2, Imp x2, TinyMage x2 (7.401s)
+  Step  86: 24 / Imp Cap. x4, Imp x2 (8.344s)
+Mt.Ordeals                                                                    Seed:  84   Index:   2
+  Step   6: 25 / Soul x2, Red Bone x2 (9.583s)
+  Step   8: 26 / Spirit x3, Skelton x2, Red Bone x1 (9.131s)
+Mt.Ordeals-3rd station                                                        Seed:  84   Index:  45
+Recruit Tellah                                                                Seed:  84   Index:  68
+Mt.Ordeals-3rd station                                                        Seed:  84   Index:  68
+Mt.Ordeals-7th station                                                        Seed:  84   Index:  73
+  Step  12: 27 / Lilith x1 (8.745s)
+Mt.Ordeals Summit                                                             Seed:  84   Index: 115
+  Optional Steps: 1
+  Step   2: 28 / Lilith x1 (8.745s)
+Battle: Milon and Milon Z                                                     Seed:  84   Index: 133
+Mt.Ordeals Summit                                                             Seed:  84   Index: 133
+Paladin                                                                       Seed:  84   Index: 137
+Mt.Ordeals Summit                                                             Seed:  84   Index: 137
+  Optional Steps: 1
+  Step   3: 29 / Lilith x1, Red Bone x2 (8.437s)
+  Step  20: 30 / Soul x3, Ghoul x1, Revenant x1 (9.621s)
+Mt.Ordeals-7th station                                                        Seed:  84   Index: 160
+  Step  35: 31 / Lilith x1, Red Bone x2 (8.437s)
+Mt.Ordeals-3rd station                                                        Seed:  84   Index: 202
+  Step  27: 32 / Zombie x3, Ghoul x2, Revenant x2 (7.923s)
+Mt.Ordeals                                                                    Seed:  84   Index: 232
+Overworld (Mt.Ordeals)                                                        Seed: 101   Index:  20
+Take Chocobo to Mysidia                                                       Seed: 101   Index:  33
+Overworld (Mysidia)                                                           Seed: 101   Index:  33
+Town of Baron Serpent Road                                                    Seed: 101   Index:  33
+Credit Warp Fight Search                                                      Seed: 101   Index:  37
+  Overworld (Baron)                                                           Seed: 101   Index:  37
+    Extra Steps: 14
+    Step   2: 33 / Imp x3, SwordRat x1 (7.227s)
+    Step  14: 34 / Imp x3, SwordRat x1 (7.227s)
+   (Step  54: 35 / Imp x3)
+   (Step  65: 36 / Imp x3, SwordRat x1)
+   (Step  78: 37 / Imp x3)
+   (Step 110: 38 / Imp x3)
+   (Step 180: 39 / FloatEye x2)
+   (Step 236: 40 / Imp x3, SwordRat x1)
+
+Encounter Time:      268.948s
+Other Time:          535.884s
+Total Time:          804.833s
+
+Base Total Time:     971.238s
+Time Saved:          166.405s
+
+Optional Steps:      12
+Extra Steps:         157
+Encounters:          34
+
+Base Encounters:     48
+Encounters Saved:    14
+
+Number of Variables: 54

--- a/src/ff4kb/routes/views.py
+++ b/src/ff4kb/routes/views.py
@@ -78,6 +78,20 @@ ROUTES: dict[str, dict[str, str | bool]] = {
         "seed_finder": True,
         "status": "Optimal",
     },
+    "cw": {
+        "name": "Any% (Credits Warp)",
+        "description": (
+            "This route is for the modern (2026+) Any% category that does a credits warp shortly after Cecil becomes a"
+            " paladin. I did not generate the current version of the routes myself, so I make no guarantees about"
+            " correctness. I may or may not fix that at some point."
+        ),
+        "group": "alternate",
+        "enabled": True,
+        "twin_safe": False,
+        "complete": False,
+        "seed_finder": False,
+        "status": "Unknown",
+    },
     "nocw": {
         "name": "Any% NoCW",
         "description": (


### PR DESCRIPTION
This adds the step routes for the new credits warp category developed in 2026.

Please note that these are the initial routes generated by neerrm and have not been made twin-seed safe, integrated into the seed finder, or have any tutorial data.
